### PR TITLE
fix(policies): exclude longhorn-system from mutate policies

### DIFF
--- a/policies/best-practices/add-default-resources.yaml
+++ b/policies/best-practices/add-default-resources.yaml
@@ -44,3 +44,9 @@ spec:
                 requests:
                   +(memory): "32Mi"
                   +(cpu): "32m"
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+          - longhorn-system

--- a/policies/best-practices/add-emptydir-sizelimit.yaml
+++ b/policies/best-practices/add-emptydir-sizelimit.yaml
@@ -44,3 +44,9 @@ spec:
           - path: "/spec/volumes/{{elementIndex}}/emptyDir/sizeLimit"
             op: add
             value: 256Mi
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+          - longhorn-system


### PR DESCRIPTION
Kyverno's autogen expands Pod mutate rules to ReplicaSets, and add-default-resources was injecting cpu/memory requests into the Longhorn CSI ReplicaSets at admission. Since longhorn-manager's Deployment templates carry empty resources, each controller-created RS diverged from its Deployment template, so the deployment controller bumped collisionCount and spawned a new RS every sync — ~48k dead ReplicaSets over 16d. The object explosion OOMKilled prometheus and the kyverno reports/cleanup controllers and thrashed goldilocks.

Add a longhorn-system namespace exclude to add-default-resources, add-emptydir-sizelimit, and add-ndots. Only the first was firing, but all three are the same hazard for any operator-enforced workload whose managed template must stay authoritative (CNPG, Cilium, future Talos migration). Excludes are inherited by the autogen rules.