### PR TITLE
fix(cluster-homelab): patch unifi MCP servers' allowed-hosts to include port

### DIFF
--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -57,3 +57,41 @@ spec:
     target:
       group: postgresql.cnpg.io
       kind: Cluster
+  # Workaround: UNIFI_MCP_ALLOWED_HOSTS is missing the service port upstream,
+  # so the MCP Python SDK's transport-security host check rejects every
+  # request from LiteLLM with a 421 "Invalid Host header". Remove once fixed
+  # upstream in homelab-ops-kubernetes-apps.
+  # yamllint disable-line rule:indentation
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: irrelevant
+      spec:
+        template:
+          spec:
+            containers:
+            - name: mcp-unifi-network
+              env:
+              - name: UNIFI_MCP_ALLOWED_HOSTS
+                value: mcp-unifi-network.ai.svc.cluster.local:3000,localhost,127.0.0.1
+    target:
+      kind: Deployment
+      name: mcp-unifi-network
+  # yamllint disable-line rule:indentation
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: irrelevant
+      spec:
+        template:
+          spec:
+            containers:
+            - name: mcp-unifi-protect
+              env:
+              - name: UNIFI_MCP_ALLOWED_HOSTS
+                value: mcp-unifi-protect.ai.svc.cluster.local:3001,localhost,127.0.0.1
+    target:
+      kind: Deployment
+      name: mcp-unifi-protect


### PR DESCRIPTION
## Summary

- `mcp-unifi-network` and `mcp-unifi-protect` (apps-ai module, namespace `ai`) reject every request from LiteLLM with HTTP `421 Misdirected Request` / `Invalid Host header: mcp-unifi-protect.ai.svc.cluster.local:3001` (or `:3000` for network) -- pods are otherwise healthy.
- Root cause: both Deployments hardcode `UNIFI_MCP_ALLOWED_HOSTS` without the service port, but the MCP Python SDK's transport-security host check (`mcp/server/transport_security.py`, `_validate_host()`) does exact `host:port` string matching, so a bare hostname never matches an incoming `Host` header that includes the port.
- This is upstream `apps/subsystems/ai/mcp-unifi-{network,protect}/deployment.yaml` code in `ppat/homelab-ops-kubernetes-apps`. Fixing it there is deferred (tracked in ppat/homelab-ops-kubernetes-apps#3381) since there's unrelated in-progress work on that repo right now.
- This PR is a clusters-repo-only Kustomize patch workaround: appends the two Deployments' `UNIFI_MCP_ALLOWED_HOSTS` env var to include the correct port (3000/3001), using the same strategic-merge patch pattern already used elsewhere in `clusters/homelab/kustomizations/apps-ai.yaml`. It should be removed once the upstream fix lands and this cluster picks up a new apps-ai release that includes it.

## Test plan

- [x] `kustomize build` against the apps-ai module (mcp-unifi-network + mcp-unifi-protect) at the pinned `apps-ai-v0.6.5` tag with these two patches applied, confirmed via local render: `UNIFI_MCP_ALLOWED_HOSTS` now reads `mcp-unifi-network.ai.svc.cluster.local:3000,localhost,127.0.0.1` and `mcp-unifi-protect.ai.svc.cluster.local:3001,localhost,127.0.0.1` respectively, with all other env vars intact and none duplicated/dropped.
- [x] `pre-commit run --all-files` passes (yamllint, kubeconform via `validate-kubernetes-manifests`, etc.).
- [ ] Confirm in-cluster after merge: `mcp-unifi-network`/`mcp-unifi-protect` pods restart with the patched env var and LiteLLM requests to them stop returning 421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)