### PR TITLE
docs: init repo documentation and doc-maintenance skills

### DIFF
--- a/.claude/skills/audit-repo-docs/SKILL.md
+++ b/.claude/skills/audit-repo-docs/SKILL.md
@@ -57,26 +57,29 @@ verifies against the rules those skills already encode:
 
 ## Also check: convention violations that aren't classic "drift"
 
-Two categories worth checking even though they aren't a fact going stale
+Two categories worth checking even though neither is a fact going stale
 against a source file — both were found and fixed across all six docs once
 already, so treat them as recurring risks, not one-time cleanup:
 
-- **Restated tunable config.** Any specific value in a doc that duplicates a
-  number/list/setting living in exactly one config file (a soak-period day
-  count, a reviewer name, a cron schedule, an exclusion namespace list, a
-  CIDR) is a convention violation regardless of whether it's currently
-  *correct* — it's one edit to that file away from becoming a lie, and the
-  doc's own rules (see `update-repo-docs`) say it shouldn't be there at all.
-  Flag it even if the value still matches the source right now.
+- **Restating instead of elevating.** Flag any passage that only restates
+  what a config file, patch body, or manifest already says — a specific
+  number, list, cron schedule, CIDR, enum value, or JSON6902 body reproduced
+  in the doc instead of described by its effect and pointed at. This is a
+  violation regardless of whether the value happens to be currently
+  *correct* or likely to change — the test is whether the passage added
+  understanding above the source file, per `update-repo-docs`'s "Elevate,
+  don't restate." A value that will never change can still be a
+  restatement violation; conversely this is not simply "did a version
+  number sneak in" — check for restated mechanics and structure too (a
+  `dependsOn` list spelled out as prose, an `exclude` block's namespace
+  list transcribed, a patch's exact JSON6902 operations narrated line by
+  line).
 - **Mermaid diagrams that don't actually render correctly.** Check every
