### PR TITLE
feat(cluster-homelab): roll out n8n + OpenClaw (apps-ai) — wiring, seed workflows, alertmanager receiver

### DIFF
--- a/clusters/homelab/README.md
+++ b/clusters/homelab/README.md
@@ -48,7 +48,7 @@ for the general pattern.
 
 | Directory | Purpose |
 | --- | --- |
-| `services/ai/` | Supplies an optional model catalog and routing config for the LiteLLM gateway — featured model aliases with cost tracking plus a provider wildcard catch-all and router fallbacks — picked up by name by `apps-ai`'s LiteLLM `HelmRelease` |
+| `services/ai/` | Supplies an optional model catalog and routing config for the LiteLLM gateway — featured model aliases with cost tracking plus a provider wildcard catch-all and router fallbacks — picked up by name by `apps-ai`'s LiteLLM `HelmRelease`. Also holds example n8n workflow exports (`services/ai/n8n/workflows/`), staged here for manual import at rollout since n8n↔OpenClaw wiring is cluster-specific |
 | `services/dns/` | Tunes Pi-hole's DNS/DNSSEC/reverse-DNS behavior, picked up by name by `networking-extra`'s Pi-hole |
 | `services/downloaders/` | Supplies VPN provider/server selection, port-forwarding hooks, and the WireGuard key for qBittorrent's `gluetun` VPN sidecar inside `apps-downloaders`, picked up by name |
 | `services/logging/` | Tunes Loki's log retention and adds Promtail scrape jobs for apps that write logs to a PVC instead of stdout (Pi-hole, Plex, Traefik) — picked up by name by `observability-core`'s Loki/Promtail |

--- a/clusters/homelab/cluster/secrets/cluster-secrets.yaml
+++ b/clusters/homelab/cluster/secrets/cluster-secrets.yaml
@@ -45,6 +45,9 @@ spec:
   - secretKey: n8n_owner_email
     remoteRef:
       key: cluster_homelab_n8n_owner_email
+  - secretKey: n8n_smtp_sender
+    remoteRef:
+      key: cluster_homelab_n8n_smtp_sender
   refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secret-manager-store

--- a/clusters/homelab/cluster/secrets/cluster-secrets.yaml
+++ b/clusters/homelab/cluster/secrets/cluster-secrets.yaml
@@ -42,12 +42,6 @@ spec:
   - secretKey: freeradius_external_ip_address
     remoteRef:
       key: cluster_homelab_freeradius_ip
-  - secretKey: n8n_owner_email
-    remoteRef:
-      key: cluster_homelab_n8n_owner_email
-  - secretKey: n8n_smtp_sender
-    remoteRef:
-      key: cluster_homelab_n8n_smtp_sender
   refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secret-manager-store

--- a/clusters/homelab/cluster/secrets/cluster-secrets.yaml
+++ b/clusters/homelab/cluster/secrets/cluster-secrets.yaml
@@ -42,6 +42,9 @@ spec:
   - secretKey: freeradius_external_ip_address
     remoteRef:
       key: cluster_homelab_freeradius_ip
+  - secretKey: n8n_owner_email
+    remoteRef:
+      key: cluster_homelab_n8n_owner_email
   refreshInterval: 24h
   secretStoreRef:
     name: bitwarden-secret-manager-store

--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -82,6 +82,59 @@ spec:
       group: postgresql.cnpg.io
       kind: Cluster
       namespace: n8n
