### PR TITLE
fix(cluster-homelab): apps-ai rollout prerequisites missed in #745

### DIFF
--- a/clusters/homelab/cluster/secrets/bitwarden-secret-store.yaml
+++ b/clusters/homelab/cluster/secrets/bitwarden-secret-store.yaml
@@ -39,6 +39,8 @@ spec:
     - maddy
     - minio
     - monitoring
+    - n8n
+    - openclaw
     - pihole
     - tailscale
     - traefik

--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -173,3 +173,18 @@ spec:
     target:
       kind: Deployment
       name: mcp-unifi-protect
+  # PVCs are cluster-provisioned (see storage/apps/pvc/ai/openclaw-data.yaml), matching
+  # the openwebui convention -- the module's own openclaw-data PVC is deleted here so
+  # only the cluster-provisioned one exists (avoids two Flux Kustomizations owning it).
+  # yamllint disable-line rule:indentation
+  - patch: |
+      $patch: delete
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: openclaw-data
+        namespace: openclaw
+    target:
+      kind: PersistentVolumeClaim
+      name: openclaw-data
+      namespace: openclaw

--- a/clusters/homelab/storage/apps/pvc/ai/kustomization.yaml
+++ b/clusters/homelab/storage/apps/pvc/ai/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 
 resources:
 - openwebui.yaml
+- n8n-data.yaml
+- openclaw-data.yaml
 
 patches:
 # yamllint disable-line rule:indentation
@@ -20,3 +22,31 @@ patches:
   target:
     kind: PersistentVolumeClaim
     name: openwebui
+# yamllint disable-line rule:indentation
+- patch: |-
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: irrelevant
+      labels:
+        recurring-job.longhorn.io/source: enabled
+        recurring-job-group.longhorn.io/default: enabled
+        recurring-job-group.longhorn.io/snapshot-ops: enabled
+        recurring-job-group.longhorn.io/backup-ops: enabled
+  target:
+    kind: PersistentVolumeClaim
+    name: n8n-data
+# yamllint disable-line rule:indentation
+- patch: |-
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: irrelevant
+      labels:
+        recurring-job.longhorn.io/source: enabled
+        recurring-job-group.longhorn.io/default: enabled
+        recurring-job-group.longhorn.io/snapshot-ops: enabled
+        recurring-job-group.longhorn.io/backup-ops: enabled
+  target:
+    kind: PersistentVolumeClaim
+    name: openclaw-data

--- a/clusters/homelab/storage/apps/pvc/ai/kustomization.yaml
+++ b/clusters/homelab/storage/apps/pvc/ai/kustomization.yaml
@@ -21,32 +21,3 @@ patches:
         recurring-job-group.longhorn.io/backup-ops: enabled
   target:
     kind: PersistentVolumeClaim
-    name: openwebui
-# yamllint disable-line rule:indentation
-- patch: |-
-    apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      name: irrelevant
-      labels:
-        recurring-job.longhorn.io/source: enabled
-        recurring-job-group.longhorn.io/default: enabled
-        recurring-job-group.longhorn.io/snapshot-ops: enabled
-        recurring-job-group.longhorn.io/backup-ops: enabled
-  target:
-    kind: PersistentVolumeClaim
-    name: n8n-data
-# yamllint disable-line rule:indentation
-- patch: |-
-    apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      name: irrelevant
-      labels:
-        recurring-job.longhorn.io/source: enabled
-        recurring-job-group.longhorn.io/default: enabled
-        recurring-job-group.longhorn.io/snapshot-ops: enabled
-        recurring-job-group.longhorn.io/backup-ops: enabled
-  target:
-    kind: PersistentVolumeClaim
-    name: openclaw-data

--- a/clusters/homelab/storage/apps/pvc/ai/n8n-data.yaml
+++ b/clusters/homelab/storage/apps/pvc/ai/n8n-data.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: n8n-data
+  namespace: n8n
+  labels:
+    app.kubernetes.io/name: n8n
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: sc-longhorn-replicated
+  volumeMode: Filesystem

