### PR TITLE
ci(github-actions): various updates to linting github workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -74,7 +74,7 @@ jobs:
 
   kubernetes-manifests:
     needs: [detect-changes]
-    # if: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.kubernetes_any_changed == 'true' }}
+    if: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.kubernetes_any_changed == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
- kubernetes-manifests:
  - on `pull-request`: validate affected kustomizations for changed manifests only
  - on other events: validate all kustomizations
- other types of linting:
  - commit-messages: only get triggered on `pull-request` as before (as its not applicable on other events)
  - all others: gets triggered on all events (not just `pull-request` or `workflow-displatch`, but also `schedule`)