+  # n8n's owner login email and SMTP sender are pulled from the n8n-secrets
+  # ExternalSecret (BWS keys n8n_owner_email / n8n_smtp_sender) instead of the module's
+  # hardcoded/postBuild-literal defaults -- add the two keys here rather than in the
+  # module so they stay scoped to this cluster's n8n instance.
+  # yamllint disable-line rule:indentation
+  - patch: |
+      - op: add
+        path: /spec/data/-
+        value:
+          secretKey: N8N_INSTANCE_OWNER_EMAIL
+          remoteRef:
+            key: n8n_owner_email
+      - op: add
+        path: /spec/data/-
+        value:
+          secretKey: N8N_SMTP_SENDER
+          remoteRef:
+            key: n8n_smtp_sender
+    target:
+      group: external-secrets.io
+      version: v1
+      kind: ExternalSecret
+      name: n8n-secrets
+  # Companion to the n8n-secrets patch above: point the n8n Deployment's owner-email and
+  # SMTP-sender envs at the two new secretKeyRefs instead of the module's literal defaults.
+  # yamllint disable-line rule:indentation
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: irrelevant
+      spec:
+        template:
+          spec:
+            containers:
+            - name: n8n
+              env:
+              - name: N8N_INSTANCE_OWNER_EMAIL
+                value: null
+                valueFrom:
+                  secretKeyRef:
+                    name: n8n-secrets
+                    key: N8N_INSTANCE_OWNER_EMAIL
+              - name: N8N_SMTP_SENDER
+                value: null
+                valueFrom:
+                  secretKeyRef:
+                    name: n8n-secrets
+                    key: N8N_SMTP_SENDER
+    target:
+      kind: Deployment
+      namespace: n8n
+      name: n8n
   # Workaround: UNIFI_MCP_ALLOWED_HOSTS is missing the service port upstream,
   # so the MCP Python SDK's transport-security host check rejects every
   # request from LiteLLM with a 421 "Invalid Host header". Remove once fixed

--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -120,24 +120,3 @@ spec:
     target:
       kind: Deployment
       name: mcp-unifi-protect
-  # The upstream SMTP provider behind the Maddy relay rejects any From address
-  # that isn't the account's real sender, so n8n's hardcoded `n8n@${domain_name}`
-  # (apps#3383) can't be used as-is. Override it with the account's real sender,
-  # sourced from BWS via cluster-secrets rather than hardcoded here.
-  # yamllint disable-line rule:indentation
-  - patch: |-
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: irrelevant
-      spec:
-        template:
-          spec:
-            containers:
-            - name: n8n
-              env:
-              - name: N8N_SMTP_SENDER
-                value: ${n8n_smtp_sender}
-    target:
-      kind: Deployment
-      name: n8n

--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -44,7 +44,6 @@ spec:
       n8n_db_storage_size: 10Gi
       n8n_db_storage_class: sc-longhorn-local-non-replicated
       n8n_db_suffix_current: "v20260725"
-      n8n_owner_email: anthropic@wellcapitalized.net
       secret_store: bitwarden-secret-manager-store
       # see: https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-substitution-of-numbers-and-booleans
       quote: '"'

--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -120,3 +120,24 @@ spec:
     target:
       kind: Deployment
       name: mcp-unifi-protect
+  # The upstream SMTP provider behind the Maddy relay rejects any From address
+  # that isn't the account's real sender, so n8n's hardcoded `n8n@${domain_name}`
+  # (apps#3383) can't be used as-is. Override it with the account's real sender,
+  # sourced from BWS via cluster-secrets rather than hardcoded here.
+  # yamllint disable-line rule:indentation
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: irrelevant
+      spec:
+        template:
+          spec:
+            containers:
+            - name: n8n
+              env:
+              - name: N8N_SMTP_SENDER
+                value: ${n8n_smtp_sender}
+    target:
+      kind: Deployment
+      name: n8n

--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -41,6 +41,10 @@ spec:
       db_storage_size: 10Gi
       db_suffix_current: "v20260723"
       db_suffix_restore: "v20260722"
+      n8n_db_storage_size: 10Gi
+      n8n_db_storage_class: sc-longhorn-local-non-replicated
+      n8n_db_suffix_current: "v20260725"
+      n8n_owner_email: anthropic@wellcapitalized.net
       secret_store: bitwarden-secret-manager-store
       # see: https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-substitution-of-numbers-and-booleans
       quote: '"'
@@ -57,6 +61,28 @@ spec:
     target:
       group: postgresql.cnpg.io
       kind: Cluster
