### PR TITLE
fix(cluster-homelab): allow in-cluster host for mcp-playwright (patch apps-ai)

### DIFF
--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -64,3 +64,20 @@ spec:
     target:
       group: postgresql.cnpg.io
       kind: Cluster
+  # mcp-playwright (v0.0.78) enforces a Host-header allowlist (DNS-rebinding
+  # protection) that defaults to localhost, so LiteLLM's in-cluster requests to
+  # http://mcp-playwright.ai.svc.cluster.local:8931/mcp get 403. Add --allowed-hosts
+  # for the service FQDN LiteLLM connects to. Interim cluster-side patch; remove once
+  # the apps-ai module sets --allowed-hosts itself and is re-pinned.
+  # yamllint disable-line rule:indentation
+  - patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --allowed-hosts
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: mcp-playwright.ai.svc.cluster.local:8931
+    target:
+      kind: Deployment
+      name: mcp-playwright
+      namespace: ai


### PR DESCRIPTION
## Summary

The mcp-playwright Deployment (apps-ai module, `mcr.microsoft.com/playwright/mcp:v0.0.78`) enforces a Host-header allowlist as DNS-rebinding protection, defaulting to `localhost:8931`. LiteLLM's in-cluster requests arrive with `Host: mcp-playwright.ai.svc.cluster.local:8931`, which the server rejects with a 403, breaking the litellm-to-mcp-playwright gateway path wired up in #730.

The playwright-mcp CLI supports an `--allowed-hosts` flag for exactly this case. Since apps-ai is pinned at v0.6.2 and the module doesn't set this flag itself, this adds it as an interim cluster-side fix: a new JSON6902 patch entry in `clusters/homelab/kustomizations/apps-ai.yaml` appends `--allowed-hosts mcp-playwright.ai.svc.cluster.local:8931` to the mcp-playwright container's args, alongside the existing ollama-release delete and CNPG anti-affinity patches.

This should be superseded once the apps-ai module sets `--allowed-hosts` itself and this repo re-pins to that release; the patch comment notes this so it's easy to remove later.

## Test plan

- [x] `pre-commit run --all-files` passes (yamllint, kubeconform, etc.)
- [x] Rendered the patched Kustomization with `flux-local` against a prepared checkout of `apps-ai-v0.6.2` — the mcp-playwright container's args end with `--allowed-hosts` / `mcp-playwright.ai.svc.cluster.local:8931`, with the original args (`--headless --browser chromium --no-sandbox --port 8931 --host 0.0.0.0`) unchanged ahead of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)