### PR TITLE
fix(cluster-homelab): disable litellm prompt-injection filter (patch apps-ai)

### DIFF
--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -81,3 +81,15 @@ spec:
       kind: Deployment
       name: mcp-playwright
       namespace: ai
+  # LiteLLM ships detect_prompt_injection in litellm_settings.callbacks inline in
+  # the apps-ai HelmRelease values; it's a replaced (not merged) list and inline
+  # values outrank our litellm-model-config ConfigMap, so it must be patched here.
+  # yamllint disable-line rule:indentation
+  - patch: |
+      - op: replace
+        path: /spec/values/proxy_config/litellm_settings/callbacks
+        value: ["prometheus"]
+    target:
+      kind: HelmRelease
+      name: litellm-release
+      namespace: ai


### PR DESCRIPTION
## Summary

The apps-ai v0.6.2 litellm HelmRelease enables legacy prompt-injection
detection inline via
`spec.values.proxy_config.litellm_settings.callbacks: ["prometheus", "detect_prompt_injection"]`,
and it's rejecting normal user requests.

This can't be overridden through the `litellm-model-config` ConfigMap: inline
HelmRelease values outrank `valuesFrom` ConfigMaps in helm-controller merge,
and Helm replaces lists rather than merging them. So this PR adds a JSON6902
patch on the in-cluster HelmRelease (`litellm-release`, namespace `ai`) in
`clusters/homelab/kustomizations/apps-ai.yaml`, keeping only the `prometheus`
callback.

## Test plan

- [x] `pre-commit run --all-files` passes (yamllint, kubeconform via
      `validate-kubernetes-manifests`, markdownlint, shellcheck, etc.)
- [ ] Flux reconciles the patched HelmRelease and prompt-injection detection
      is disabled without affecting metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)