+  # components/db-backups and components/db-restore both patch `kind: Cluster` with no name
+  # filter, so they also inject litellm's barman plugin config and recovery bootstrap into
+  # n8n's Cluster (namespace n8n). n8n's DB has no backup store of its own yet (unbacked by
+  # design for now -- see clusters#740), so undo that injection here and restore n8n's Cluster
+  # to a plain initdb bootstrap. Drop this patch once n8n gets its own db-backups wiring.
+  # yamllint disable-line rule:indentation
+  - patch: |
+      - op: remove
+        path: /spec/plugins
+      - op: remove
+        path: /spec/externalClusters
+      - op: remove
+        path: /spec/bootstrap/recovery
+      - op: add
+        path: /spec/bootstrap/initdb
+        value:
+          database: ${n8n_db_bootstrap_database:=n8n}
+          owner: ${n8n_db_bootstrap_owner:=n8n}
+    target:
+      group: postgresql.cnpg.io
+      kind: Cluster
+      namespace: n8n
   # Workaround: UNIFI_MCP_ALLOWED_HOSTS is missing the service port upstream,
   # so the MCP Python SDK's transport-security host check rejects every
   # request from LiteLLM with a 421 "Invalid Host header". Remove once fixed

--- a/clusters/homelab/kustomizations/infra-observability-core.yaml
+++ b/clusters/homelab/kustomizations/infra-observability-core.yaml
@@ -90,3 +90,60 @@ spec:
       kind: HelmRelease
       name: kube-prometheus-stack-release
       namespace: monitoring
+  # Route alerts to n8n's Alertmanager-intake webhook (apps-ai's alertmanager-receiver
+  # workflow) instead of the chart's default null receiver -- Alertmanager otherwise has
+  # zero receivers configured. Watchdog stays routed to 'null' so the dead-man's-switch
+  # heartbeat doesn't spam the webhook. Inert until that n8n workflow is manually imported
+  # and activated (clusters#740) -- until then this just posts to a 404.
+  # yamllint disable-line rule:indentation
+  - patch: |
+      - op: add
+        path: /spec/values/alertmanager/config
+        value:
+          global:
+            resolve_timeout: 5m
+          inhibit_rules:
+          - source_matchers:
+            - 'severity = critical'
+            target_matchers:
+            - 'severity =~ warning|info'
+            equal:
+            - 'namespace'
+            - 'alertname'
+          - source_matchers:
+            - 'severity = warning'
+            target_matchers:
+            - 'severity = info'
+            equal:
+            - 'namespace'
+            - 'alertname'
+          - source_matchers:
+            - 'alertname = InfoInhibitor'
+            target_matchers:
+            - 'severity = info'
+            equal:
+            - 'namespace'
+          - target_matchers:
+            - 'alertname = InfoInhibitor'
+          route:
+            group_by: ['namespace']
+            group_wait: 30s
+            group_interval: 5m
+            repeat_interval: 12h
+            receiver: 'n8n-webhook'
+            routes:
+            - receiver: 'null'
+              matchers:
+              - alertname = "Watchdog"
+          receivers:
+          - name: 'null'
+          - name: 'n8n-webhook'
+            webhook_configs:
+            - url: 'http://n8n.n8n.svc.cluster.local:5678/webhook/alertmanager'
+          templates:
+          - '/etc/alertmanager/config/*.tmpl'
+    target:
+      group: helm.toolkit.fluxcd.io
+      kind: HelmRelease
+      name: kube-prometheus-stack-release
+      namespace: monitoring

--- a/clusters/homelab/services/ai/n8n/workflows/README.md
+++ b/clusters/homelab/services/ai/n8n/workflows/README.md
@@ -24,3 +24,9 @@ an `Execute Workflow` node, which n8n resolves post-import in the UI.
 Both pre-seeded credentials referenced by these workflows (LiteLLM Bearer, Maddy SMTP) come from
 `apps-ai`'s `n8n_credentials_overwrite` secret-store key — no manual credential setup is required,
 only the workflow import above.
+
+**Before importing**, edit `notify-subworkflow.json`'s email node: the `${domain_name}` tokens in
+its `fromEmail`/`toEmail` fields are Flux postBuild placeholders that only get substituted in
+GitOps-applied manifests, not on a manual `n8n import:workflow`. Replace `fromEmail` with the real
+SMTP sender (BWS key `cluster_homelab_n8n_smtp_sender`) and `toEmail` with the real notification
+recipient before importing.