-  diagram in all six docs for: a `direction` line inside a `subgraph` that
-  also has an edge crossing its boundary (silently ignored by Mermaid, and
-  can cause real node overlap — not just dead syntax); unescaped `<`/`>`
-  inside a node label (breaks under GitHub's sanitizer). Render each diagram
-  with the harness in `update-repo-docs`' "Verifying a Mermaid diagram
-  renders correctly" and check for overlapping node coordinates — don't rely
-  on reading the Mermaid source, since both failure modes are invisible by
-  inspection alone (`mermaid.parse` succeeds on both).
+  diagram in all six docs against `verify-mermaid-diagrams`' rules
+  (`direction` inside a `subgraph` that also has a boundary-crossing edge;
+  unescaped `<`/`>` in a label) using its render-and-check harness — don't
+  rely on reading the Mermaid source, since both failure modes are
+  invisible by inspection and `mermaid.parse` succeeds on both.
 
 ## Procedure
 

--- a/.claude/skills/audit-repo-docs/SKILL.md
+++ b/.claude/skills/audit-repo-docs/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: audit-repo-docs
+description: This skill should be used when the user asks to "audit the docs", "check the docs for drift", "are the docs up to date", "verify the documentation", "doc health check", or before a release/handoff when nobody's certain the docs kept pace with recent merges. Read-only — walks all six repo docs (README.md, DESIGN.md, CLAUDE.md, policies/README.md, clusters/homelab/README.md, clusters/nas/README.md) and cross-checks their specific factual claims against the current manifests, reporting drift without editing anything. Use this instead of update-repo-docs when the goal is diagnosis, not repair.
+---
+
+# Audit Repo Docs
+
+Reads all six documentation files and verifies each factual claim against
+the manifests it's supposed to describe. Reports drift; does not fix it —
+that's `update-repo-docs`'s job, once the user decides which findings to act
+on. Doc drift accumulates silently: a Renovate PR bumps a `dependsOn`, a
+patch gets removed, a `services/` file gets deleted — none of these fail CI
+(the docs aren't executable), so nothing forces a doc update at the time. This
+skill exists to surface that drift on demand instead of waiting for someone
+to notice a doc is wrong mid-conversation.
+
+## Why per-claim checking, not per-file skimming
+
+A doc can *look* current — same structure, same section headings, same
+Mermaid diagram — while individual facts inside it have quietly gone stale
+(a module that's been removed but is still listed, a `dependsOn` edge that
+changed, a `services/` entry that was deleted). Skimming a doc for "does this
+still look right" won't catch that; each table row and diagram edge needs to
+be checked against its actual source file. Treat every table row, every
+Mermaid node/edge, and every prose claim of the form "X does Y" as an
+individually falsifiable claim, then falsify it against real files, not
+memory of what the repo used to look like.
+
+## What to check, per doc
+
+For each doc, cross-reference against the same source-of-truth files its
+matching update skill uses — this audit doesn't invent new criteria, it
+verifies against the rules those skills already encode:
+
+| Doc | Check each row/claim against |
+| --- | --- |
+| `clusters/homelab/README.md`, `clusters/nas/README.md` | `clusters/<name>/kustomizations/*.yaml` (does every listed module have a matching `Kustomization`? does every `Kustomization` appear in the doc? do `dependsOn` edges in the doc's Mermaid diagram match `spec.dependsOn` exactly?), `clusters/<name>/services/**` or outpost-equivalent (does every file have a table row? does every table row have a file?) |
+| `policies/README.md` | `policies/*/kustomization.yaml` (every policy in every group's resource list has a row?), `clusters/*/kustomizations/policy-*.yaml` (does the doc's stated enforcement mode match the current `validationFailureAction` patch?) |
+| `DESIGN.md` | Directory anatomy table against `find clusters -maxdepth 2 -type d`; CI table against current `.github/workflows/*.yaml` job names; "Versioning and updates" against current `.github/renovate*/**` |
+| `CLAUDE.md` | Repository-layout bullets against the same directory listing; commit-scope list against `commitlint.config.js`'s `scope-enum` |
+| `README.md` | Cluster table against `clusters/*/` directories that actually exist |
+
+## Things that are NOT drift (don't flag these)
+
+- A module version (`ref.tag`) that's out of date — none of these docs
+  record versions, by design (see `update-repo-docs`). Only flag a version
+  if one has crept into a doc despite that rule; that's itself a finding
+  (the doc violated its own convention), reported as such rather than as
+  "version X is stale."
+- A fact that's technically derivable from a module's own apps-repo README
+  but isn't restated here — these docs deliberately link out rather than
+  duplicate. Missing restatement isn't drift; a broken or misleading link
+  is.
+- Prose style, wording choices, or diagram aesthetics — this audit checks
+  factual accuracy, not writing quality.
+
+## Procedure
+
+1. Read all six docs in full.
+2. For each doc, build the list of checkable claims per the table above, then
+   read the corresponding source files and check each one individually — do
+   this systematically (e.g. build a checklist first) rather than
+   holistically, since holistic review is exactly what misses row-level
+   drift.
+3. For anything found broken, distinguish:
+   - **Stale**: fact was true, no longer is (module removed, dependsOn
+     changed, patch removed).
+   - **Missing**: a real file/resource has no corresponding doc entry.
+   - **Fabricated**: a doc entry has no corresponding file/resource anymore
+     (rare, but check for it — usually from a doc edit made without
+     re-verifying against the file).
+   - **Convention violation**: a version number, count, or other value crept
+     in that the doc's own rules say shouldn't be there.
+4. Report findings grouped by doc, each with: the specific claim, what the
+   source file actually shows, and the classification above. Don't edit any
+   file — hand the report back to the user (or to `update-repo-docs`, if the
+   user wants it acted on immediately) so they can decide what to fix.
+5. If every claim checks out for a doc, say so plainly rather than
+   manufacturing a minor nitpick to seem thorough.
+
+For the documentation values this audit enforces (why versions are excluded,
+why altitude matters), see the `update-repo-docs` skill — this skill checks
+compliance with those rules, it doesn't redefine them.

--- a/.claude/skills/audit-repo-docs/SKILL.md
+++ b/.claude/skills/audit-repo-docs/SKILL.md
@@ -51,8 +51,32 @@ verifies against the rules those skills already encode:
   but isn't restated here — these docs deliberately link out rather than
   duplicate. Missing restatement isn't drift; a broken or misleading link
   is.
-- Prose style, wording choices, or diagram aesthetics — this audit checks
-  factual accuracy, not writing quality.
+- Prose style or wording choices — this audit checks factual accuracy, not
+  writing quality. Diagram *aesthetics* (color choices, layout) are also out
+  of scope, but diagram *correctness* is not — see below.
+
+## Also check: convention violations that aren't classic "drift"
+
+Two categories worth checking even though they aren't a fact going stale
+against a source file — both were found and fixed across all six docs once
+already, so treat them as recurring risks, not one-time cleanup:
+
+- **Restated tunable config.** Any specific value in a doc that duplicates a
+  number/list/setting living in exactly one config file (a soak-period day
+  count, a reviewer name, a cron schedule, an exclusion namespace list, a
+  CIDR) is a convention violation regardless of whether it's currently
+  *correct* — it's one edit to that file away from becoming a lie, and the
+  doc's own rules (see `update-repo-docs`) say it shouldn't be there at all.
+  Flag it even if the value still matches the source right now.
+- **Mermaid diagrams that don't actually render correctly.** Check every
+  diagram in all six docs for: a `direction` line inside a `subgraph` that
+  also has an edge crossing its boundary (silently ignored by Mermaid, and
+  can cause real node overlap — not just dead syntax); unescaped `<`/`>`
+  inside a node label (breaks under GitHub's sanitizer). Render each diagram
+  with the harness in `update-repo-docs`' "Verifying a Mermaid diagram
+  renders correctly" and check for overlapping node coordinates — don't rely
+  on reading the Mermaid source, since both failure modes are invisible by
+  inspection alone (`mermaid.parse` succeeds on both).
 
 ## Procedure
 
@@ -69,8 +93,11 @@ verifies against the rules those skills already encode:
    - **Fabricated**: a doc entry has no corresponding file/resource anymore
      (rare, but check for it — usually from a doc edit made without
      re-verifying against the file).
-   - **Convention violation**: a version number, count, or other value crept
-     in that the doc's own rules say shouldn't be there.
+   - **Convention violation**: a version number, count, tunable config value,
+     or other value crept in that the doc's own rules say shouldn't be
+     there — including a Mermaid diagram that fails to render correctly (dead
+     `direction` inside a bounded subgraph, unescaped angle brackets, or
+     confirmed node overlap).
 4. Report findings grouped by doc, each with: the specific claim, what the
    source file actually shows, and the classification above. Don't edit any
    file — hand the report back to the user (or to `update-repo-docs`, if the

--- a/.claude/skills/update-cluster-docs/SKILL.md
+++ b/.claude/skills/update-cluster-docs/SKILL.md
@@ -58,21 +58,22 @@ the doc:
   `spec.dependsOn` across all this cluster's `Kustomization`s, grouped by
   core/extra/apps the same way the existing diagram does. Regenerate the
   whole diagram rather than patching one edge in by hand — a single added
-  `dependsOn` can change which nodes belong in which subgraph. These
-  diagrams group nodes into `subgraph`s and always have edges crossing those
-  subgraphs' boundaries (that's how the core/extra/apps layering is drawn) —
-  do **not** add a `direction` line inside any subgraph here, and use plain
-  unhyphenated node IDs (`secx`, not `sec-x`). See `update-repo-docs`'
-  "Verifying a Mermaid diagram renders correctly" for why, and render the
-  regenerated diagram before finishing to confirm no two nodes land on
-  identical coordinates.
-- **Does NOT belong**: `ref.tag` versions, replica counts or storage sizes
-  from `postBuild.substitute`, secret key names, exact CIDR/IP values from a
-  `services/tailscale/connector.yaml`-style resource, anything that changes
-  on a Renovate PR (or a config edit) without a human deciding the *shape* of
-  the deployment changed. If tempted to write a specific value, write a
-  pointer to the file that holds it instead — describe what the value is
-  *for*, not what it currently *is*.
+  `dependsOn` can change which nodes belong in which subgraph. Before
+  finishing, invoke `verify-mermaid-diagrams` on the regenerated diagram —
+  it owns the correctness rules for `subgraph`/`direction`/labels and a
+  render-and-check harness; don't skip it just because the diagram "looks"
+  right.
+- **Does NOT belong**: exact values that only restate what a config file
+  already says more precisely — `ref.tag` versions, replica counts or
+  storage sizes from `postBuild.substitute`, secret key names, exact
+  CIDR/IP values, a `patches:` body reproduced verbatim instead of described
+  by effect. The test isn't just "will this go stale" — even a value that's
+  unlikely to ever change still doesn't belong if writing it added no
+  understanding beyond what the surrounding sentence already gave the
+  reader. Describe what a value is *for* and, if a reader needs the exact
+  current value, point them to the file that holds it. See
+  `update-repo-docs`'s "Elevate, don't restate" for the general rule this
+  follows.
 
 ## Procedure
 
@@ -85,8 +86,7 @@ the doc:
    entry.
 4. If a module was added or removed, or a `dependsOn` edge changed, rebuild
    the Mermaid dependency graph rather than hand-editing individual node
-   lines. Render it afterward to confirm it renders cleanly and no nodes
-   overlap (see `update-repo-docs`).
+   lines. Run `verify-mermaid-diagrams` on the result before moving on.
 5. If the change also affects wiring mechanics that DESIGN.md documents in
    the abstract (a new kind of `patches:` usage, a new `services/` pattern
    not yet described there), flag it — that's `update-design-docs`'

--- a/.claude/skills/update-cluster-docs/SKILL.md
+++ b/.claude/skills/update-cluster-docs/SKILL.md
@@ -58,12 +58,21 @@ the doc:
   `spec.dependsOn` across all this cluster's `Kustomization`s, grouped by
   core/extra/apps the same way the existing diagram does. Regenerate the
   whole diagram rather than patching one edge in by hand — a single added
-  `dependsOn` can change which nodes belong in which subgraph.
+  `dependsOn` can change which nodes belong in which subgraph. These
+  diagrams group nodes into `subgraph`s and always have edges crossing those
+  subgraphs' boundaries (that's how the core/extra/apps layering is drawn) —
+  do **not** add a `direction` line inside any subgraph here, and use plain
+  unhyphenated node IDs (`secx`, not `sec-x`). See `update-repo-docs`'
+  "Verifying a Mermaid diagram renders correctly" for why, and render the
+  regenerated diagram before finishing to confirm no two nodes land on
+  identical coordinates.
 - **Does NOT belong**: `ref.tag` versions, replica counts or storage sizes
-  from `postBuild.substitute`, secret key names, anything that changes on a
-  Renovate PR without a human deciding the *shape* of the deployment
-  changed. If tempted to write a specific value, write a pointer to the file
-  that holds it instead.
+  from `postBuild.substitute`, secret key names, exact CIDR/IP values from a
+  `services/tailscale/connector.yaml`-style resource, anything that changes
+  on a Renovate PR (or a config edit) without a human deciding the *shape* of
+  the deployment changed. If tempted to write a specific value, write a
+  pointer to the file that holds it instead — describe what the value is
+  *for*, not what it currently *is*.
 
 ## Procedure
 
@@ -76,7 +85,8 @@ the doc:
    entry.
 4. If a module was added or removed, or a `dependsOn` edge changed, rebuild
    the Mermaid dependency graph rather than hand-editing individual node
-   lines.
+   lines. Render it afterward to confirm it renders cleanly and no nodes
+   overlap (see `update-repo-docs`).
 5. If the change also affects wiring mechanics that DESIGN.md documents in
    the abstract (a new kind of `patches:` usage, a new `services/` pattern
    not yet described there), flag it — that's `update-design-docs`'

--- a/.claude/skills/update-cluster-docs/SKILL.md
+++ b/.claude/skills/update-cluster-docs/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: update-cluster-docs
+description: This skill should be used when the user asks to "update the homelab README", "update the nas README", "add a module to the cluster docs", "the cluster catalog is out of date", or after any change under clusters/homelab/** or clusters/nas/** — a new or removed Kustomization, a changed dependsOn, a new services/ entry, a patch that deletes or disables part of a module, or a storage change. Keeps clusters/homelab/README.md and clusters/nas/README.md — the per-cluster module catalogs and dependency diagrams — matching what's actually wired into each cluster.
+---
+
+# Update Cluster Docs
+
+Keeps `clusters/homelab/README.md` and `clusters/nas/README.md` accurate.
+Each of these docs answers one question: **what does this specific cluster
+actually run, and how does it differ from a stock deployment of those
+modules?** Everything in the doc should serve that question.
+
+## Source of truth, in order
+
+For the cluster that changed, read in this order — later files are where the
+cluster-specific *differences* live, which is usually what needs to change in
+the doc:
+
+1. `clusters/<name>/kustomizations/*.yaml` — one `Kustomization` per module.
+   `spec.dependsOn` is the dependency graph; `spec.components` is what gets
+   mixed in; `spec.patches` is where a cluster deviates from the module's
+   defaults (deletes a `HelmRelease`, resizes something, disables a
+   sub-feature).
+2. `clusters/<name>/sources/*.yaml` — confirms which modules exist for this
+   cluster (one `GitRepository` per module) and, via `spec.ignore`, whether a
+   source pulls a submodule path rather than the whole thing (e.g. nas's
+   `storage-core` split into `csi-driver-nfs` + `minio` sub-paths).
+3. `clusters/<name>/services/**` (homelab) or the cluster-specific directory
+   equivalent (e.g. nas's `outpost/**`) — anything that isn't a module at
+   all. Two categories, and the doc must say which one a new entry is:
+   - Config/secrets a module looks up **by name** (may be optional — the
+     module runs without it, just with reduced functionality).
+   - Standalone resources with no module awareness (a CRD instance for an
+     operator a module installs, cluster-local content with no upstream
+     module at all).
+4. `clusters/<name>/storage/**` — only worth a doc mention if it reveals
+   something cluster-specific (a storage backend choice like NFS vs.
+   Longhorn, not the existence of a PVC).
+5. The matching module's own README in
+   `../homelab-ops-kubernetes-apps/{infrastructure,apps}/subsystems/<name>/README.md`
+   (sibling repo, read-only — never edit it from here) — this is where the
+   *what does this module do* description comes from. The cluster doc should
+   describe deltas from this, not restate it.
+
+## What belongs in the doc vs. what doesn't
+
+- **Module catalog tables**: module name (linked to its apps-repo README),
+  the `Kustomization` name, and a one-line "provides" summary. If a
+  `patches:` block removes or disables part of what the module normally
+  ships (like `homelab`'s `apps-ai` deleting `ollama-release`), say so with a
+  footnote — a reader trusting the apps-repo README alone would expect
+  something that isn't actually there.
+- **Cluster-specific resources table** (`services/`, `outpost/`, etc.): path,
+  kind, and *why it exists* — named-lookup consumption vs. standalone. Don't
+  just restate the YAML; explain the relationship (which module looks this
+  up, or why it's independent).
+- **Dependency graph diagram** (Mermaid `flowchart`): should mirror
+  `spec.dependsOn` across all this cluster's `Kustomization`s, grouped by
+  core/extra/apps the same way the existing diagram does. Regenerate the
+  whole diagram rather than patching one edge in by hand — a single added
+  `dependsOn` can change which nodes belong in which subgraph.
+- **Does NOT belong**: `ref.tag` versions, replica counts or storage sizes
+  from `postBuild.substitute`, secret key names, anything that changes on a
+  Renovate PR without a human deciding the *shape* of the deployment
+  changed. If tempted to write a specific value, write a pointer to the file
+  that holds it instead.
+
+## Procedure
+
+1. Identify which cluster(s) changed from the diff paths.
+2. Read that cluster's `kustomizations/`, `sources/`, and
+   service/outpost-equivalent directory in full — not just the changed file,
+   since a new `dependsOn` edge can affect other rows in the same table.
+3. Diff what's now true against the existing table/diagram in
+   `clusters/<name>/README.md`. Update in place — don't append a changelog
+   entry.
+4. If a module was added or removed, or a `dependsOn` edge changed, rebuild
+   the Mermaid dependency graph rather than hand-editing individual node
+   lines.
+5. If the change also affects wiring mechanics that DESIGN.md documents in
+   the abstract (a new kind of `patches:` usage, a new `services/` pattern
+   not yet described there), flag it — that's `update-design-docs`'
+   territory, not this skill's.
+6. Run `pre-commit run --files clusters/<name>/README.md` before finishing.
+
+For the full rationale behind these rules (why versions are excluded, why
+altitude matters, why cross-linking beats duplication), see the
+`update-repo-docs` skill.

--- a/.claude/skills/update-design-docs/SKILL.md
+++ b/.claude/skills/update-design-docs/SKILL.md
@@ -51,6 +51,14 @@ DESIGN.md and add at most one pointer line to CLAUDE.md.
   changing its filename. Update DESIGN.md's CI table and/or
   "Versioning and updates" section, and CLAUDE.md's Commands/CI-enforcement
   section if the change affects a command a contributor would run locally.
+  Renovate config is exactly the case the restated-config rule targets —
+  describe what a `packageRules` entry *does* ("k3s patch bumps may
+  auto-merge after a soak period; major/minor always require review") and
+  point to `.github/renovate/*.json` for the current soak-period length or
+  reviewer name, don't quote them. Job *names* in the CI table are fine to
+  state exactly (they're structural, not tunable parameters) — the line is
+  between "this job exists and does X" (stable) and "this job runs on this
+  exact schedule/threshold" (tunable, so point to the file).
 - **New or removed cluster**: update README.md's cluster table, DESIGN.md's
   references to "both clusters" (search for that literal phrase — it appears
   multiple times and assumes exactly two), and spawn a whole new
@@ -80,7 +88,14 @@ system; the other two document its *current contents*.
    a single file's diff.
 3. Update DESIGN.md's relevant section, including its Mermaid diagram if the
    change affects a relationship the diagram depicts. Regenerate rather than
-   patch a diagram when a node or edge's meaning has changed.
+   patch a diagram when a node or edge's meaning has changed. If the diagram
+   uses `subgraph` blocks with edges crossing them (DESIGN.md's
+   "Two repositories, one system" and "Cluster directory anatomy" diagrams
+   both do), don't add a `direction` line inside a subgraph, escape any `<`/`>`
+   in a label as `&lt;`/`&gt;`, and render the result before finishing to
+   confirm it renders cleanly with no overlapping nodes — see
+   `update-repo-docs`'s "Verifying a Mermaid diagram renders correctly" for
+   why and how.
 4. Update CLAUDE.md only if the change affects something a contributor would
    need without opening DESIGN.md (a new command, a new commit scope, a new
    top-level directory worth naming in the layout bullets). Otherwise leave

--- a/.claude/skills/update-design-docs/SKILL.md
+++ b/.claude/skills/update-design-docs/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: update-design-docs
+description: This skill should be used when the user asks to "update DESIGN.md", "update CLAUDE.md", "update the root README", "document this new pattern", "a new cluster was added", or after a change that introduces a new top-level directory, a new wiring mechanism (a new Kustomize component category, a new services/ sub-pattern), a CI/pre-commit/Renovate config change, or a new/removed cluster. Keeps DESIGN.md (architecture), CLAUDE.md (thin pointer + commands/conventions), and README.md (entry point) matching the repo's actual current structure and mechanics — never module versions or per-cluster catalog details, which belong to update-cluster-docs and update-policy-docs instead.
+---
+
+# Update Design Docs
+
+Keeps `DESIGN.md`, `CLAUDE.md`, and root `README.md` accurate. These three
+sit one level of abstraction above the per-cluster and policy docs — they
+describe *how the repo works as a system*, not what any one cluster runs
+today. Get the altitude right before editing: if a change is really about
+"homelab now has module X," that belongs in `clusters/homelab/README.md` via
+`update-cluster-docs`, not here. This skill only applies when the change is
+about a **pattern**, **mechanism**, or **repo-wide fact** — something that
+would be true regardless of which specific modules either cluster runs.
+
+## What each of the three files owns, and why they're split this way
+
+| File | Scope | Read by |
+| --- | --- | --- |
+| `README.md` | Entry point: what this repo is, the two-repo relationship, links onward. Almost never changes. | Humans landing here first |
+| `DESIGN.md` | The mechanics: directory anatomy, how `dependsOn`/`components`/`postBuild`/`patches` wire a module in, the `services/` pattern, secrets/RBAC/storage model, CI, Renovate. Changes when a *mechanism* changes. | Anyone (human or AI) needing to understand *why* the repo is shaped this way before touching it |
+| `CLAUDE.md` | Thin pointer + the parts an AI agent needs fast (commands, commit scopes) without re-deriving them from DESIGN.md. Should stay short — if it's growing past a pointer plus a commands/conventions section, content probably belongs in DESIGN.md instead. | Claude Code specifically |
+
+Keeping CLAUDE.md thin isn't a style preference — every line in it is loaded
+into context on every session in this repo, whether or not the session ends
+up touching cluster manifests. DESIGN.md and the per-cluster/policy docs are
+loaded only when linked to or read on demand. Adding detail to CLAUDE.md has
+a different cost than adding it to DESIGN.md; when in doubt, put it in
+DESIGN.md and add at most one pointer line to CLAUDE.md.
+
+## Source of truth, by trigger
+
+- **New top-level directory or new per-cluster sub-directory pattern**
+  (e.g. `clusters/<name>/services/` didn't always exist — it was split out
+  from `cluster/` in commit `7f93684`): re-read the actual directory tree
+  (`find clusters -maxdepth 4 -type d`) and update DESIGN.md's directory
+  anatomy table/diagram and CLAUDE.md's repository-layout bullets together —
+  they describe the same tree from two levels of detail and must not
+  contradict each other.
+- **New Kustomize wiring pattern** (a `components:` category not yet seen,
+  a new `services/` sub-pattern beyond the two DESIGN.md currently
+  describes): update DESIGN.md's "Wiring a module into a cluster" or
+  "The `services/` directory" section with the new pattern, generalized —
+  not just the one example that prompted the change. Verify the example
+  still matches a real file in the repo before writing it down.
+- **CI, pre-commit, or Renovate config change**
+  (`.github/workflows/*.yaml`, `.pre-commit-config.yaml`,
+  `.github/renovate*/**`): re-read the actual workflow/config file in full —
+  these are easy to half-update, since a workflow can gain a new job without
+  changing its filename. Update DESIGN.md's CI table and/or
+  "Versioning and updates" section, and CLAUDE.md's Commands/CI-enforcement
+  section if the change affects a command a contributor would run locally.
+- **New or removed cluster**: update README.md's cluster table, DESIGN.md's
+  references to "both clusters" (search for that literal phrase — it appears
+  multiple times and assumes exactly two), and spawn a whole new
+  `clusters/<name>/README.md` via `update-cluster-docs` rather than writing
+  it here.
+- **Cross-repo relationship changes** (apps repo restructures its module
+  layout, e.g. renames `infrastructure/subsystems/` or changes the
+  core/extra pattern): confirm against the apps repo's own
+  `projectBrief.md`/`CLAUDE.md` (read-only, sibling checkout) before editing
+  — don't describe the apps repo from memory of what it looked like when
+  these docs were first written.
+
+## What never belongs here (same rule as everywhere else)
+
+No module versions, no cluster-specific catalog details (which modules a
+given cluster runs — that's `update-cluster-docs`), no per-policy detail
+(that's `update-policy-docs`). This skill documents the *shape* of the
+system; the other two document its *current contents*.
+
+## Procedure
+
+1. Confirm the change is genuinely architectural (see the altitude check
+   above) — if not, redirect to `update-cluster-docs` or
+   `update-policy-docs` instead of editing here.
+2. Read the actual source (directory tree, workflow file, config file) in
+   full before writing anything — don't extrapolate a whole new pattern from
+   a single file's diff.
+3. Update DESIGN.md's relevant section, including its Mermaid diagram if the
+   change affects a relationship the diagram depicts. Regenerate rather than
+   patch a diagram when a node or edge's meaning has changed.
+4. Update CLAUDE.md only if the change affects something a contributor would
+   need without opening DESIGN.md (a new command, a new commit scope, a new
+   top-level directory worth naming in the layout bullets). Otherwise leave
+   CLAUDE.md alone and rely on its existing pointer to DESIGN.md.
+5. Update README.md only for cluster-list or repo-purpose changes.
+6. Run `pre-commit run --files README.md DESIGN.md CLAUDE.md` before
+   finishing.
+
+For the full rationale behind these rules (why versions are excluded, why
+altitude matters, why cross-linking beats duplication), see the
+`update-repo-docs` skill.

--- a/.claude/skills/update-design-docs/SKILL.md
+++ b/.claude/skills/update-design-docs/SKILL.md
@@ -51,14 +51,17 @@ DESIGN.md and add at most one pointer line to CLAUDE.md.
   changing its filename. Update DESIGN.md's CI table and/or
   "Versioning and updates" section, and CLAUDE.md's Commands/CI-enforcement
   section if the change affects a command a contributor would run locally.
-  Renovate config is exactly the case the restated-config rule targets —
-  describe what a `packageRules` entry *does* ("k3s patch bumps may
-  auto-merge after a soak period; major/minor always require review") and
-  point to `.github/renovate/*.json` for the current soak-period length or
-  reviewer name, don't quote them. Job *names* in the CI table are fine to
-  state exactly (they're structural, not tunable parameters) — the line is
-  between "this job exists and does X" (stable) and "this job runs on this
-  exact schedule/threshold" (tunable, so point to the file).
+  Renovate config is exactly the case `update-repo-docs`' "Elevate, don't
+  restate" rule targets — describe what a `packageRules` entry *does* ("k3s
+  patch bumps may auto-merge after a soak period; major/minor always require
+  review") and point to `.github/renovate/*.json` for the current
+  soak-period length or reviewer name, don't quote them; quoting them adds
+  nothing a reader couldn't get by opening that file, and now the doc has to
+  be kept in sync with a value it never needed to state. Job *names* in the
+  CI table are fine to state exactly (they're structural, not tunable
+  parameters) — the line is between "this job exists and does X" (an
+  elevated fact about the system's shape) and "this job runs on this exact
+  schedule/threshold" (a restatement of the workflow file's own content).
 - **New or removed cluster**: update README.md's cluster table, DESIGN.md's
   references to "both clusters" (search for that literal phrase — it appears
   multiple times and assumes exactly two), and spawn a whole new
@@ -88,14 +91,10 @@ system; the other two document its *current contents*.
    a single file's diff.
 3. Update DESIGN.md's relevant section, including its Mermaid diagram if the
    change affects a relationship the diagram depicts. Regenerate rather than
-   patch a diagram when a node or edge's meaning has changed. If the diagram
-   uses `subgraph` blocks with edges crossing them (DESIGN.md's
-   "Two repositories, one system" and "Cluster directory anatomy" diagrams
-   both do), don't add a `direction` line inside a subgraph, escape any `<`/`>`
-   in a label as `&lt;`/`&gt;`, and render the result before finishing to
-   confirm it renders cleanly with no overlapping nodes — see
-   `update-repo-docs`'s "Verifying a Mermaid diagram renders correctly" for
-   why and how.
+   patch a diagram when a node or edge's meaning has changed, then invoke
+   `verify-mermaid-diagrams` on the result before moving on — DESIGN.md has
+   three diagrams, and the correctness rules that skill checks are not
+   obvious from reading the Mermaid source.
 4. Update CLAUDE.md only if the change affects something a contributor would
    need without opening DESIGN.md (a new command, a new commit scope, a new
    top-level directory worth naming in the layout bullets). Otherwise leave

--- a/.claude/skills/update-policy-docs/SKILL.md
+++ b/.claude/skills/update-policy-docs/SKILL.md
@@ -45,20 +45,20 @@ Both halves matter and come from different files.
   derived from the `description` annotation, not copied verbatim (those
   annotations are written for kyverno.io's policy library, often longer and
   more general than this repo needs). Don't enumerate the `exclude` block's
-  namespace/name list in the doc — that list grows (a new infra DaemonSet
-  needs a carve-out, a name-specific exclusion gets added) independently of
-  any decision that belongs in this doc, and a partial list is worse than no
-  list because it reads as complete. Say that exclusions exist and roughly
-  why in one clause ("excludes system namespaces and workloads that
-  legitimately need what this otherwise disallows") and point to the
-  policy's own `exclude` block for the current, exact list — this is the
-  same "point to the file, not the value" rule `update-repo-docs` states for
-  versions and counts, applied to exclusion lists.
+  namespace/name list in the doc — transcribing it is restating a config
+  file's own content, the exact thing `update-repo-docs`' "Elevate, don't
+  restate" rule targets, and it also drifts (a new infra DaemonSet needs a
+  carve-out, a name-specific exclusion gets added) independently of any
+  decision that belongs in this doc. A partial list is worse than none,
+  since it reads as complete. Say that exclusions exist and roughly why in
+  one clause ("excludes system namespaces and workloads that legitimately
+  need what this otherwise disallows") and point to the policy's own
+  `exclude` block for the exact, current list.
 - **Enforcement mode**: state current mode plainly (e.g. "all policies
   currently run in `Audit` mode"). If a cluster's `policy-*.yaml` patch
   changes `validationFailureAction`, update this immediately — it's a
-  safety-relevant fact, not a version number, so it doesn't fall under the
-  "don't track values that Renovate changes" rule that applies to versions.
+  safety-relevant fact about what the policy *does*, the kind of thing this
+  doc exists to convey, not a config value being restated for its own sake.
 - **Does NOT belong**: Kyverno version numbers, the full upstream policy
   description text, implementation-level rule syntax (JMESPath expressions,
   raw `match`/`exclude` YAML) — link to the file instead of reproducing its
@@ -73,7 +73,9 @@ Both halves matter and come from different files.
    itself tell you which cluster is affected; the per-cluster `Kustomization`
    does.
 3. Update the group table and the relevant per-policy table in
-   `policies/README.md` in place.
+   `policies/README.md` in place. If the change affects the groups/clusters
+   relationship, update the Mermaid diagram too, then run
+   `verify-mermaid-diagrams` on it before moving on.
 4. If a change adds a wholly new group (not `baseline`/`restricted`/
    `best-practices`), that's a structural change worth flagging to
    `update-design-docs` too, since DESIGN.md's policy-enforcement section

--- a/.claude/skills/update-policy-docs/SKILL.md
+++ b/.claude/skills/update-policy-docs/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: update-policy-docs
+description: This skill should be used when the user asks to "update the policies README", "add a Kyverno policy", "document this policy", "the policy docs are stale", or after any change under policies/** — a new ClusterPolicy or ClusterCleanupPolicy, a change to which cluster a policy group applies to, or a validationFailureAction flip between Audit and Enforce. Keeps policies/README.md matching the actual Kyverno policies defined and which cluster enforces which group.
+---
+
+# Update Policy Docs
+
+Keeps `policies/README.md` accurate. This doc answers two questions: **what
+does each Kyverno policy group actually restrict or mutate**, and **which
+cluster runs which group, in what mode**.
+
+Unlike the per-cluster docs, the policy *definitions* here are genuinely
+cluster-agnostic (they live at the repo root, not under `clusters/`) — but
+which cluster applies which group, and in `Audit` vs the blocking mode, is
+decided per-cluster in each `clusters/<name>/kustomizations/policy-*.yaml`.
+Both halves matter and come from different files.
+
+## Source of truth, in order
+
+1. `policies/<group>/kustomization.yaml` — the definitive list of policies in
+   each group (`pod-security-standard/baseline`, `pod-security-standard/restricted`,
+   `best-practices`). Note that `restricted` composes `baseline` via
+   `resources: [../baseline]` — restricted-cluster docs need both lists.
+2. Each `policies/<group>/*.yaml` file itself — read the
+   `metadata.annotations.policies.kyverno.io/description` and the
+   `spec.rules`/`match`/`exclude` blocks. The annotation gives the plain-English
+   intent; the `exclude` block tells you which namespaces are carved out
+   (e.g. `kube-system`, `longhorn-system`) — that's often the detail worth
+   documenting, since it's what makes the policy safe to run at all.
+3. `clusters/<name>/kustomizations/policy-*.yaml` (one per cluster, per
+   group) — this is where `validationFailureAction` gets patched (Audit vs.
+   the enforcing mode) and confirms which groups a given cluster actually
+   applies. Don't assume from the group's existence alone that both clusters
+   use it — `nas` runs `baseline`, `homelab` runs `restricted`, and that's a
+   deliberate per-cluster choice made here, not in `policies/`.
+
+## What belongs in the doc vs. what doesn't
+
+- **Group table**: one row per group, its path, and which cluster(s) apply
+  it — this table is the fastest way to answer "is X enforced on Y," so keep
+  it first and complete.
+- **Per-policy tables**: policy name and a short plain-English restriction —
+  derived from the `description` annotation, not copied verbatim (those
+  annotations are written for kyverno.io's policy library, often longer and
+  more general than this repo needs). Mention an `exclude`d namespace only
+  when it changes the practical scope (e.g. "excludes `kube-system`,
+  `longhorn-system`" is worth a line; excluding a namespace that doesn't
+  otherwise appear in this repo isn't).
+- **Enforcement mode**: state current mode plainly (e.g. "all policies
+  currently run in `Audit` mode"). If a cluster's `policy-*.yaml` patch
+  changes `validationFailureAction`, update this immediately — it's a
+  safety-relevant fact, not a version number, so it doesn't fall under the
+  "don't track values that Renovate changes" rule that applies to versions.
+- **Does NOT belong**: Kyverno version numbers, the full upstream policy
+  description text, implementation-level rule syntax (JMESPath expressions,
+  raw `match`/`exclude` YAML) — link to the file instead of reproducing its
+  internals.
+
+## Procedure
+
+1. Read the changed `policies/**` files in full, plus any sibling files in
+   the same group directory (a new policy added to `best-practices/` means
+   re-checking that group's whole table, not just adding one row).
+2. Check both clusters' `policy-*.yaml` — a policy file change doesn't by
+   itself tell you which cluster is affected; the per-cluster `Kustomization`
+   does.
+3. Update the group table and the relevant per-policy table in
+   `policies/README.md` in place.
+4. If a change adds a wholly new group (not `baseline`/`restricted`/
+   `best-practices`), that's a structural change worth flagging to
+   `update-design-docs` too, since DESIGN.md's policy-enforcement section
+   and the Mermaid diagram assume exactly these three groups.
+5. Run `pre-commit run --files policies/README.md` before finishing.
+
+For the full rationale behind these rules (why versions are excluded, why
+altitude matters, why cross-linking beats duplication), see the
+`update-repo-docs` skill.

--- a/.claude/skills/update-policy-docs/SKILL.md
+++ b/.claude/skills/update-policy-docs/SKILL.md
@@ -23,10 +23,12 @@ Both halves matter and come from different files.
    `resources: [../baseline]` — restricted-cluster docs need both lists.
 2. Each `policies/<group>/*.yaml` file itself — read the
    `metadata.annotations.policies.kyverno.io/description` and the
-   `spec.rules`/`match`/`exclude` blocks. The annotation gives the plain-English
-   intent; the `exclude` block tells you which namespaces are carved out
-   (e.g. `kube-system`, `longhorn-system`) — that's often the detail worth
-   documenting, since it's what makes the policy safe to run at all.
+   `spec.rules`/`match`/`exclude` blocks. The annotation gives the
+   plain-English intent; the `exclude` block tells you *that* namespaces or
+   named workloads are carved out and roughly why (so you can write "excludes
+   system namespaces and a handful of workloads that legitimately need this"),
+   but don't transcribe the actual namespace/name list into the doc — see
+   "What belongs" below for why that specific list drifts.
 3. `clusters/<name>/kustomizations/policy-*.yaml` (one per cluster, per
    group) — this is where `validationFailureAction` gets patched (Audit vs.
    the enforcing mode) and confirms which groups a given cluster actually
@@ -42,10 +44,16 @@ Both halves matter and come from different files.
 - **Per-policy tables**: policy name and a short plain-English restriction —
   derived from the `description` annotation, not copied verbatim (those
   annotations are written for kyverno.io's policy library, often longer and
-  more general than this repo needs). Mention an `exclude`d namespace only
-  when it changes the practical scope (e.g. "excludes `kube-system`,
-  `longhorn-system`" is worth a line; excluding a namespace that doesn't
-  otherwise appear in this repo isn't).
+  more general than this repo needs). Don't enumerate the `exclude` block's
+  namespace/name list in the doc — that list grows (a new infra DaemonSet
+  needs a carve-out, a name-specific exclusion gets added) independently of
+  any decision that belongs in this doc, and a partial list is worse than no
+  list because it reads as complete. Say that exclusions exist and roughly
+  why in one clause ("excludes system namespaces and workloads that
+  legitimately need what this otherwise disallows") and point to the
+  policy's own `exclude` block for the current, exact list — this is the
+  same "point to the file, not the value" rule `update-repo-docs` states for
+  versions and counts, applied to exclusion lists.
 - **Enforcement mode**: state current mode plainly (e.g. "all policies
   currently run in `Audit` mode"). If a cluster's `policy-*.yaml` patch
   changes `validationFailureAction`, update this immediately — it's a

--- a/.claude/skills/update-repo-docs/SKILL.md
+++ b/.claude/skills/update-repo-docs/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: update-repo-docs
+description: This skill should be used when the user asks to "update the docs", "update the README", "sync the docs", "fix the documentation", "the docs are out of date", "update CLAUDE.md", or after making any change to clusters/**, policies/**, or the repo's directory structure that could make README.md, DESIGN.md, CLAUDE.md, policies/README.md, clusters/homelab/README.md, or clusters/nas/README.md inaccurate. Always consult this skill before hand-editing any of those six files directly — it routes to the specific skill that owns each one and carries the shared rules for what belongs in documentation versus what doesn't.
+---
+
+# Update Repo Docs
+
+This repo's documentation is split across six files, each owned by a
+narrower skill. This skill's only job is figuring out which of those apply to
+a given change and dispatching to them — it does not edit any file itself.
+
+## Why documentation is split this way
+
+Every doc in this repo maps to a distinct part of the underlying manifests, and
+each part changes for different reasons and at different rates:
+
+| Doc | Owning skill | Backs onto |
+| --- | --- | --- |
+| `clusters/homelab/README.md` | `update-cluster-docs` | `clusters/homelab/{kustomizations,sources,services,storage,cluster}/**` |
+| `clusters/nas/README.md` | `update-cluster-docs` | `clusters/nas/{kustomizations,sources,outpost,storage,cluster}/**` |
+| `policies/README.md` | `update-policy-docs` | `policies/**` |
+| `DESIGN.md` | `update-design-docs` | Cross-cluster patterns: new top-level directory, new mechanism (e.g. a new component type), CI/Renovate config changes, new cluster |
+| `CLAUDE.md` | `update-design-docs` | Same triggers as DESIGN.md, plus anything that changes a command or convention it documents |
+| `README.md` | `update-design-docs` | New/removed cluster, changed repo purpose |
+
+A module version bump alone (Renovate bumping `sources/*.yaml`'s `ref.tag`)
+does **not** require a doc update — none of the six docs mention module
+versions, on purpose (see "What never changes" below). Don't let that pattern
+tempt you into skipping real changes, though: a bump that also adds
+`dependsOn`, a new `components:` entry, or a new `postBuild.substitute` key
+*is* a change worth reflecting, because those show up in the tables and
+diagrams these docs carry.
+
+## How to route
+
+1. Get the actual changed paths — `git diff --name-only` (uncommitted) or
+   `git diff --name-only <base>...HEAD` (a branch) — don't guess from the
+   conversation alone, since a change can touch more than what was discussed.
+2. Match each path against the table above. A single change often triggers
+   more than one skill — e.g. adding a new app module to `homelab` touches
+   `update-cluster-docs` (the catalog table + dependency diagram) and
+   possibly `update-design-docs` (if it introduces a new directory-level
+   pattern DESIGN.md doesn't yet describe).
+3. Invoke each matched skill with the `Skill` tool, passing along the
+   specific changed paths so it doesn't have to rediscover them.
+4. If nothing matches any row — e.g. the change is purely inside a module's
+   own manifests with no new wiring pattern — no doc update is needed. Say so
+   rather than force an edit.
+
+## Shared rules (apply regardless of which sub-skill runs)
+
+These are enforced identically by every update-*-docs skill; stated once here
+so sub-skills can stay short and just link back:
+
+- **Every doc claim must trace to a file in this repo, right now.** Don't
+  describe what a module *usually* does or what its apps repo README says it
+  "typically" provides beyond what's actually wired in this cluster's
+  `Kustomization`. If a `patches:` block deletes a `HelmRelease` or an
+  `ExternalSecret`, the doc must say so — the apps repo's own README won't
+  know about it.
+- **Never encode a version, tag, or count that Renovate or a module release
+  will change.** No `v0.2.6`, no "8 modules currently deployed," no replica
+  counts pulled from a `postBuild.substitute`. If a fact will go stale on the
+  next automated PR, the doc references *where to look* instead of the value
+  itself (e.g. "see `kustomizations/infra-security-core.yaml`" rather than
+  quoting its `ref.tag`).
+- **Match altitude to the doc, not to how interesting the change is.** A
+  fascinating implementation detail inside a module's Helm values still
+  doesn't belong in `clusters/<name>/README.md` — that doc answers "what's
+  deployed and why," not "how does it work internally." Save internals for
+  the module's own README in the apps repo, and link to it instead of
+  re-explaining it.
+- **Update, don't append.** If a fact in a table or diagram is now wrong,
+  correct it in place. Don't leave the old row and add a new one, and don't
+  add a "Note: as of \[date], this changed" — these docs describe the current
+  state, not a change history (that's what `git log` and commit messages are
+  for).
+- **Cross-link instead of duplicating.** If the same fact belongs in two
+  docs' scopes, one owns it and the other links there. Before adding a new
+  paragraph, check whether the fact already has a home.
+- **Run `pre-commit run --files <changed-docs>` before considering the update
+  done.** All six docs must pass markdownlint (and yamllint/kubeconform if a
+  manifest changed alongside).
+
+## When a change doesn't fit any existing doc's scope
+
+If a change introduces something genuinely new at the architecture level — a
+third cluster, a wholly new top-level directory, a mechanism DESIGN.md's table
+of contents has no section for — don't force it into an existing section.
+Flag it to the user with a proposed new section or file rather than
+squeezing a mismatched fact into the nearest existing heading.

--- a/.claude/skills/update-repo-docs/SKILL.md
+++ b/.claude/skills/update-repo-docs/SKILL.md
@@ -58,19 +58,30 @@ so sub-skills can stay short and just link back:
   `Kustomization`. If a `patches:` block deletes a `HelmRelease` or an
   `ExternalSecret`, the doc must say so — the apps repo's own README won't
   know about it.
-- **Never restate a configuration value that lives in exactly one file
-  already — point to that file instead.** This isn't only about versions. It
-  includes any number, list, or setting that can change without the change
-  being architectural: a `ref.tag`, a replica count from
-  `postBuild.substitute`, a Renovate soak-period day-count or reviewer name,
-  a cron schedule, a per-policy namespace exclusion list, an IP range or
-  CIDR. The test isn't "is this a version" — it's "if someone edits the one
-  file that actually controls this, does my sentence become wrong without
-  anyone noticing." If yes, replace the value with a pointer: "see
-  `kustomizations/infra-security-core.yaml`," not its `ref.tag`; "see
-  `.github/renovate/k3s-version.json`," not "auto-merges after 7 days."
-  Describing *what a mechanism does* ("k3s patches may auto-merge after a
-  soak period") stays fine — restating its *current parameter* doesn't.
+- **Elevate, don't restate.** A doc's job is to give a reader an
+  understanding of what exists and how to operate or maintain it, at a level
+  of abstraction *above* the code — not to re-express the code's own
+  specifics in prose form. If a sentence could only have been written by
+  reading the implementation and transcribing what it says, it's restating,
+  not elevating, regardless of whether that specific value happens to be
+  stable or volatile. Example: "Renovate manages Flux-source and k3s-version
+  bumps" is elevation — it tells the reader what exists and why the split
+  matters. Following it with the exact soak-period day count, the exact
+  reviewer username, or the exact `packageRules` match pattern is restating
+  the config file's own content back at the reader, in a form that now has
+  to be kept in sync with it for no benefit — the file is right there, and
+  the doc added a second, weaker copy of the same fact instead of a new
+  layer of understanding. The same applies to exact cron schedules, exact
+  `exclude` namespace lists, exact CIDRs, exact enum values reproduced
+  verbatim, exact JSON6902 patch bodies, or a `dependsOn` list spelled out
+  as prose instead of drawn as a graph — none of these become acceptable
+  just because the underlying value is unlikely to change soon. When a
+  concrete value is genuinely necessary to make a sentence meaningful, point
+  to the file that holds it ("see `kustomizations/infra-security-core.yaml`")
+  rather than copying the value into the doc. Drift risk is a *symptom* of
+  restating, not the definition of it — a value that never changes can still
+  be a restatement problem if copying it added no understanding a reader
+  didn't already get from the higher-level sentence around it.
 - **Match altitude to the doc, not to how interesting the change is.** A
   fascinating implementation detail inside a module's Helm values still
   doesn't belong in `clusters/<name>/README.md` — that doc answers "what's
@@ -88,84 +99,13 @@ so sub-skills can stay short and just link back:
 - **Run `pre-commit run --files <changed-docs>` before considering the update
   done.** All six docs must pass markdownlint (and yamllint/kubeconform if a
   manifest changed alongside).
-- **A Mermaid diagram must actually render on GitHub and in VS Code, not just
-  parse.** Both platforms use the current mermaid.js and its stock sanitizer.
-  Verify any diagram you write or edit before considering it done — see
-  "Verifying a Mermaid diagram renders correctly" below. Don't rely on eyeballing
-  the source for correctness; the failure modes here are silent (a diagram
-  renders "successfully" with nodes stacked on top of each other, or GitHub
-  shows a parse error with no useful line number).
-
-### Verifying a Mermaid diagram renders correctly
-
-Two known, easy-to-hit failure classes, both confirmed against a real
-mermaid.js render (not just `mermaid.parse`, which does not catch either one):
-
-1. **`direction LR`/`TB` inside a `subgraph` is silently dropped the moment
-   that subgraph has any edge crossing its boundary** (an edge from a node
-   inside it to a node outside it, or vice versa) — this is a known upstream
-   Mermaid layout limitation, not a bug in this repo's diagrams specifically.
-   The dropped direction isn't just cosmetic: it can cause nodes in different
-   subgraphs to be laid out at identical coordinates, i.e. actually
-   overlapping. Every dependency-graph diagram in this repo has cross-subgraph
-   edges, so **do not add a `direction` line inside a `subgraph` here** —
-   check whether your new/edited subgraph has any inbound or outbound edge; if
-   it does (it almost always will), omit `direction` entirely rather than
-   write a line that will be silently ignored.
-2. **Angle brackets in a node label must be escaped as `&lt;`/`&gt;`, never
-   written raw** (e.g. `root["clusters/&lt;name&gt;/"]`, not
-   `root["clusters/<name>/"]`). GitHub's markdown sanitizer parses an
-   unescaped `<name>` as the start of an HTML tag and can break rendering.
-   This is easy to miss because a raw angle bracket parses fine locally and
-   even renders fine in some contexts — it fails specifically under GitHub's
-   sanitization pass.
-
-To verify a diagram before finishing, render it with mermaid.js locally
-(don't rely on a browser-based headless renderer like `mermaid-cli` unless
-one is already working in this environment — installing a browser purely to
-render a diagram is out of scope for a doc update): use the `mermaid` npm
-package inside a `jsdom` environment. Sample harness — save as a script, run
-with `node`, pass the `.mmd` source as an argument:
-
-```js
-import { JSDOM } from 'jsdom';
-const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { pretendToBeVisual: true });
-global.window = dom.window;
-global.document = dom.window.document;
-Object.defineProperty(global, 'navigator', { value: dom.window.navigator, configurable: true });
-class FakeCSSStyleSheet {
-  cssRules = [];
-  replaceSync() {}
-  insertRule(rule, index) { this.cssRules.splice(index ?? this.cssRules.length, 0, rule); return index ?? this.cssRules.length - 1; }
-}
-global.CSSStyleSheet = FakeCSSStyleSheet;
-dom.window.CSSStyleSheet = FakeCSSStyleSheet;
-dom.window.SVGElement.prototype.getBBox = () => ({ x: 0, y: 0, width: 100, height: 20 });
-dom.window.SVGElement.prototype.getComputedTextLength = () => 60;
-
-const mermaid = (await import('mermaid')).default;
-mermaid.initialize({ startOnLoad: false });
-import fs from 'fs';
-const code = fs.readFileSync(process.argv[2], 'utf8');
-const { svg } = await mermaid.render('check', code);
-console.log('rendered, svg length:', svg.length);
-```
-
-After it renders, check for node overlap by extracting each
-`<g class="node ...">` element's `transform="translate(x, y)"` and confirming
-no two nodes share the same `(x, y)` pair — that's the concrete symptom of the
-`direction`-inside-subgraph bug above, and parsing/rendering success alone
-won't catch it. Run this check (`npm install jsdom mermaid` in a scratch
-directory is fine) whenever you add a subgraph, add a cross-subgraph edge, or
-touch a label containing `<`/`>`. A diagram with no subgraphs and no angle
-brackets in labels doesn't need this — the failure modes above don't apply to
-it.
-
-- **Prefer plain, unhyphenated node IDs** (`secx` not `sec-x`, `homeauto` not
-  `home-auto`). A hyphen in a bare node ID works today but is fragile across
-  Mermaid versions and easy to get wrong when adding edges (`sec-x --> net-x`
-  can be misparsed as `sec - x --> net - x` in some contexts). Keep the
-  human-readable name in the label (`secx[security-extra]`), not the ID.
+- **Any Mermaid diagram you write or edit must be verified with
+  `verify-mermaid-diagrams`, not just eyeballed.** That skill owns the
+  diagram-correctness rules (a couple of real, silent failure modes exist —
+  `mermaid.parse` succeeding is not evidence a diagram is right) and a
+  runnable verification harness. Invoke it whenever a change touches a
+  `subgraph`, an edge, or a label — don't re-derive or duplicate its rules
+  here.
 
 ## When a change doesn't fit any existing doc's scope
 

--- a/.claude/skills/update-repo-docs/SKILL.md
+++ b/.claude/skills/update-repo-docs/SKILL.md
@@ -58,12 +58,19 @@ so sub-skills can stay short and just link back:
   `Kustomization`. If a `patches:` block deletes a `HelmRelease` or an
   `ExternalSecret`, the doc must say so — the apps repo's own README won't
   know about it.
-- **Never encode a version, tag, or count that Renovate or a module release
-  will change.** No `v0.2.6`, no "8 modules currently deployed," no replica
-  counts pulled from a `postBuild.substitute`. If a fact will go stale on the
-  next automated PR, the doc references *where to look* instead of the value
-  itself (e.g. "see `kustomizations/infra-security-core.yaml`" rather than
-  quoting its `ref.tag`).
+- **Never restate a configuration value that lives in exactly one file
+  already — point to that file instead.** This isn't only about versions. It
+  includes any number, list, or setting that can change without the change
+  being architectural: a `ref.tag`, a replica count from
+  `postBuild.substitute`, a Renovate soak-period day-count or reviewer name,
+  a cron schedule, a per-policy namespace exclusion list, an IP range or
+  CIDR. The test isn't "is this a version" — it's "if someone edits the one
+  file that actually controls this, does my sentence become wrong without
+  anyone noticing." If yes, replace the value with a pointer: "see
+  `kustomizations/infra-security-core.yaml`," not its `ref.tag`; "see
+  `.github/renovate/k3s-version.json`," not "auto-merges after 7 days."
+  Describing *what a mechanism does* ("k3s patches may auto-merge after a
+  soak period") stays fine — restating its *current parameter* doesn't.
 - **Match altitude to the doc, not to how interesting the change is.** A
   fascinating implementation detail inside a module's Helm values still
   doesn't belong in `clusters/<name>/README.md` — that doc answers "what's
@@ -81,6 +88,84 @@ so sub-skills can stay short and just link back:
 - **Run `pre-commit run --files <changed-docs>` before considering the update
   done.** All six docs must pass markdownlint (and yamllint/kubeconform if a
   manifest changed alongside).
+- **A Mermaid diagram must actually render on GitHub and in VS Code, not just
+  parse.** Both platforms use the current mermaid.js and its stock sanitizer.
+  Verify any diagram you write or edit before considering it done — see
+  "Verifying a Mermaid diagram renders correctly" below. Don't rely on eyeballing
+  the source for correctness; the failure modes here are silent (a diagram
+  renders "successfully" with nodes stacked on top of each other, or GitHub
+  shows a parse error with no useful line number).
+
+### Verifying a Mermaid diagram renders correctly
+
+Two known, easy-to-hit failure classes, both confirmed against a real
+mermaid.js render (not just `mermaid.parse`, which does not catch either one):
+
+1. **`direction LR`/`TB` inside a `subgraph` is silently dropped the moment
+   that subgraph has any edge crossing its boundary** (an edge from a node
+   inside it to a node outside it, or vice versa) — this is a known upstream
+   Mermaid layout limitation, not a bug in this repo's diagrams specifically.
+   The dropped direction isn't just cosmetic: it can cause nodes in different
+   subgraphs to be laid out at identical coordinates, i.e. actually
+   overlapping. Every dependency-graph diagram in this repo has cross-subgraph
+   edges, so **do not add a `direction` line inside a `subgraph` here** —
+   check whether your new/edited subgraph has any inbound or outbound edge; if
+   it does (it almost always will), omit `direction` entirely rather than
+   write a line that will be silently ignored.
+2. **Angle brackets in a node label must be escaped as `&lt;`/`&gt;`, never
+   written raw** (e.g. `root["clusters/&lt;name&gt;/"]`, not
+   `root["clusters/<name>/"]`). GitHub's markdown sanitizer parses an
+   unescaped `<name>` as the start of an HTML tag and can break rendering.
+   This is easy to miss because a raw angle bracket parses fine locally and
+   even renders fine in some contexts — it fails specifically under GitHub's
+   sanitization pass.
+
+To verify a diagram before finishing, render it with mermaid.js locally
+(don't rely on a browser-based headless renderer like `mermaid-cli` unless
+one is already working in this environment — installing a browser purely to
+render a diagram is out of scope for a doc update): use the `mermaid` npm
+package inside a `jsdom` environment. Sample harness — save as a script, run
+with `node`, pass the `.mmd` source as an argument:
+
+```js
+import { JSDOM } from 'jsdom';
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { pretendToBeVisual: true });
+global.window = dom.window;
+global.document = dom.window.document;
+Object.defineProperty(global, 'navigator', { value: dom.window.navigator, configurable: true });
+class FakeCSSStyleSheet {
+  cssRules = [];
+  replaceSync() {}
+  insertRule(rule, index) { this.cssRules.splice(index ?? this.cssRules.length, 0, rule); return index ?? this.cssRules.length - 1; }
+}
+global.CSSStyleSheet = FakeCSSStyleSheet;
+dom.window.CSSStyleSheet = FakeCSSStyleSheet;
+dom.window.SVGElement.prototype.getBBox = () => ({ x: 0, y: 0, width: 100, height: 20 });
+dom.window.SVGElement.prototype.getComputedTextLength = () => 60;
+
+const mermaid = (await import('mermaid')).default;
+mermaid.initialize({ startOnLoad: false });
+import fs from 'fs';
+const code = fs.readFileSync(process.argv[2], 'utf8');
+const { svg } = await mermaid.render('check', code);
+console.log('rendered, svg length:', svg.length);
+```
+
+After it renders, check for node overlap by extracting each
+`<g class="node ...">` element's `transform="translate(x, y)"` and confirming
+no two nodes share the same `(x, y)` pair — that's the concrete symptom of the
+`direction`-inside-subgraph bug above, and parsing/rendering success alone
+won't catch it. Run this check (`npm install jsdom mermaid` in a scratch
+directory is fine) whenever you add a subgraph, add a cross-subgraph edge, or
+touch a label containing `<`/`>`. A diagram with no subgraphs and no angle
+brackets in labels doesn't need this — the failure modes above don't apply to
+it.
+
+- **Prefer plain, unhyphenated node IDs** (`secx` not `sec-x`, `homeauto` not
+  `home-auto`). A hyphen in a bare node ID works today but is fragile across
+  Mermaid versions and easy to get wrong when adding edges (`sec-x --> net-x`
+  can be misparsed as `sec - x --> net - x` in some contexts). Keep the
+  human-readable name in the label (`secx[security-extra]`), not the ID.
 
 ## When a change doesn't fit any existing doc's scope
 

--- a/.claude/skills/verify-mermaid-diagrams/SKILL.md
+++ b/.claude/skills/verify-mermaid-diagrams/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: verify-mermaid-diagrams
+description: This skill should be used whenever writing, editing, or reviewing a Mermaid diagram in this repo's docs (README.md, DESIGN.md, policies/README.md, clusters/homelab/README.md, clusters/nas/README.md) — including when the user asks "does this diagram render correctly", "fix the mermaid diagram", or "why doesn't this diagram show up on GitHub". Every other doc-maintenance skill that touches a Mermaid diagram invokes this one rather than re-deriving diagram-correctness rules itself. Covers two real, silent failure classes (dead `direction` inside a subgraph causing node overlap, unescaped angle brackets breaking under GitHub's sanitizer) plus a runnable verification harness — `mermaid.parse` alone does not catch either failure.
+---
+
+# Verify Mermaid Diagrams
+
+A Mermaid diagram can parse without error and still render wrong on GitHub or
+in VS Code — sometimes silently (nodes overlapping, a subgraph laid out in
+the wrong direction), sometimes outright (GitHub's sanitizer eating part of
+the diagram). This skill is the single place that knows about these failure
+modes and how to check for them, so every doc-maintenance skill that writes
+or edits a diagram invokes it instead of restating the rules inline.
+
+## Two known, easy-to-hit failure classes
+
+Both confirmed against a real mermaid.js render — `mermaid.parse()` succeeds
+on both, so parsing cleanly is not evidence of correctness.
+
+1. **`direction LR`/`TB` inside a `subgraph` is silently dropped the moment
+   that subgraph has any edge crossing its boundary** (an edge from a node
+   inside it to a node outside it, or vice versa). This is a known upstream
+   Mermaid layout limitation, not specific to this repo's diagrams. The
+   dropped direction isn't just cosmetic: it can cause nodes in different
+   subgraphs to be laid out at identical coordinates — actual overlap, not a
+   rendering-quality issue. Every dependency-graph diagram in this repo has
+   cross-subgraph edges (that's the point of grouping core/extra/apps into
+   subgraphs while also drawing dependencies between them), so **do not add
+   a `direction` line inside a `subgraph` in this repo** — check whether the
+   subgraph you're writing has any inbound or outbound edge; if it does (it
+   almost always will here), omit `direction` entirely rather than write a
+   line that will be silently ignored.
+2. **Angle brackets in a node label must be escaped as `&lt;`/`&gt;`, never
+   written raw** — e.g. `root["clusters/&lt;name&gt;/"]`, not
+   `root["clusters/<name>/"]`. GitHub's markdown sanitizer parses an
+   unescaped `<name>` as the start of an HTML tag and can break rendering.
+   Easy to miss because a raw angle bracket parses fine locally and can even
+   render fine in some viewers — it fails specifically under GitHub's
+   sanitization pass, which is the platform that matters most here.
+
+A third, lower-severity guideline: **prefer plain, unhyphenated node IDs**
+(`secx` not `sec-x`, `homeauto` not `home-auto`). A hyphen in a bare node ID
+works today but is fragile across Mermaid versions and easy to misparse when
+adding edges (`sec-x --> net-x` can be read as `sec - x --> net - x` in some
+contexts). Keep the human-readable name in the label
+(`secx[security-extra]`), not the ID.
+
+## Verifying a diagram before finishing
+
+Render it with mermaid.js locally rather than eyeballing the source — both
+failure classes above are invisible by inspection and `mermaid.parse` does
+not catch either. Don't reach for a browser-based headless renderer (e.g.
+`mermaid-cli`) unless one is already working in this environment; installing
+a browser purely to check a diagram is disproportionate. Instead, run
+mermaid's own renderer inside `jsdom`, which needs no browser.
+
+Save as a script and run with `node <script>.mjs <path-to-mmd-source>`
+(`npm install jsdom mermaid` in a scratch directory first if not already
+available):
+
+```js
+import { JSDOM } from 'jsdom';
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { pretendToBeVisual: true });
+global.window = dom.window;
+global.document = dom.window.document;
+Object.defineProperty(global, 'navigator', { value: dom.window.navigator, configurable: true });
+class FakeCSSStyleSheet {
+  cssRules = [];
+  replaceSync() {}
+  insertRule(rule, index) { this.cssRules.splice(index ?? this.cssRules.length, 0, rule); return index ?? this.cssRules.length - 1; }
+}
+global.CSSStyleSheet = FakeCSSStyleSheet;
+dom.window.CSSStyleSheet = FakeCSSStyleSheet;
+dom.window.SVGElement.prototype.getBBox = () => ({ x: 0, y: 0, width: 100, height: 20 });
+dom.window.SVGElement.prototype.getComputedTextLength = () => 60;
+
+const mermaid = (await import('mermaid')).default;
+mermaid.initialize({ startOnLoad: false });
+import fs from 'fs';
+const code = fs.readFileSync(process.argv[2], 'utf8');
+const { svg } = await mermaid.render('check', code);
+console.log('rendered, svg length:', svg.length);
+fs.writeFileSync(process.argv[2] + '.svg', svg);
+```
+
+After it renders, check for node overlap: extract each
+`<g class="node ...">` element's `transform="translate(x, y)"` from the
+written `.svg` and confirm no two nodes share the same `(x, y)` pair — that's
+the concrete symptom of the `direction`-inside-subgraph bug, and rendering
+"successfully" doesn't rule it out.
+
+```python
+import re
+svg = open("<path>.mmd.svg").read()
+coords = re.findall(r'<g class="node[^"]*" id="([^"]+)"[^>]*transform="translate\(([-\d.]+), ([-\d.]+)\)"', svg)
+seen = {}
+for nid, x, y in coords:
+    key = (x, y)
+    if key in seen:
+        print("OVERLAP:", seen[key], "and", nid, "both at", key)
+    seen[key] = nid
+```
+
+## When to run this
+
+Any time you write a new diagram or edit an existing one in this repo —
+adding/removing a node, subgraph, or edge, or touching a label. A diagram
+with no `subgraph` blocks and no `<`/`>` in any label doesn't need the
+render-and-check step (neither failure class applies), but still gets a
+plain read-through for the node-ID guideline above.
+
+This skill doesn't decide *what* a diagram should show — that's the job of
+whichever doc-maintenance skill invoked it (`update-cluster-docs`,
+`update-design-docs`, `update-policy-docs`) or `audit-repo-docs` when
+checking one for drift. It only verifies that a diagram, once written, will
+actually render the way it's supposed to.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Start here
+
+- [README.md](./README.md) — what this repo is, how it relates to the sibling apps repo, per-cluster catalog links
+- [DESIGN.md](./DESIGN.md) — directory anatomy, how a module gets wired into a cluster (sources/kustomizations/dependsOn/components/postBuild/patches), the `services/` pattern, secrets/RBAC/storage model, CI, versioning
+- [clusters/homelab/README.md](./clusters/homelab/README.md) / [clusters/nas/README.md](./clusters/nas/README.md) — what's actually deployed on each cluster, with links to each module's own README in the apps repo
+- [policies/README.md](./policies/README.md) — Kyverno policy groups and what's enforced where
+
+This is a GitOps repo (FluxCD) of Kustomize manifests — there is no application
+code to build. "Development" here means authoring/editing YAML and validating
+it. This repo defines *no modules of its own* — it only pins versions of, and
+configures, modules that live in the sibling apps repo (see below).
+
+## Repository layout
+
+- `clusters/<name>/sources/` — one Flux `GitRepository` per module, pinned to a released tag of the apps repo
+- `clusters/<name>/kustomizations/` — one Flux `Kustomization` per module (the actual deploy wiring: `dependsOn`, `components`, `postBuild`, `patches`); `root.yaml` is the Flux bootstrap entry point
+- `clusters/<name>/cluster/` — cluster-wide, not module-specific: k8s version upgrades, RBAC bindings, Bitwarden-backed cluster secrets
+- `clusters/<name>/storage/` — `PersistentVolume`/`PersistentVolumeClaim`/`StorageClass` split `infra/`/`apps/`, pre-provisioned ahead of the module that claims them
+- `clusters/<name>/services/` — cluster-specific extras that aren't modules: either config/secrets a module looks up by name, or standalone CRs with no module awareness. See [DESIGN.md#the-services-directory](./DESIGN.md#the-services-directory)
+- `clusters/nas/outpost/` — nas-specific: an Authentik remote outpost, authored directly in this repo (not sourced from the apps repo)
+- `policies/` — shared, cluster-agnostic Kyverno `ClusterPolicy`/`ClusterCleanupPolicy` definitions, applied to both clusters
+- `ci/validation/` — base kustomization + `.env` of dummy post-build substitution variables used by kubeconform validation
+
+## How this repo consumes the apps repo (cross-repo)
+
+Modules — infrastructure subsystems, applications, cross-cutting components —
+are built, versioned, and released independently in the sibling
+`homelab-ops-kubernetes-apps` repo, checked out alongside this one
+(`../homelab-ops-kubernetes-apps`). This repo has no modules of its own; every
+`sources/<module>.yaml` + `kustomizations/<module>.yaml` pair pins a released
+tag of that repo and configures it for one specific cluster. The same module
+can be referenced by both clusters at different versions with different
+components/patches/variables. When changing something here, check the
+matching module's README in the apps repo for its prerequisites and
+dependencies before assuming a config change is valid.
+
+Full mechanics — what `dependsOn`/`components`/`postBuild`/`patches` do and a
+worked example — are in [DESIGN.md](./DESIGN.md#wiring-a-module-into-a-cluster).
+
+## Commands
+
+### Lint / validate locally (same checks CI enforces on every PR)
+
+```bash
+pre-commit run --all-files      # yamllint, markdownlint, shellcheck, commitlint, kubeconform, etc.
+```
+
+Individual checks can be run standalone: `yamllint --strict <path>`,
+`markdownlint-cli2 --fix --config .markdownlint-cli2.yaml <path>`, `shellcheck <script>`.
+
+Kubernetes manifest validation (kubeconform via the `validate-kubernetes-manifests`
+pre-commit hook) uses `ci/validation/kustomization.yaml` as the base
+kustomization and `ci/validation/.env` for dummy post-build substitution
+values, restricted to `clusters/*` and `policies/*` (excludes `components/*`
+and `.archive/*`).
+
+### CI enforcement
+
+Every PR runs `.github/workflows/lint.yaml`, which fans out to per-file-type
+jobs (commit-messages via commitlint, github-actions, kubernetes-manifests via
+kubeconform, markdown, pre-commit, renovate-config-check, shellcheck, yaml) —
+each gated on whether matching files changed. Separately,
+`.github/workflows/diff-changes.yaml` checks out the apps repo alongside
+before/after versions of this repo and comments a rendered `flux-diff` of
+affected `HelmRelease`/`Kustomization` resources on any PR touching
+`clusters/**` or `policies/**`. Full breakdown in
+[DESIGN.md#ci-and-validation](./DESIGN.md#ci-and-validation).
+
+## Commit conventions
+
+Conventional Commits, enforced by commitlint (`commitlint.config.js`):
+
+- header max 120 chars; scope must be one of: `cluster-homelab`, `cluster-nas`, `dev-tools`, `github-actions`, `kubernetes-api`, `policies`, `renovate`, `release`
+- version bumps to a module use scope matching the cluster, e.g. `chore(cluster-homelab): deploy infra-security-core (v0.2.5 -> v0.2.6)`
+
+## Dependency updates
+
+Renovate manages module version bumps (`clusters/*/sources/*.yaml`) and k3s
+version bumps (`cluster/kubernetes-version/server-upgrade.yaml`). Module bumps
+never auto-merge (config-split across `.github/renovate/*.json`); k3s patches
+auto-merge after a 7-day soak, major/minor require review. See
+[DESIGN.md#versioning-and-updates](./DESIGN.md#versioning-and-updates).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,24 @@ Conventional Commits, enforced by commitlint (`commitlint.config.js`):
 - header max 120 chars; scope must be one of: `cluster-homelab`, `cluster-nas`, `dev-tools`, `github-actions`, `kubernetes-api`, `policies`, `renovate`, `release`
 - version bumps to a module use scope matching the cluster, e.g. `chore(cluster-homelab): deploy infra-security-core (v0.2.5 -> v0.2.6)`
 
+## Pull requests
+
+GitHub is configured to **squash-merge** every PR into `main` — all commits
+on a branch collapse into a single commit at merge time. GitHub seeds the
+squash commit from the PR's **first commit**: the first commit's subject
+line becomes the PR title, and the rest of its message becomes the PR body
+(later commits' messages are discarded from that seed, though GitHub also
+appends a list of all commit subjects below the body).
+
+Practical effect: **write the first commit on a branch as if it already
+describes everything the branch will eventually do**, not just that first
+step. If a branch grows additional commits, go back and reword the first
+commit's message (`git commit --amend` if it's still last, or a rebase
+otherwise) to fold in what the later commits added, before opening or
+updating the PR. A first commit message that only describes its own small
+slice will ship as an incomplete PR title/body even though the branch as a
+whole did more.
+
 ## Dependency updates
 
 Renovate manages module version bumps (`clusters/*/sources/*.yaml`) and k3s

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ affected `HelmRelease`/`Kustomization` resources on any PR touching
 Conventional Commits, enforced by commitlint (`commitlint.config.js`):
 
 - header max 120 chars; scope must be one of: `cluster-homelab`, `cluster-nas`, `dev-tools`, `github-actions`, `kubernetes-api`, `policies`, `renovate`, `release`
-- version bumps to a module use scope matching the cluster, e.g. `chore(cluster-homelab): deploy infra-security-core (v0.2.5 -> v0.2.6)`
+- version bumps to a module use scope matching the cluster, e.g. `chore(cluster-homelab): deploy <module> (<old-version> -> <new-version>)`
 
 ## Pull requests
 
@@ -98,7 +98,9 @@ whole did more.
 ## Dependency updates
 
 Renovate manages module version bumps (`clusters/*/sources/*.yaml`) and k3s
-version bumps (`cluster/kubernetes-version/server-upgrade.yaml`). Module bumps
-never auto-merge (config-split across `.github/renovate/*.json`); k3s patches
-auto-merge after a 7-day soak, major/minor require review. See
+version bumps (`cluster/kubernetes-version/server-upgrade.yaml`); config is
+split across `.github/renovate/*.json` by category. Module bumps always
+require review; k3s patch bumps may auto-merge after a soak period, major/minor
+always require review. Current soak periods and reviewers are in
+`.github/renovate/*.json`, not restated here. See
 [DESIGN.md#versioning-and-updates](./DESIGN.md#versioning-and-updates).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -22,20 +22,18 @@ repo and are released there independently, one version per module.
 ```mermaid
 flowchart LR
     subgraph apps["homelab-ops-kubernetes-apps"]
-        direction TB
         M1["infrastructure/subsystems/*"]
         M2["apps/subsystems/*"]
         M3["components/*"]
     end
 
     subgraph clusters["homelab-ops-kubernetes-clusters (this repo)"]
-        direction TB
         GR["GitRepository\n(pinned to a released tag)"]
         KZ["Kustomization\n(path, dependsOn, components,\npostBuild, patches)"]
         GR --> KZ
     end
 
-    apps -- "released tag\ne.g. infra-security-core-v0.2.6" --> GR
+    apps -- "released tag" --> GR
     KZ -- "spec.path points into" --> apps
     KZ -- "spec.components mixes in" --> M3
 
@@ -93,8 +91,8 @@ that module are made:
 
 ```mermaid
 flowchart TB
-    GR["GitRepository (sources/infra-security-core.yaml)\nref.tag: infra-security-core-v0.2.6\nignore: only /infrastructure/subsystems/security-core + /components"]
-    KZ["Kustomization (kustomizations/infra-security-core.yaml)\npath: ./infrastructure/subsystems/security-core"]
+    GR["GitRepository (sources/&lt;module&gt;.yaml)\nref.tag: a released tag of the apps repo"]
+    KZ["Kustomization (kustomizations/&lt;module&gt;.yaml)\npath: into the apps repo's module directory"]
     GR -->|sourceRef| KZ
 
     KZ --> DEP["dependsOn\nother Kustomizations that must be Ready first"]
@@ -129,10 +127,12 @@ spec:
 
 All four mechanisms — `dependsOn`, `components`, `postBuild`, `patches` — are
 applied *only* at this point of use, never inside the module itself. That's what
-lets the same module serve both clusters differently: `infra-networking-core` on
-`homelab` sets `externaldns_txtowner_prefix: k8s.` while on `nas` it's `k8s.nas.`,
-and `nas`'s copy patches Traefik to run as a `Deployment` with 2 replicas instead
-of a `DaemonSet`.
+lets the same module serve both clusters differently: `networking-core` runs on
+both `homelab` and `nas` with different `postBuild.substitute` values (e.g. a
+per-cluster DNS TXT-record owner prefix, so external-dns on one cluster doesn't
+clobber the other's records) and a patch on `nas` alone that changes how Traefik
+is deployed there. The exact values are in each cluster's
+`kustomizations/infra-networking-core.yaml`.
 
 ## The `services/` directory
 
@@ -157,8 +157,7 @@ module's own manifests, for two distinct reasons:
 
 ```mermaid
 flowchart LR
-    subgraph svc["services/<name>/"]
-        direction TB
+    subgraph svc["services/&lt;name&gt;/"]
         A["ConfigMap / Secret\nlooked up by name from inside a module"]
         B["Standalone CRs\n(no module awareness)"]
     end
@@ -210,12 +209,14 @@ flowchart LR
     classDef ext fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
     classDef k8s fill:#dbeafe,stroke:#3b82f6,color:#1e3a8a
     class BW ext
-    class CSS,CS,K8SSECRET,K8SSECRET k8s
+    class CSS,CS,K8SSECRET k8s
 ```
 
-`cluster-secrets` holds cluster-wide values (DNS zone, domain name, external IPs
-for MetalLB/Pi-hole/Plex/etc., cert-issuer email) that many modules'
-`postBuild.substituteFrom` pull from. Module-specific secrets (e.g. the
+`cluster-secrets` is one `ExternalSecret` holding every value that's genuinely
+cluster-wide rather than owned by a single module — DNS/domain identifiers,
+per-service external IPs handed out by MetalLB, the cert-issuer contact email.
+Any module's `postBuild.substituteFrom` can pull from it; the exact key list is
+`cluster/secrets/cluster-secrets.yaml`. Module-specific secrets (e.g. the
 downloaders' VPN key in `services/downloaders/downloaders-gluetun-secrets.yaml`)
 are their own `ExternalSecret`s pointed at the same `ClusterSecretStore`, scoped
 to the namespace that needs them. `ClusterSecretStore`/`ExternalSecret` objects
@@ -252,18 +253,18 @@ checks locally (`.pre-commit-config.yaml`).
 
 ## Versioning and updates
 
-Renovate (`.github/renovate.json` + `.github/renovate/*.json`) manages two
-categories of updates in this repo:
+Renovate manages two categories of version bumps in this repo, each grouped
+and labeled per cluster: **Flux sources** (a module's `ref.tag` in
+`clusters/*/sources/*.yaml`, bumped when the apps repo cuts a new release) and
+**k3s version** (`cluster/kubernetes-version/server-upgrade.yaml`). A module
+bump changes deployed behavior, so it always requires human review — the
+`diff-changes` PR comment (see [CI and validation](#ci-and-validation)) is what
+that review is based on. k3s patch bumps may auto-merge after a soak period;
+major/minor bumps always require review. Exact soak periods and reviewers are
+configuration, not design, and belong to `.github/renovate/*.json` — read
+those files rather than this doc for the current values.
 
-- **Flux sources** (`clusters/*/sources/*.yaml`): bumps to a module's `ref.tag`
-  when a new release lands in the apps repo. Always `automerge: false`, grouped
-  and labeled by cluster (`cluster:homelab` / `cluster:nas`) since a version bump
-  changes deployed behavior and always warrants review via the `diff-changes`
-  PR comment.
-- **k3s version** (`cluster/kubernetes-version/server-upgrade.yaml`): patch
-  bumps auto-eligible after a 7-day soak; major/minor require review
-  (`reviewers: ["ppat"]`) and a 60-day soak.
-
-Commits follow Conventional Commits with `commitlint.config.js` enforcing scope
-one of: `cluster-homelab`, `cluster-nas`, `dev-tools`, `github-actions`,
-`kubernetes-api`, `policies`, `renovate`, `release`.
+Commits follow Conventional Commits, enforced by `commitlint.config.js` (see
+[CLAUDE.md](./CLAUDE.md#commit-conventions) for the current scope list). A
+version-bump commit's scope names the cluster it deploys to, e.g.
+`cluster-homelab`.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,269 @@
+# Design
+
+This document explains how this repository is structured and why: the directory
+shape every cluster follows, how a module from the sibling apps repo gets wired
+into a running cluster, and the supporting mechanisms (secrets, RBAC, storage,
+policy, CI, versioning) that make it work.
+
+For what each cluster actually runs, see [clusters/homelab/README.md](./clusters/homelab/README.md)
+and [clusters/nas/README.md](./clusters/nas/README.md). For the modules
+themselves — what they are and how they're organized — see the apps repo's
+[projectBrief.md](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/projectBrief.md).
+
+## Two repositories, one system
+
+This repo has no application code and defines no modules of its own. It holds
+only the cluster-specific wiring — Flux resources that say "deploy version X of
+module Y, configured this way, on this cluster." The modules themselves
+(infrastructure subsystems, apps, cross-cutting components) live in the sibling
+[`homelab-ops-kubernetes-apps`](https://github.com/ppat/homelab-ops-kubernetes-apps)
+repo and are released there independently, one version per module.
+
+```mermaid
+flowchart LR
+    subgraph apps["homelab-ops-kubernetes-apps"]
+        direction TB
+        M1["infrastructure/subsystems/*"]
+        M2["apps/subsystems/*"]
+        M3["components/*"]
+    end
+
+    subgraph clusters["homelab-ops-kubernetes-clusters (this repo)"]
+        direction TB
+        GR["GitRepository\n(pinned to a released tag)"]
+        KZ["Kustomization\n(path, dependsOn, components,\npostBuild, patches)"]
+        GR --> KZ
+    end
+
+    apps -- "released tag\ne.g. infra-security-core-v0.2.6" --> GR
+    KZ -- "spec.path points into" --> apps
+    KZ -- "spec.components mixes in" --> M3
+
+    classDef appsStyle fill:#dbeafe,stroke:#3b82f6,color:#1e3a8a
+    classDef clusterStyle fill:#dcfce7,stroke:#059669,color:#064e3b
+    class M1,M2,M3 appsStyle
+    class GR,KZ clusterStyle
+```
+
+The same module, at different versions, with different components/patches/variables,
+can be (and is) referenced by both clusters at once — that's how one set of
+modules serves two clusters with different needs.
+
+## Cluster directory anatomy
+
+Every cluster under `clusters/<name>/` follows the same shape:
+
+```mermaid
+flowchart TB
+    root["clusters/&lt;name&gt;/"]
+    sources["sources/\nGitRepository per module\n(pins a released tag)"]
+    kusts["kustomizations/\nFlux Kustomization per module\n(wires it into this cluster)"]
+    cluster["cluster/\ncluster-wide, not module-specific:\nk8s version, RBAC, secrets"]
+    storage["storage/\nPV / PVC / StorageClass,\nsplit infra vs apps"]
+    services["services/\ncluster-specific extras that\naren't modules — see below"]
+
+    root --> sources
+    root --> kusts
+    root --> cluster
+    root --> storage
+    root --> services
+
+    classDef dir fill:#e2e8f0,stroke:#64748b,color:#334155
+    class root,sources,kusts,cluster,storage,services dir
+```
+
+| Directory | Contents | Consumed by |
+| --- | --- | --- |
+| `sources/` | One Flux `GitRepository` per module, `spec.ref.tag` pinned to a release of the apps repo, `spec.ignore` scoped to just that module's directory (plus `/components`) | Referenced by the matching `kustomizations/*.yaml` via `spec.sourceRef` |
+| `kustomizations/` | One Flux `Kustomization` per module (or per cluster-local config group), the actual deploy wiring | Applied by the `root` Kustomization, which Flux itself watches |
+| `cluster/` | `kubernetes-version/` (k3s upgrade `Plan`), `rbac/` (admin/readonly `ClusterRoleBinding`s), `secrets/` (Bitwarden `ClusterSecretStore` + the `cluster-secrets` `ExternalSecret`) | Bootstrapped once per cluster, not tied to any single module |
+| `storage/` | `infra/` and `apps/` subtrees of `PersistentVolume`/`PersistentVolumeClaim`/`StorageClass`/Longhorn `RecurringJob`, matching the module that will claim them | Pre-provisioned ahead of the module that mounts them (see [Storage](#storage)) |
+| `services/` | Cluster-specific extras that aren't modules at all — see [The `services/` directory](#the-services-directory) | Either looked up by name from inside a module, or standalone (no module awareness) |
+
+`root.yaml` in `kustomizations/` is the Flux bootstrap entry point: it's the one
+`Kustomization` that Flux is told about directly, with `spec.path: ./clusters/<name>`,
+and it recursively picks up everything else in the cluster directory via plain
+Kustomize `resources:` composition — not via `dependsOn`.
+
+## Wiring a module into a cluster
+
+A `sources/<module>.yaml` + `kustomizations/<module>.yaml` pair is how a module
+gets deployed. The `Kustomization` is where all cluster-specific decisions about
+that module are made:
+
+```mermaid
+flowchart TB
+    GR["GitRepository (sources/infra-security-core.yaml)\nref.tag: infra-security-core-v0.2.6\nignore: only /infrastructure/subsystems/security-core + /components"]
+    KZ["Kustomization (kustomizations/infra-security-core.yaml)\npath: ./infrastructure/subsystems/security-core"]
+    GR -->|sourceRef| KZ
+
+    KZ --> DEP["dependsOn\nother Kustomizations that must be Ready first"]
+    KZ --> COMP["components\nmixes in components/* from the apps repo\n(sso, cert-issuer/letsencrypt, oidc-credentials/*, db-backups, ...)"]
+    KZ --> PB["postBuild\nsubstitute (inline) / substituteFrom (cluster-secrets)\nfills in Flux template vars the module exposes"]
+    KZ --> PATCH["patches\nJSON6902 / strategic merge overrides\n(resource sizing, deleting a HelmRelease this cluster doesn't want, etc.)"]
+
+    classDef src fill:#dcfce7,stroke:#059669,color:#064e3b
+    classDef k fill:#dbeafe,stroke:#3b82f6,color:#1e3a8a
+    class GR src
+    class KZ,DEP,COMP,PB,PATCH k
+```
+
+Concrete example — `infra-security-core` on `homelab`:
+
+```yaml
+# clusters/homelab/kustomizations/infra-security-core.yaml
+spec:
+  components:
+  - ../../../components/cert-issuer/letsencrypt   # mix in a component
+  path: ./infrastructure/subsystems/security-core  # module path in the apps repo
+  sourceRef:
+    kind: GitRepository
+    name: infra-security-core                      # matches sources/infra-security-core.yaml
+  postBuild:
+    substitute:
+      secret_store: bitwarden-secret-manager-store
+    substituteFrom:
+    - kind: Secret
+      name: cluster-secrets                          # see Secrets below
+```
+
+All four mechanisms — `dependsOn`, `components`, `postBuild`, `patches` — are
+applied *only* at this point of use, never inside the module itself. That's what
+lets the same module serve both clusters differently: `infra-networking-core` on
+`homelab` sets `externaldns_txtowner_prefix: k8s.` while on `nas` it's `k8s.nas.`,
+and `nas`'s copy patches Traefik to run as a `Deployment` with 2 replicas instead
+of a `DaemonSet`.
+
+## The `services/` directory
+
+`services/<name>/` holds cluster-specific resources that exist *outside* any
+module's own manifests, for two distinct reasons:
+
+1. **Extra config/secrets consumed by a module.** A module's app may look up a
+   `ConfigMap`/`Secret` by a fixed name at runtime, or a cluster `Kustomization`
+   may inject it via a patch or `postBuild` variable. Either way, the module
+   itself doesn't ship this object — it's cluster-specific and may be optional.
+   Example: `services/downloaders/downloaders-gluetun-config.yaml` is a
+   `ConfigMap` named `gluetun-config` that the `gluetun` container inside the
+   `apps-downloaders` module reads directly by name (VPN provider, server
+   selection, port-forwarding hooks) — the downloaders module works without it,
+   but qBittorrent's traffic won't route through a VPN unless it's present.
+2. **Standalone extra resources with no module awareness.** CRDs or other
+   objects that just need to exist on this cluster, independent of any module's
+   name-lookup contract. Example: `services/tailscale/connector.yaml` (a
+   Tailscale `Connector` advertising the homelab subnet and acting as an exit
+   node) and `proxyclass.yaml` — these aren't referenced by any module, they're
+   deployed because this cluster needs a subnet router.
+
+```mermaid
+flowchart LR
+    subgraph svc["services/<name>/"]
+        direction TB
+        A["ConfigMap / Secret\nlooked up by name from inside a module"]
+        B["Standalone CRs\n(no module awareness)"]
+    end
+
+    A -.->|"consumed by name\n(optional or required)"| MOD["a deployed module"]
+    B -->|"exists independently"| CLUSTER["the cluster itself"]
+
+    classDef svcStyle fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
+    class A,B svcStyle
+```
+
+`config-services` (a `kustomizations/config-services.yaml` entry) applies
+everything under `services/` cluster-wide, `dependsOn` whatever
+security/networking core it needs.
+
+## Storage
+
+`storage/infra/` and `storage/apps/` hold `PersistentVolume`, `PersistentVolumeClaim`,
+and `StorageClass` objects, pre-provisioned ahead of the module that will claim
+them (by matching PVC name) — infra objects for infrastructure modules (e.g.
+`minio-data`, `unifi-data`), apps objects per app subsystem (e.g.
+`storage/apps/pvc/downloaders/*`). `storage/infra/job/` on `homelab` also holds
+Longhorn `RecurringJob` snapshot/backup/trim schedules. `PersistentVolume`,
+`PersistentVolumeClaim`, `StorageClass`, and `RecurringJob` are excluded from
+Flux pruning (patched via `kustomize.toolkit.fluxcd.io/prune: disabled`) since
+deleting them would mean data loss.
+
+The `nas` cluster mounts NFS shares dynamically (`sc-nfs-dynamic-share`) or
+statically per app (`storage/apps/pv/<app>/static-nfs-share-*.yaml`), while
+`homelab` mixes Longhorn-backed classes (`sc-longhorn-replicated`,
+`sc-longhorn-local-non-replicated`, `sc-longhorn-rwx`) with static NFS mounts
+for large media libraries.
+
+## Secrets
+
+All cluster secrets originate from a shared Bitwarden Secrets Manager project,
+surfaced into each cluster via External Secrets Operator:
+
+```mermaid
+flowchart LR
+    BW["Bitwarden Secrets Manager\n(shared project)"]
+    CSS["ClusterSecretStore\nbitwarden-secret-manager-store\n(cluster/secrets/bitwarden-secret-store.yaml)"]
+    CS["ExternalSecret: cluster-secrets\n(cluster/secrets/cluster-secrets.yaml)\none secretKey per cluster-wide value"]
+    K8SSECRET["Secret: cluster-secrets\n(flux-system namespace)"]
+    KZ["any module's Kustomization\npostBuild.substituteFrom"]
+
+    BW --> CSS --> CS --> K8SSECRET --> KZ
+
+    classDef ext fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
+    classDef k8s fill:#dbeafe,stroke:#3b82f6,color:#1e3a8a
+    class BW ext
+    class CSS,CS,K8SSECRET,K8SSECRET k8s
+```
+
+`cluster-secrets` holds cluster-wide values (DNS zone, domain name, external IPs
+for MetalLB/Pi-hole/Plex/etc., cert-issuer email) that many modules'
+`postBuild.substituteFrom` pull from. Module-specific secrets (e.g. the
+downloaders' VPN key in `services/downloaders/downloaders-gluetun-secrets.yaml`)
+are their own `ExternalSecret`s pointed at the same `ClusterSecretStore`, scoped
+to the namespace that needs them. `ClusterSecretStore`/`ExternalSecret` objects
+in `cluster/secrets/` are prune-disabled for the same reason storage is —
+losing the pointer to Bitwarden shouldn't be a side effect of a bad Kustomize
+diff.
+
+## RBAC
+
+`cluster/rbac/` binds two Kubernetes API groups (`homelab-admins`,
+`homelab-users`) — backed by the OIDC identity provider from the apps repo's
+`security-extra` module — to the built-in `cluster-admin` and `view`
+`ClusterRole`s via `ClusterRoleBinding`s. These are cluster-wide and unrelated
+to any single module.
+
+## Policy enforcement
+
+Kyverno `ClusterPolicy`/`ClusterCleanupPolicy` objects live in the shared,
+cluster-agnostic `policies/` directory at the repo root (not under
+`clusters/`) and are applied to both clusters via their own
+`policy-*` Kustomizations. See [policies/README.md](./policies/README.md) for
+what's enforced and in what mode.
+
+## CI and validation
+
+| Workflow | Trigger | What it does |
+| --- | --- | --- |
+| `lint.yaml` | every PR + weekly | yamllint, markdownlint, shellcheck, commitlint, Renovate config check, and `kubeconform`-based Kubernetes manifest validation (via `ci/validation/kustomization.yaml` + `ci/validation/.env` dummy `postBuild` values) restricted to `clusters/*` and `policies/*` |
+| `diff-changes.yaml` | PRs touching `clusters/**` or `policies/**` | Checks out the apps repo (`main`) alongside before/after versions of this repo, resolves each `Kustomization`'s `sourceRef` tag via `.github/scripts/prepare-sources.sh`, then runs `flux-diff` to comment a rendered HelmRelease/Kustomization diff on the PR — so a reviewer sees the actual resource-level effect of a version bump or config change before merging |
+| `renovate.yaml` | schedule/dispatch | Runs Renovate to open dependency-update PRs |
+
+`pre-commit` mirrors the yamllint/markdownlint/shellcheck/commitlint/kubeconform
+checks locally (`.pre-commit-config.yaml`).
+
+## Versioning and updates
+
+Renovate (`.github/renovate.json` + `.github/renovate/*.json`) manages two
+categories of updates in this repo:
+
+- **Flux sources** (`clusters/*/sources/*.yaml`): bumps to a module's `ref.tag`
+  when a new release lands in the apps repo. Always `automerge: false`, grouped
+  and labeled by cluster (`cluster:homelab` / `cluster:nas`) since a version bump
+  changes deployed behavior and always warrants review via the `diff-changes`
+  PR comment.
+- **k3s version** (`cluster/kubernetes-version/server-upgrade.yaml`): patch
+  bumps auto-eligible after a 7-day soak; major/minor require review
+  (`reviewers: ["ppat"]`) and a 60-day soak.
+
+Commits follow Conventional Commits with `commitlint.config.js` enforcing scope
+one of: `cluster-homelab`, `cluster-nas`, `dev-tools`, `github-actions`,
+`kubernetes-api`, `policies`, `renovate`, `release`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# homelab-ops-kubernetes-clusters
+# Homelab Kubernetes Clusters
+
+This repository defines the actual Kubernetes clusters that make up the
+homelab: which modules each cluster runs, at which versions, wired together
+with cluster-specific configuration. It contains no application code — only
+Flux/Kustomize manifests. "Development" here means authoring and validating
+YAML.
+
+The modules themselves — infrastructure subsystems, applications, and
+cross-cutting components — are built and released independently in the
+sibling [`homelab-ops-kubernetes-apps`](https://github.com/ppat/homelab-ops-kubernetes-apps)
+repo. This repo pins specific released versions of those modules per cluster
+and configures them for that cluster's needs.
+
+```mermaid
+flowchart LR
+    apps["homelab-ops-kubernetes-apps\nmodules (infra / apps / components)\nreleased & versioned independently"]
+    clusters["homelab-ops-kubernetes-clusters (this repo)\nwhich modules, which versions,\nhow they're configured, per cluster"]
+    apps -- "pinned tags" --> clusters
+```
+
+## Clusters
+
+| Cluster | Role | Catalog |
+| --- | --- | --- |
+| `homelab` | Primary cluster: media, downloaders, home automation, AI, dev environments, plus the full observability/networking/security/storage/database core stack | [clusters/homelab/README.md](./clusters/homelab/README.md) |
+| `nas` | Secondary cluster co-located with NAS storage: Bitwarden, Harbor container registry, and an Authentik SSO outpost, backed by NFS | [clusters/nas/README.md](./clusters/nas/README.md) |
+
+## Finding your way
+
+| I need to... | Look in... |
+| --- | --- |
+| See what's deployed on a specific cluster | [clusters/homelab/README.md](./clusters/homelab/README.md) / [clusters/nas/README.md](./clusters/nas/README.md) |
+| Understand the directory layout and how modules get wired in | [DESIGN.md](./DESIGN.md) |
+| Understand a module's own capabilities, prerequisites, dependencies | The module's README in the [apps repo](https://github.com/ppat/homelab-ops-kubernetes-apps) (linked from each cluster's catalog) |
+| See what cluster-wide Kyverno policy is enforced | [policies/README.md](./policies/README.md) |
+| Run lint/validation locally | [DESIGN.md#ci-and-validation](./DESIGN.md#ci-and-validation) |
+| Understand release/versioning conventions | [DESIGN.md#versioning-and-updates](./DESIGN.md#versioning-and-updates) |

--- a/clusters/homelab/README.md
+++ b/clusters/homelab/README.md
@@ -65,7 +65,6 @@ flowchart TB
     classDef apps fill:#93c5fd,stroke:#2563eb,color:#1e3a8a
 
     subgraph Core["Infrastructure (Core)"]
-        direction LR
         sec[security-core]:::core
         store[storage-core]:::core
         k8s[kubernetes-core]:::core
@@ -76,19 +75,17 @@ flowchart TB
     end
 
     subgraph Extra["Infrastructure (Extra)"]
-        direction LR
-        sec-x[security-extra]:::extra
-        net-x[networking-extra]:::extra
-        k8s-x[kubernetes-extra]:::extra
-        obs-x[observability-extra]:::extra
+        secx[security-extra]:::extra
+        netx[networking-extra]:::extra
+        k8sx[kubernetes-extra]:::extra
+        obsx[observability-extra]:::extra
     end
 
     subgraph Apps["Applications"]
-        direction LR
         ai:::apps
         coder:::apps
         downloaders:::apps
-        home-auto[home-automation]:::apps
+        homeauto[home-automation]:::apps
         media:::apps
         misc:::apps
     end
@@ -99,10 +96,10 @@ flowchart TB
     db --> net & store
     obs --> sec & net & store
 
-    sec-x --> sec & store & db
-    net-x --> sec & store & net
-    k8s-x --> k8s & net & store
-    obs-x --> obs
+    secx --> sec & store & db
+    netx --> sec & store & net
+    k8sx --> k8s & net & store
+    obsx --> obs
 
     Core --> Extra --> Apps
 ```

--- a/clusters/homelab/README.md
+++ b/clusters/homelab/README.md
@@ -1,0 +1,111 @@
+# homelab cluster
+
+The primary cluster: full observability/networking/security/storage/database
+core stack, plus end-user applications (media, downloaders, home automation,
+AI, remote dev environments). Runs the **Restricted** Pod Security Standard
+(see [policies/README.md](../../policies/README.md)).
+
+For how modules get wired in (sources/kustomizations/dependsOn/patches), see
+[DESIGN.md](../../DESIGN.md). For what each module itself provides, follow the
+links below into the [apps repo](https://github.com/ppat/homelab-ops-kubernetes-apps).
+
+## Infrastructure modules
+
+| Module | Kustomization | Provides |
+| --- | --- | --- |
+| [security-core](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/infrastructure/subsystems/security-core/README.md) | `infra-security-core` | cert-manager, external-secrets, trust-manager, Kyverno, Policy Reporter |
+| [storage-core](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/infrastructure/subsystems/storage-core/README.md) | `infra-storage-core` | Longhorn, MinIO, NFS CSI driver |
+| [networking-core](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/infrastructure/subsystems/networking-core/README.md) | `infra-networking-core` | MetalLB, external-dns, Traefik |
+| [kubernetes-core](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/infrastructure/subsystems/kubernetes-core/README.md) | `infra-kubernetes-core` | CoreDNS, Node Feature Discovery, Vertical Pod Autoscaler |
+| [database-core](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/infrastructure/subsystems/database-core/README.md) | `infra-database-core` | CloudNativePG |
+| [observability-core](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/infrastructure/subsystems/observability-core/README.md) | `infra-observability-core` | Prometheus, Loki, Grafana, Goldilocks |
+| [clusterops-core](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/infrastructure/subsystems/clusterops-core/README.md) | `infra-clusterops-core` | Flux CD, system-upgrade-controller, Reloader |
+| [security-extra](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/infrastructure/subsystems/security-extra/README.md) | `infra-security-extra` | Authentik (SSO identity provider) |
+| [networking-extra](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/infrastructure/subsystems/networking-extra/README.md) | `infra-networking-extra` | Pi-hole, Unbound, Tailscale operator, FreeRADIUS (Cloudflared DoH is patched out on this cluster*) |
+| [observability-extra](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/infrastructure/subsystems/observability-extra/README.md) | `infra-observability-extra` | Node Problem Detector, SNMP Exporter, Syslog-ng, UniFi Poller |
+| [kubernetes-extra](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/infrastructure/subsystems/kubernetes-extra/README.md) | `infra-kubernetes-extra` | descheduler |
+
+\* `infra-networking-extra`'s `cloudflared-doh` `Deployment` and `pihole-secrets`
+`ExternalSecret` are patched out on this cluster (see
+`kustomizations/infra-networking-extra.yaml`).
+
+## Applications
+
+| Module | Kustomization | Provides |
+| --- | --- | --- |
+| [ai](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/apps/subsystems/ai/README.md) | `apps-ai` | OpenWebUI (Ollama's own `HelmRelease` is deleted on this cluster — see note below) |
+| [coder](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/apps/subsystems/coder/README.md) | `apps-coder` | Remote development workspaces |
+| [downloaders](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/apps/subsystems/downloaders/README.md) | `apps-downloaders` | autobrr, Sonarr, Radarr, Lidarr, Prowlarr, qBittorrent, qui, SABnzbd, Seerr |
+| [home-automation](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/apps/subsystems/home-automation/README.md) | `apps-home-automation` | Home Assistant |
+| [media](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/apps/subsystems/media/README.md) | `apps-media` | Agregarr, Plex, Jellyfin, FreeTube, Tautulli |
+| [misc](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/apps/subsystems/misc/README.md) | `apps-misc` | Maddy (SMTP relay) |
+
+Note: `apps-ai`'s `ollama-release` `HelmRelease` is deleted via patch on this
+cluster — Ollama runs elsewhere and this cluster's OpenWebUI points at it.
+
+## Cluster-specific services
+
+Resources under `services/` that aren't modules — see
+[DESIGN.md#the-services-directory](../../DESIGN.md#the-services-directory)
+for the general pattern.
+
+| Path | Kind | Purpose |
+| --- | --- | --- |
+| `services/downloaders/downloaders-gluetun-config.yaml` | `ConfigMap` (`gluetun-config`) | VPN provider/server selection and port-forwarding hooks, read by name by the `gluetun` sidecar inside `apps-downloaders` |
+| `services/downloaders/downloaders-gluetun-secrets.yaml` | `ExternalSecret` (`gluetun-secrets`) | WireGuard private key for the same `gluetun` sidecar |
+| `services/tailscale/connector.yaml` | Tailscale `Connector` | Subnet router (`192.168.8.0/24`) + exit node, a custom resource for the CRD the `networking-extra` module's Tailscale operator installs — not something that module ships an instance of itself |
+| `services/tailscale/proxyclass.yaml` | Tailscale `ProxyClass` | Grants the Tailscale proxy pod `NET_ADMIN` + TUN device access needed for the connector above |
+
+## Module dependency graph
+
+```mermaid
+flowchart TB
+    classDef core fill:#dcfce7,stroke:#059669,color:#064e3b
+    classDef extra fill:#fca5a5,stroke:#dc2626,color:#7f1d1d
+    classDef apps fill:#93c5fd,stroke:#2563eb,color:#1e3a8a
+
+    subgraph Core["Infrastructure (Core)"]
+        direction LR
+        sec[security-core]:::core
+        store[storage-core]:::core
+        k8s[kubernetes-core]:::core
+        net[networking-core]:::core
+        db[database-core]:::core
+        obs[observability-core]:::core
+        ops[clusterops-core]:::core
+    end
+
+    subgraph Extra["Infrastructure (Extra)"]
+        direction LR
+        sec-x[security-extra]:::extra
+        net-x[networking-extra]:::extra
+        k8s-x[kubernetes-extra]:::extra
+        obs-x[observability-extra]:::extra
+    end
+
+    subgraph Apps["Applications"]
+        direction LR
+        ai:::apps
+        coder:::apps
+        downloaders:::apps
+        home-auto[home-automation]:::apps
+        media:::apps
+        misc:::apps
+    end
+
+    store --> sec
+    k8s --> sec
+    net --> sec & store & k8s
+    db --> net & store
+    obs --> sec & net & store
+
+    sec-x --> sec & store & db
+    net-x --> sec & store & net
+    k8s-x --> k8s & net & store
+    obs-x --> obs
+
+    Core --> Extra --> Apps
+```
+
+`ops` (clusterops-core) has no module dependencies — it bootstraps Flux itself.
+Exact per-module `dependsOn` lists are in each `kustomizations/*.yaml`.

--- a/clusters/homelab/README.md
+++ b/clusters/homelab/README.md
@@ -53,7 +53,7 @@ for the general pattern.
 | --- | --- | --- |
 | `services/downloaders/downloaders-gluetun-config.yaml` | `ConfigMap` (`gluetun-config`) | VPN provider/server selection and port-forwarding hooks, read by name by the `gluetun` sidecar inside `apps-downloaders` |
 | `services/downloaders/downloaders-gluetun-secrets.yaml` | `ExternalSecret` (`gluetun-secrets`) | WireGuard private key for the same `gluetun` sidecar |
-| `services/tailscale/connector.yaml` | Tailscale `Connector` | Subnet router (`192.168.8.0/24`) + exit node, a custom resource for the CRD the `networking-extra` module's Tailscale operator installs — not something that module ships an instance of itself |
+| `services/tailscale/connector.yaml` | Tailscale `Connector` | Subnet router for the homelab LAN + exit node, a custom resource for the CRD the `networking-extra` module's Tailscale operator installs — not something that module ships an instance of itself |
 | `services/tailscale/proxyclass.yaml` | Tailscale `ProxyClass` | Grants the Tailscale proxy pod `NET_ADMIN` + TUN device access needed for the connector above |
 
 ## Module dependency graph

--- a/clusters/nas/README.md
+++ b/clusters/nas/README.md
@@ -56,7 +56,6 @@ flowchart TB
     classDef outpost fill:#fde68a,stroke:#d97706,color:#92400e
 
     subgraph Core["Infrastructure (Core)"]
-        direction LR
         sec[security-core]:::core
         nfs[storage: csi-driver-nfs]:::core
         minio[storage: minio]:::core
@@ -67,7 +66,6 @@ flowchart TB
     end
 
     subgraph Apps["Applications"]
-        direction LR
         bw[bitwarden]:::apps
         harbor:::apps
     end

--- a/clusters/nas/README.md
+++ b/clusters/nas/README.md
@@ -1,0 +1,86 @@
+# nas cluster
+
+Secondary cluster co-located with the NAS, backed by NFS storage. Runs
+Bitwarden, the Harbor container registry, and an Authentik SSO outpost for
+cross-cluster authentication. Runs the **Baseline** Pod Security Standard (see
+[policies/README.md](../../policies/README.md)).
+
+For how modules get wired in (sources/kustomizations/dependsOn/patches), see
+[DESIGN.md](../../DESIGN.md). For what each module itself provides, follow the
+links below into the [apps repo](https://github.com/ppat/homelab-ops-kubernetes-apps).
+
+## Infrastructure modules
+
+| Module | Kustomization(s) | Provides |
+| --- | --- | --- |
+| [security-core](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/infrastructure/subsystems/security-core/README.md) | `infra-security-core` | cert-manager, external-secrets, trust-manager, Kyverno, Policy Reporter |
+| [storage-core](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/infrastructure/subsystems/storage-core/README.md) | `infra-storage-csi-driver-nfs`, `infra-storage-minio` | NFS CSI driver, MinIO — deployed as two separate `Kustomization`s pointing at submodule paths (`storage-core/csi-driver-nfs`, `storage-core/minio`) instead of one, since this cluster has no Longhorn |
+| [networking-core](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/infrastructure/subsystems/networking-core/README.md) | `infra-networking-core` | MetalLB, external-dns, Traefik (patched to run as a 2-replica `Deployment` instead of a `DaemonSet` for redundancy) |
+| [kubernetes-core](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/infrastructure/subsystems/kubernetes-core/README.md) | `infra-kubernetes-core` | CoreDNS, Node Feature Discovery, Vertical Pod Autoscaler |
+| [database-core](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/infrastructure/subsystems/database-core/README.md) | `infra-database-core` | CloudNativePG |
+| [clusterops-core](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/infrastructure/subsystems/clusterops-core/README.md) | `infra-clusterops-core` | Flux CD, system-upgrade-controller, Reloader |
+
+This cluster runs no `*-extra` infrastructure modules and no `observability-core`.
+
+## Applications
+
+| Module | Kustomization | Provides |
+| --- | --- | --- |
+| [bitwarden](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/apps/subsystems/bitwarden/README.md) | `apps-bitwarden` | Self-hosted password vault |
+| [harbor](https://github.com/ppat/homelab-ops-kubernetes-apps/blob/main/apps/subsystems/harbor/README.md) | `apps-harbor` | Container image registry with vulnerability scanning |
+
+## Cluster-specific resources
+
+Unlike `homelab`, this cluster has no `services/` directory. Instead it has a
+dedicated `outpost/` directory — content authored directly in this repo rather
+than pulled from the apps repo (its `Kustomization`, `infra-security-outpost`,
+sources from `root`, not a module `GitRepository`):
+
+| Path | Kind | Purpose |
+| --- | --- | --- |
+| `outpost/helm-release-authentik-outpost.yaml` | `HelmRelease` (`authentik-remote-cluster` chart) | Deploys a remote Authentik outpost so this cluster's Ingress can authenticate against the Authentik instance running on `homelab`, without running Authentik itself here |
+| `outpost/middleware-forward-auth.yaml` | Traefik `Middleware` (`forward-auth`) | Routes Ingress auth checks to the outpost's `forwardAuth` endpoint |
+| `outpost/ingress-authentik-outpost.yaml` | `Ingress` | Exposes the outpost's own auth endpoint |
+| `outpost/namespace.yaml` | `Namespace` | `authentik` namespace (this cluster only runs the outpost, not the full Authentik stack) |
+
+This exists because SSO (`components/sso`) is used across both clusters, but
+Authentik itself (`security-extra`) only runs on `homelab` — the outpost lets
+`nas`'s apps (Harbor, Bitwarden) participate in the same SSO domain.
+
+## Module dependency graph
+
+```mermaid
+flowchart TB
+    classDef core fill:#dcfce7,stroke:#059669,color:#064e3b
+    classDef apps fill:#93c5fd,stroke:#2563eb,color:#1e3a8a
+    classDef outpost fill:#fde68a,stroke:#d97706,color:#92400e
+
+    subgraph Core["Infrastructure (Core)"]
+        direction LR
+        sec[security-core]:::core
+        nfs[storage: csi-driver-nfs]:::core
+        minio[storage: minio]:::core
+        k8s[kubernetes-core]:::core
+        net[networking-core]:::core
+        db[database-core]:::core
+        ops[clusterops-core]:::core
+    end
+
+    subgraph Apps["Applications"]
+        direction LR
+        bw[bitwarden]:::apps
+        harbor:::apps
+    end
+
+    out[Authentik outpost]:::outpost
+
+    net --> sec & nfs
+    minio --> nfs
+    db --> net & nfs
+    out --> sec & net
+
+    Core --> Apps
+```
+
+`ops` (clusterops-core) has no module dependencies — it bootstraps Flux itself.
+Exact per-module `dependsOn` lists are in each `kustomizations/*.yaml`.

--- a/policies/README.md
+++ b/policies/README.md
@@ -1,0 +1,86 @@
+# Policies
+
+Cluster-wide [Kyverno](https://kyverno.io/) `ClusterPolicy`/`ClusterCleanupPolicy`
+objects, applied identically across both clusters (unlike everything under
+`clusters/`, these aren't per-cluster — they live at the repo root because
+they're cluster-agnostic). Each policy group here is deployed via its own
+`policy-*` Flux `Kustomization` per cluster; see
+[DESIGN.md#policy-enforcement](../DESIGN.md#policy-enforcement) for how that
+wiring works.
+
+## Groups
+
+| Group | Path | Applied to |
+| --- | --- | --- |
+| Pod Security Standards — Baseline | [`pod-security-standard/baseline`](./pod-security-standard/baseline) | `nas` only |
+| Pod Security Standards — Restricted | [`pod-security-standard/restricted`](./pod-security-standard/restricted) | `homelab` only (includes baseline via `resources: [../baseline]`) |
+| Best Practices | [`best-practices`](./best-practices) | Both clusters |
+
+`homelab` runs the stricter Restricted profile; `nas` runs Baseline. All
+policies across both groups currently run in `validationFailureAction: Audit`
+mode (patched at the point of use in each cluster's `policy-*.yaml`
+`Kustomization`) — they report violations via Policy Reporter rather than
+blocking admission.
+
+```mermaid
+flowchart LR
+    baseline["Pod Security Standards\nBaseline"]
+    restricted["Pod Security Standards\nRestricted\n(extends Baseline)"]
+    bp["Best Practices"]
+
+    baseline --> nas["nas cluster"]
+    restricted --> homelab["homelab cluster"]
+    bp --> nas
+    bp --> homelab
+
+    classDef pol fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
+    classDef cl fill:#dcfce7,stroke:#059669,color:#064e3b
+    class baseline,restricted,bp pol
+    class nas,homelab cl
+```
+
+## Pod Security Standards
+
+Ports the upstream [Kubernetes Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+to Kyverno `ClusterPolicy` validation rules.
+
+| Policy | What it disallows/requires |
+| --- | --- |
+| `disallow-capabilities` | Capabilities beyond a default-safe set |
+| `disallow-host-namespaces` | Host PID/IPC/network namespaces |
+| `disallow-host-path` | `hostPath` volumes |
+| `disallow-host-ports` | `hostPort` |
+| `disallow-host-process` | Windows HostProcess containers |
+| `disallow-privileged-containers` | `privileged: true` |
+| `disallow-proc-mount` | Non-default `procMount` |
+| `disallow-selinux` | Custom `seLinuxOptions` |
+| `restrict-apparmor-profiles` | Non-default AppArmor profiles |
+| `restrict-seccomp` | `seccompProfile: Unconfined` |
+| `restrict-sysctls` | Unsafe sysctls |
+
+Restricted adds on top of all of the above:
+
+| Policy | What it disallows/requires |
+| --- | --- |
+| `disallow-capabilities-strict` | Any capability except `NET_BIND_SERVICE` |
+| `disallow-privilege-escalation` | `allowPrivilegeEscalation: true` |
+| `require-run-as-non-root-user` | `runAsUser` unset or 0 |
+| `require-run-as-nonroot` | `runAsNonRoot` unset/false |
+| `restrict-seccomp-strict` | Missing seccomp profile (not just `Unconfined`) |
+| `restrict-volume-types` | Volume types beyond a safe allow-list |
+
+## Best Practices
+
+Applied to both clusters. Mixes validation, mutation, and scheduled cleanup:
+
+| Policy | Type | What it does |
+| --- | --- | --- |
+| `add-default-resources` | Mutate | Adds default CPU/memory requests to containers missing them (excludes `kube-system`, `longhorn-system`) |
+| `add-emptydir-sizelimit` | Mutate | Adds a `sizeLimit` to `emptyDir` volumes missing one (excludes `kube-system`, `longhorn-system`) |
+| `add-ndots` | Mutate | Sets DNS `ndots: 1` on Pods outside `dns`/`kube-system`/`longhorn-system` |
+| `disallow-cri-sock-mount` | Validate | Blocks mounting the container runtime socket |
+| `disallow-latest-tag` | Validate | Requires an explicit, non-`latest` image tag |
+| `require-probes` | Validate | Requires a liveness/readiness/startup probe (excludes `csi-driver-nfs`, `kube-system`) |
+| `restrict-node-port` | Validate | Blocks `Service` type `NodePort` |
+| `cleanup-bare-pods` | Cleanup | Deletes unowned (controller-less) Pods daily at 05:00 UTC |
+| `cleanup-empty-replicasets` | Cleanup | Deletes empty `ReplicaSet`s (excludes `kube-system`) |

--- a/policies/README.md
+++ b/policies/README.md
@@ -75,12 +75,18 @@ Applied to both clusters. Mixes validation, mutation, and scheduled cleanup:
 
 | Policy | Type | What it does |
 | --- | --- | --- |
-| `add-default-resources` | Mutate | Adds default CPU/memory requests to containers missing them (excludes `kube-system`, `longhorn-system`) |
-| `add-emptydir-sizelimit` | Mutate | Adds a `sizeLimit` to `emptyDir` volumes missing one (excludes `kube-system`, `longhorn-system`) |
-| `add-ndots` | Mutate | Sets DNS `ndots: 1` on Pods outside `dns`/`kube-system`/`longhorn-system` |
+| `add-default-resources` | Mutate | Adds default CPU/memory requests to containers missing them |
+| `add-emptydir-sizelimit` | Mutate | Adds a `sizeLimit` to `emptyDir` volumes missing one |
+| `add-ndots` | Mutate | Sets DNS `ndots: 1` on Pods, avoiding an extra DNS lookup per query |
 | `disallow-cri-sock-mount` | Validate | Blocks mounting the container runtime socket |
 | `disallow-latest-tag` | Validate | Requires an explicit, non-`latest` image tag |
-| `require-probes` | Validate | Requires a liveness/readiness/startup probe (excludes `csi-driver-nfs`, `kube-system`) |
+| `require-probes` | Validate | Requires a liveness, readiness, or startup probe on every container |
 | `restrict-node-port` | Validate | Blocks `Service` type `NodePort` |
-| `cleanup-bare-pods` | Cleanup | Deletes unowned (controller-less) Pods daily at 05:00 UTC |
-| `cleanup-empty-replicasets` | Cleanup | Deletes empty `ReplicaSet`s (excludes `kube-system`) |
+| `cleanup-bare-pods` | Cleanup | Deletes unowned (controller-less) Pods on a daily schedule |
+| `cleanup-empty-replicasets` | Cleanup | Deletes empty `ReplicaSet`s on a recurring schedule |
+
+Each policy excludes the system namespaces and workloads that legitimately need
+the behavior it otherwise disallows (e.g. `require-probes` doesn't apply to a
+handful of infra DaemonSets that have none) — the exact exclusion list is a
+policy-tuning detail that lives in, and should be read from, each policy's own
+`exclude` block rather than restated here.


### PR DESCRIPTION
Adds a repo-root README/DESIGN split, per-cluster catalogs, and a
policies overview so both humans and AI agents can navigate this repo
without inspecting every manifest by hand. CLAUDE.md stays a thin
pointer into these docs rather than duplicating them.

Also adds five Claude Code skills that encode this session's
documentation values (no versions/counts that Renovate churns, match
altitude to each doc's scope, update in place rather than append,
cross-link instead of duplicating) so future changes to clusters/**,
policies/**, or the repo's architecture get the matching doc updated
consistently:

- update-repo-docs: routes a change to the right doc-owning skill(s)
- update-cluster-docs: clusters/homelab|nas/README.md catalogs
- update-policy-docs: policies/README.md
- update-design-docs: DESIGN.md, CLAUDE.md, root README.md
- audit-repo-docs: read-only drift check across all six docs
- verify-mermaid-diagrams: render-and-check rules for any Mermaid
  diagram these docs carry