--- a/clusters/homelab/storage/apps/pvc/ai/openclaw-data.yaml
+++ b/clusters/homelab/storage/apps/pvc/ai/openclaw-data.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openclaw-data
+  namespace: openclaw
+  labels:
+    app.kubernetes.io/name: openclaw
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: sc-longhorn-replicated
+  volumeMode: Filesystem


### PR DESCRIPTION
## Summary

Fixes cluster-side prerequisites for the n8n + OpenClaw rollout (apps-ai) that were missed when #745 merged. These were blocking both apps from starting. Follow-up to #740.

- **ClusterSecretStore namespace allowlist**: `bitwarden-secret-manager-store`'s `spec.conditions[0].namespaces` was missing `n8n` and `openclaw`, so both apps' `ExternalSecret`s were denied ("using cluster store ... is not allowed from namespace openclaw: denied by spec.condition"). Added both, alphabetically ordered.
- **n8n-data PVC**: the n8n module references `claimName: n8n-data` but ships no PVC — it's a cluster prerequisite that was never added. Provisioned under `storage/apps/pvc/ai/n8n-data.yaml` (2Gi, `sc-longhorn-replicated`).
- **openclaw-data PVC moved from module to cluster**: the openclaw module wrongly shipped its own PVC; per repo convention (see `openwebui`, and the broader pattern across `storage/apps/pvc/{downloaders,media,home-automation}` and `storage/infra/pvc`), app data PVCs are cluster-provisioned, not module-shipped. Added `storage/apps/pvc/ai/openclaw-data.yaml` (10Gi, `sc-longhorn-replicated`) and deleted the module's own PVC via a `$patch: delete` in `apps-ai.yaml` so only the cluster-provisioned one exists (avoids two Flux Kustomizations owning the same PVC).

Both new PVCs get the same longhorn recurring-job labels as their siblings via the `ai` PVC directory's `kustomization.yaml` patches, matching the existing per-PVC patch pattern used there and in the other `pvc/` directories.

Note: I initially considered mirroring `openwebui.yaml` exactly (no `app.kubernetes.io/name` label on the PVC body). Checking the full set of existing cluster PVCs, `openwebui` is actually the outlier — every other Longhorn-backed app PVC in the repo (`downloaders/*`, `media/*`, `home-automation/home-assistant-data`, `infra/pvc/*`) carries `app.kubernetes.io/name` in the body, with the longhorn recurring-job labels layered on separately via the kustomization patch. Followed that majority convention for `n8n-data` and `openclaw-data`.

**Safe to apply**: openclaw hasn't started yet, so its module-shipped PVC is empty — deleting/recreating it via this PR loses no data. PVC sizes/storage class (n8n 2Gi, openclaw 10Gi, `sc-longhorn-replicated`) are easy to adjust later if usage patterns call for it.

## Verification

- `flux build kustomization apps-ai --path <local apps-ai module> --kustomization-file clusters/homelab/kustomizations/apps-ai.yaml --dry-run`: renders cleanly; **no `PersistentVolumeClaim` resource is emitted at all** (openclaw's module PVC is deleted by the new patch; n8n never had one), while the openclaw and n8n `Deployment`s still reference `claimName: openclaw-data` / `claimName: n8n-data` respectively — both satisfied by the cluster-provisioned PVCs.
- `kustomize build clusters/homelab/storage/apps/pvc/ai`: renders 3 PVCs (`openwebui`, `n8n-data`, `openclaw-data`), each with the longhorn recurring-job labels applied.
- `kustomize build clusters/homelab/storage`: full storage tree still builds cleanly (36 PVCs total).
- `pre-commit run` (yamllint, kubeconform-based `validate-k8s`, etc.) passes on all changed files.

## Test plan

- [ ] Merge and let `config-storage` reconcile — confirm `n8n-data` and `openclaw-data` PVCs are created and bind in their namespaces.
- [ ] Confirm `apps-ai` reconciles cleanly — no duplicate-ownership conflict on `openclaw-data`, and the n8n/openclaw `ExternalSecret`s sync successfully (no more `denied by spec.condition`).
- [ ] Confirm n8n and openclaw pods start and mount their PVCs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)