--- a/clusters/homelab/services/ai/n8n/workflows/README.md
+++ b/clusters/homelab/services/ai/n8n/workflows/README.md
@@ -1,0 +1,26 @@
+# n8n Seed Workflows
+
+Example n8n workflow exports for this cluster's day-one integrations. n8n↔OpenClaw wiring is
+cluster-specific behavior, so it lives here rather than in the `apps-ai` module's n8n slice
+(which is OpenClaw-agnostic). These are **not** auto-imported by GitOps — workflows live in
+n8n's Postgres database, not the filesystem, so importing them is a one-time, manual,
+not-GitOps-able bootstrap step (same category as OpenClaw's WhatsApp QR pairing). Re-running the
+import is safe (it upserts by workflow ID) but will overwrite any in-UI edits made to these
+specific workflows.
+
+| File | Purpose |
+| ---- | ------- |
+| `alertmanager-receiver.json` | Alertmanager webhook → dedup on `status: firing` → one-line LiteLLM (`openai/gpt-5-nano`) summary → relay to OpenClaw's `/hooks/agent` → WhatsApp |
+| `notify-subworkflow.json` | Shared "Notify" sub-workflow (`Execute Workflow` target) — fans out a `subject`/`message` pair to Maddy SMTP and OpenClaw |
+| `media-downloaded-notify.json` | Example Radarr/Sonarr "downloaded" webhook (header-auth) → builds a notify payload → calls the shared Notify sub-workflow |
+
+## Importing
+
+The import step itself (copying these into the n8n pod and running `n8n import:workflow`) is
+tracked as part of the cluster rollout, not performed here. `notify-subworkflow.json` must be
+imported before `media-downloaded-notify.json` — the latter references it by workflow name via
+an `Execute Workflow` node, which n8n resolves post-import in the UI.
+
+Both pre-seeded credentials referenced by these workflows (LiteLLM Bearer, Maddy SMTP) come from
+`apps-ai`'s `n8n_credentials_overwrite` secret-store key — no manual credential setup is required,
+only the workflow import above.

--- a/clusters/homelab/services/ai/n8n/workflows/alertmanager-receiver.json
+++ b/clusters/homelab/services/ai/n8n/workflows/alertmanager-receiver.json
@@ -1,0 +1,140 @@
+{
+  "name": "Alertmanager Receiver",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "alertmanager",
+        "responseMode": "onReceived",
+        "options": {}
+      },
+      "id": "5f6a1e10-1a2b-4c3d-9e0f-000000000001",
+      "name": "Webhook - Alertmanager",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "alertmanager-receiver"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "9f2c1e10-0000-4c3d-9e0f-000000000002",
+              "leftValue": "={{ $json.body.status }}",
+              "rightValue": "firing",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "5f6a1e10-1a2b-4c3d-9e0f-000000000002",
+      "name": "IF - Firing",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://litellm.ai.svc.cluster.local:4000/v1/chat/completions",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({\n  \"model\": \"openai/gpt-5-nano\",\n  \"messages\": [\n    { \"role\": \"system\", \"content\": \"Summarize this Prometheus alert in one short sentence for a WhatsApp notification.\" },\n    { \"role\": \"user\", \"content\": JSON.stringify($json.body) }\n  ]\n}) }}",
+        "options": {}
+      },
+      "id": "5f6a1e10-1a2b-4c3d-9e0f-000000000003",
+      "name": "LiteLLM - Summarize",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [680, 220],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "litellm-header-auth",
+          "name": "LiteLLM Bearer"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://openclaw.openclaw.svc.cluster.local:18789/hooks/agent",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({\n  \"source\": \"alertmanager\",\n  \"message\": $json.choices[0].message.content\n}) }}",
+        "options": {}
+      },
+      "id": "5f6a1e10-1a2b-4c3d-9e0f-000000000004",
+      "name": "OpenClaw - Relay to WhatsApp",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 220],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "openclaw-hooks-auth",
+          "name": "OpenClaw Hooks Token"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook - Alertmanager": {
+      "main": [
+        [
+          {
+            "node": "IF - Firing",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "IF - Firing": {
+      "main": [
+        [
+          {
+            "node": "LiteLLM - Summarize",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "LiteLLM - Summarize": {
+      "main": [
+        [
+          {
+            "node": "OpenClaw - Relay to WhatsApp",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateCredsSetupCompleted": false
+  },
+  "tags": [
+    "observability",
+    "alertmanager"
+  ]
+}

--- a/clusters/homelab/services/ai/n8n/workflows/media-downloaded-notify.json
+++ b/clusters/homelab/services/ai/n8n/workflows/media-downloaded-notify.json
@@ -1,0 +1,113 @@
+{
+  "name": "Media Downloaded Notify",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "media-downloaded",
+        "authentication": "headerAuth",
+        "responseMode": "onReceived",
+        "options": {}
+      },
+      "id": "5f6a1e10-1a2b-4c3d-9e0f-000000000201",
+      "name": "Webhook - Radarr/Sonarr",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "media-downloaded",
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "arr-webhook-auth",
+          "name": "Radarr/Sonarr Webhook Auth"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "5f6a1e10-1a2b-4c3d-9e0f-000000000202",
+              "name": "subject",
+              "type": "string",
+              "value": "={{ 'Downloaded: ' + ($json.body.movie ? $json.body.movie.title : $json.body.series.title) }}"
+            },
+            {
+              "id": "5f6a1e10-1a2b-4c3d-9e0f-000000000203",
+              "name": "message",
+              "type": "string",
+              "value": "={{ JSON.stringify($json.body.episodeFile || $json.body.movieFile) }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "5f6a1e10-1a2b-4c3d-9e0f-000000000204",
+      "name": "Set - Notify Payload",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "source": "database",
+        "workflowId": {
+          "__rl": true,
+          "value": "notify",
+          "mode": "list",
+          "cachedResultName": "Notify"
+        },
+        "workflowInputs": {
+          "value": {
+            "subject": "={{ $json.subject }}",
+            "message": "={{ $json.message }}"
+          },
+          "matchingColumns": [
+            "subject",
+            "message"
+          ]
+        }
+      },
+      "id": "5f6a1e10-1a2b-4c3d-9e0f-000000000205",
+      "name": "Execute Workflow - Notify",
+      "type": "n8n-nodes-base.executeWorkflow",
+      "typeVersion": 1.2,
+      "position": [680, 300]
+    }
+  ],
+  "connections": {
+    "Webhook - Radarr/Sonarr": {
+      "main": [
+        [
+          {
+            "node": "Set - Notify Payload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set - Notify Payload": {
+      "main": [
+        [
+          {
+            "node": "Execute Workflow - Notify",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateCredsSetupCompleted": false
+  },
+  "tags": [
+    "media",
+    "example"
+  ]
+}

--- a/clusters/homelab/services/ai/n8n/workflows/notify-subworkflow.json
+++ b/clusters/homelab/services/ai/n8n/workflows/notify-subworkflow.json
@@ -1,0 +1,97 @@
+{
+  "name": "Notify",
+  "nodes": [
+    {
+      "parameters": {
+        "workflowInputs": {
+          "values": [
+            {
+              "name": "subject"
+            },
+            {
+              "name": "message"
+            }
+          ]
+        }
+      },
+      "id": "5f6a1e10-1a2b-4c3d-9e0f-000000000101",
+      "name": "Workflow Input",
+      "type": "n8n-nodes-base.executeWorkflowTrigger",
+      "typeVersion": 1.1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "fromEmail": "n8n@${domain_name}",
+        "toEmail": "owner@${domain_name}",
+        "subject": "={{ $json.subject }}",
+        "emailFormat": "text",
+        "text": "={{ $json.message }}",
+        "options": {}
+      },
+      "id": "5f6a1e10-1a2b-4c3d-9e0f-000000000102",
+      "name": "Send Email - Maddy",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 2.1,
+      "position": [500, 220],
+      "credentials": {
+        "smtp": {
+          "id": "maddy-smtp",
+          "name": "Maddy SMTP"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://openclaw.openclaw.svc.cluster.local:18789/hooks/agent",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ \"source\": \"n8n\", \"message\": $json.subject + ': ' + $json.message }) }}",
+        "options": {}
+      },
+      "id": "5f6a1e10-1a2b-4c3d-9e0f-000000000103",
+      "name": "OpenClaw - Relay to WhatsApp",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [500, 380],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "openclaw-hooks-auth",
+          "name": "OpenClaw Hooks Token"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Workflow Input": {
+      "main": [
+        [
+          {
+            "node": "Send Email - Maddy",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "OpenClaw - Relay to WhatsApp",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateCredsSetupCompleted": false
+  },
+  "tags": [
+    "shared",
+    "notify"
+  ]
+}

--- a/clusters/homelab/sources/apps-ai.yaml
+++ b/clusters/homelab/sources/apps-ai.yaml
@@ -14,5 +14,5 @@ spec:
     !/apps/subsystems/ai
   interval: 1m0s
   ref:
-    tag: apps-ai-v0.6.5
+    tag: apps-ai-v0.6.7
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git


### PR DESCRIPTION
## Summary

Expands this PR from "n8n seed workflows only" into the full cluster-side GitOps wiring for
Phase 1 of the n8n + OpenClaw agentic-workflow rollout (issue #740):

- **Tag bump**: `clusters/homelab/sources/apps-ai.yaml` `apps-ai-v0.6.5` → `apps-ai-v0.6.7`
  (the released tag containing both n8n's manifests, apps#3383, and OpenClaw's, apps#3393/#3386).
- **n8n Postgres postBuild vars**: added `n8n_db_storage_size` (`10Gi`),
  `n8n_db_storage_class` (`sc-longhorn-local-non-replicated`), and `n8n_db_suffix_current`
  (`"v20260725"`) to `clusters/homelab/kustomizations/apps-ai.yaml`. `n8n_db_name`/
  `n8n_db_replicas`/`n8n_db_bootstrap_*` are left on their module defaults.
- **OpenClaw**: needs no postBuild vars — `openclaw-config`'s ConfigMap disables Flux
  substitution and expands its own `${VAR}` tokens from its container env at startup.
- **n8n's DB scoped out of backups/restore (deliberately unbacked for now)**:
  `components/db-backups` and `components/db-restore` (both mixed into the `apps-ai`
  Kustomization) patch `kind: postgresql.cnpg.io/Cluster` with **no name filter**, so without
  correction they inject litellm's barman backup-store plugin config into n8n's Cluster too, and
  db-restore strips n8n's `initdb` bootstrap and points it at `spec.bootstrap.recovery` sourced
  from **litellm's** backup store (wrong data, wrong owner/database). Added two `spec.patches`
  entries scoped to `namespace: n8n` that undo the injection and restore n8n's Cluster to a plain
  `initdb` bootstrap — see verification below. Litellm's Cluster is unaffected. Revisit once n8n's
  workflow data is worth backing up.
- **Alertmanager receiver (inert until manual import)**: added a `webhook_configs` receiver +
  route in `infra-observability-core`'s `kube-prometheus-stack` HelmRelease values, sending alerts
  to `http://n8n.n8n.svc.cluster.local:5678/webhook/alertmanager`. Alertmanager currently has zero
  real receivers (default chart config routes everything to `null`), so this is the first live
  receiver. Watchdog stays routed to `null` so the heartbeat alert doesn't spam n8n. **This is
  inert (posts to a 404) until the n8n `alertmanager-receiver` workflow is manually imported and
  activated** — see checklist below.
- **Seed workflows** (already staged on this branch): `clusters/homelab/services/ai/n8n/workflows/`
  — `notify-subworkflow.json`, `media-downloaded-notify.json`, `alertmanager-receiver.json` — raw
  reference files for the manual `n8n import:workflow` step, not wired into any kustomization.

## Verification

Rendered both affected Kustomizations locally with `flux build kustomization --dry-run` against
the pinned tags (`apps-ai-v0.6.7`, `infra-observability-core-v0.24.1`) and validated the output
with `kubeconform` (53/53 and 27/27 resources valid, 0 errors).

n8n's Cluster (`namespace: n8n`) — before the corrective patch (components applied, uncorrected):

```yaml
spec:
  bootstrap:
    recovery:
      database: litellm
      owner: litellm
      source: origin
  externalClusters:
  - name: origin
    plugin:
      name: barman-cloud.cloudnative-pg.io
      parameters:
        barmanObjectName: litellm-db-backup-store
        serverName: v20260722
  plugins:
  - isWALArchiver: true
    name: barman-cloud.cloudnative-pg.io
    parameters:
      barmanObjectName: litellm-db-backup-store
      serverName: v20260723
```

After the corrective patch:

```yaml
spec:
  bootstrap:
    initdb:
      database: n8n
      owner: n8n
  # no plugins, no externalClusters
```

litellm's Cluster (`namespace: ai`) is byte-for-byte unchanged — still has its `recovery`
bootstrap, `externalClusters`, and `plugins` barman config from `db_bootstrap_database: litellm`,
`db_suffix_restore: v20260722`, `db_name: litellm-db`, `db_suffix_current: v20260723`.

## Manual operator checklist (not in git)

These steps are intentionally not GitOps-able and must be done by hand once this PR is deployed:

- **Bitwarden Secrets Manager keys** (names only, values provisioned directly in Bitwarden):
  - `n8n_encryption_key`
  - `n8n_owner_password_hash` (bcrypt hash, not plaintext)
  - `n8n_credentials_overwrite` (JSON blob for `N8N_CREDENTIALS_OVERWRITE_DATA` — pre-seeds the
    LiteLLM/OpenAI credential and the Maddy SMTP credential)
  - `apikey_litellm_n8n`
  - `n8n_smtp_user` / `n8n_smtp_password` (only if Maddy requires SMTP auth)
  - `n8n_owner_email` (n8n owner login email) / `n8n_smtp_sender` (upstream SMTP account From
    address, used as `N8N_SMTP_SENDER`) — both in the **n8n-secrets** BWS project, same as the
    other `n8n_*` keys above; the `n8n-secrets` ExternalSecret won't sync until these two exist
  - `openclaw_gateway_token`
  - `apikey_litellm_openclaw`
  - `openclaw_hooks_token`
  - `openclaw_owner_whatsapp_number` (owner's E.164 WhatsApp number for `allowFrom` pairing)
- **LiteLLM virtual keys**: provision one for n8n and one for OpenClaw; scope both keys' `/mcp`
  access to the read-only MCP servers only; confirm the four shared model aliases exist
  (`deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash`, `google/gemini-3.5-flash-lite`,
  `openai/gpt-5-nano`).
- **Import n8n workflows** from `clusters/homelab/services/ai/n8n/workflows/`, in order:
  1. Before importing, edit `notify-subworkflow.json`'s email node: replace the `${domain_name}`
     placeholders in `fromEmail`/`toEmail` with the real values (`fromEmail` = the same sender
     value provisioned for the `n8n_smtp_sender` BWS key above, `toEmail` = the real notification
     recipient) — these placeholders are Flux postBuild tokens and are **not** substituted on a
     manual `n8n import:workflow`.
  2. `notify-subworkflow.json` (must exist before the next two, which call it)
  3. `media-downloaded-notify.json`
  4. `alertmanager-receiver.json`

  Activate each workflow after import — the Alertmanager receiver added in this PR stays inert
  (posts to a 404) until `alertmanager-receiver` is imported and activated.
- **WhatsApp QR pairing**: `kubectl exec -n openclaw <pod> -- openclaw channels login --channel
  whatsapp`, scan the QR from the pod logs. If the `:slim` image lacks the WhatsApp plugin, run
  `openclaw plugins install clawhub:@openclaw/whatsapp` first (persists to the PVC).
- **`openclaw cron add`** for the daily digest job.
- **Post-rollout verification** per issue #740 section 7 (n8n login/healthz/metrics/AI Agent node,
  OpenClaw security audit/gateway status/WhatsApp round-trip/read-only MCP query, both scraped by
  Prometheus).

## References

- Rollout issue: #740
- n8n: ppat/homelab-ops-kubernetes-apps#3383 (merged)
- OpenClaw: ppat/homelab-ops-kubernetes-apps#3393, PR ppat/homelab-ops-kubernetes-apps#3386

## Test plan

- [x] `pre-commit run --files <changed>` (yamllint, kubeconform manifest validation) — passed
- [x] `flux build kustomization --dry-run` + `kubeconform` for both `apps-ai` and
      `infra-observability-core`, confirming n8n's Cluster gets a plain `initdb` bootstrap and
      litellm's Cluster is unaffected
- [ ] Manual operator checklist above, post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)




