### PR TITLE
chore(cluster-homelab): update apps-ai (v0.6.2 -> v0.6.3), drop upstreamed patches, set litellm db replicas to 2

### DIFF
--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -35,7 +35,7 @@ spec:
       db_bootstrap_owner: litellm
       db_name: litellm-db
       db_namespace: ai
-      db_replicas: "3"
+      db_replicas: "2"
       db_storage_class: sc-longhorn-local-non-replicated
       db_storage_size: 10Gi
       db_suffix_current: "v20260722"
@@ -64,32 +64,3 @@ spec:
     target:
       group: postgresql.cnpg.io
       kind: Cluster
-  # mcp-playwright (v0.0.78) enforces a Host-header allowlist (DNS-rebinding
-  # protection) that defaults to localhost, so LiteLLM's in-cluster requests to
-  # http://mcp-playwright.ai.svc.cluster.local:8931/mcp get 403. Add --allowed-hosts
-  # for the service FQDN LiteLLM connects to. Interim cluster-side patch; remove once
-  # the apps-ai module sets --allowed-hosts itself and is re-pinned.
-  # yamllint disable-line rule:indentation
-  - patch: |
-      - op: add
-        path: /spec/template/spec/containers/0/args/-
-        value: --allowed-hosts
-      - op: add
-        path: /spec/template/spec/containers/0/args/-
-        value: mcp-playwright.ai.svc.cluster.local:8931
-    target:
-      kind: Deployment
-      name: mcp-playwright
-      namespace: ai
-  # LiteLLM ships detect_prompt_injection in litellm_settings.callbacks inline in
-  # the apps-ai HelmRelease values; it's a replaced (not merged) list and inline
-  # values outrank our litellm-model-config ConfigMap, so it must be patched here.
-  # yamllint disable-line rule:indentation
-  - patch: |
-      - op: replace
-        path: /spec/values/proxy_config/litellm_settings/callbacks
-        value: ["prometheus"]
-    target:
-      kind: HelmRelease
-      name: litellm-release
-      namespace: ai

--- a/clusters/homelab/sources/apps-ai.yaml
+++ b/clusters/homelab/sources/apps-ai.yaml
@@ -14,5 +14,5 @@ spec:
     !/apps/subsystems/ai
   interval: 1m0s
   ref:
-    tag: apps-ai-v0.6.2
+    tag: apps-ai-v0.6.3
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git


### PR DESCRIPTION
## Why

- **Pin bump.** Bumps the homelab `apps-ai` GitRepository ref from `apps-ai-v0.6.2` to the just-released `apps-ai-v0.6.3`.
- **Drop two redundant ks-patches.** `apps-ai-v0.6.3` upstreams two fixes that this cluster was previously applying as local Kustomization patches:
  - the mcp-playwright `--allowed-hosts` arg (patch targeting `Deployment/mcp-playwright` in ns `ai`)
  - the litellm `litellm_settings.callbacks` override to `["prometheus"]` (patch targeting `HelmRelease/litellm-release` in ns `ai`)

  Both patches are now redundant: keeping the mcp-playwright patch would **double-append** `--allowed-hosts` to the container args, and the litellm patch would be a no-op since the module now ships the same value inline. Removing them leaves the *rendered* playwright args and litellm callbacks **unchanged** — only where they come from changes (module-provided vs. cluster-patched).
- **Scale litellm CNPG Postgres down.** `db_replicas` in `postBuild.substitute` goes from `"3"` to `"2"`.

## What the flux-diff should show

Reviewers: the rendered flux-diff for this PR should show **only**:
1. The `apps-ai` source tag: `apps-ai-v0.6.2 -> apps-ai-v0.6.3`
2. The CNPG `Cluster` `instances: 3 -> 2`

The mcp-playwright `Deployment` args and the litellm `HelmRelease` `callbacks` value should appear **unchanged** in the diff — the module now provides them natively, replacing what the removed patches used to add.

## Test plan

- [x] `pre-commit run --all-files` — all hooks pass (yamllint --strict, kubeconform via `Validate Kubernetes manifests`, commitlint, etc.)
- [ ] Reviewer: confirm flux-diff matches the expectations above

🤖 Generated with [Claude Code](https://claude.com/claude-code)