### PR TITLE
fix(cluster-homelab): openclaw config ownership, writable config, deepseek thinking, readiness

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,11 @@ repos:
   - id: check-added-large-files
   - id: check-executables-have-shebangs
   - id: check-json
+    # openclaw.json is JS-style JSON5 (comments) fed straight into a ConfigMap
+    # via configMapGenerator, not parsed by us -- OpenClaw's own JSON5 parser reads
+    # it -- so strict-JSON validation doesn't apply here (mirrors the .yamllint
+    # ignore homelab-ops-kubernetes-apps uses for the module's own copy).
+    exclude: ^clusters/homelab/services/ai/openclaw/openclaw\.json$
   - id: check-shebang-scripts-are-executable
   - id: detect-private-key
   - id: end-of-file-fixer

--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -277,3 +277,69 @@ spec:
       kind: Deployment
       name: openclaw
       namespace: openclaw
+  # Secret split (homelab-ops-kubernetes-clusters#740): now that openclaw.json is
+  # cluster-owned, the two config-feature-coupled secrets it references -- the WhatsApp
+  # owner allowlist (OWNER_WHATSAPP_NUMBER) and the inbound hooks token
+  # (OPENCLAW_HOOKS_TOKEN) -- move to a cluster-owned ES co-located with the config
+  # (services/ai/openclaw/externalsecret-openclaw-config-secrets.yaml), so a config change
+  # that needs one of them stays a single-repo change. The module's openclaw-secrets ES
+  # keeps the universal LITELLM_KEY + OPENCLAW_GATEWAY_TOKEN. Same BWS keys, no new remote
+  # secrets. Drop the two moved entries from the module ES here.
+  #
+  # JSON6902 (by index) rather than a strategic-merge `$patch: delete` keyed by secretKey:
+  # ExternalSecret is a CRD with no schema known to kustomize, so a schema-less strategic
+  # merge can't match spec.data list items by key and instead replaces the whole list --
+  # it would drop LITELLM_KEY/OPENCLAW_GATEWAY_TOKEN too. The `test` ops guard the indices
+  # so this fails loudly if the module ever reorders its data entries (module order today:
+  # 0=OPENCLAW_GATEWAY_TOKEN, 1=LITELLM_KEY, 2=OPENCLAW_HOOKS_TOKEN, 3=OWNER_WHATSAPP_NUMBER).
+  # Remove the higher index first so the lower index stays valid.
+  # yamllint disable-line rule:indentation
+  - patch: |
+      - op: test
+        path: /spec/data/3/secretKey
+        value: OWNER_WHATSAPP_NUMBER
+      - op: remove
+        path: /spec/data/3
+      - op: test
+        path: /spec/data/2/secretKey
+        value: OPENCLAW_HOOKS_TOKEN
+      - op: remove
+        path: /spec/data/2
+    target:
+      group: external-secrets.io
+      kind: ExternalSecret
+      name: openclaw-secrets
+      namespace: openclaw
+  # Companion to the ES split above: point the two moved env vars at the new
+  # openclaw-config-secrets Secret (same keys), and add it to the reloader annotation so a
+  # change to either moved secret still restarts the pod. LITELLM_KEY /
+  # OPENCLAW_GATEWAY_TOKEN stay sourced from openclaw-secrets.
+  # yamllint disable-line rule:indentation
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: openclaw
+        namespace: openclaw
+        annotations:
+          secret.reloader.stakater.com/reload: openclaw-secrets,openclaw-config-secrets
+      spec:
+        template:
+          spec:
+            containers:
+            - name: openclaw
+              env:
+              - name: OPENCLAW_HOOKS_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: openclaw-config-secrets
+                    key: OPENCLAW_HOOKS_TOKEN
+              - name: OWNER_WHATSAPP_NUMBER
+                valueFrom:
+                  secretKeyRef:
+                    name: openclaw-config-secrets
+                    key: OWNER_WHATSAPP_NUMBER
+    target:
+      kind: Deployment
+      name: openclaw
+      namespace: openclaw

--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -188,3 +188,92 @@ spec:
       kind: PersistentVolumeClaim
       name: openclaw-data
       namespace: openclaw
+  # Interim (homelab-ops-kubernetes-clusters#740): openclaw's config moves cluster-side
+  # (services/ai/openclaw/openclaw.json, generated into a ConfigMap of the same name/
+  # namespace by config-services) so it can carry the deepseek thinkingFormat fix below
+  # without an apps-repo module release. Same dual-ownership pattern as the PVC delete
+  # above -- delete the module's copy so only the cluster-provided ConfigMap exists.
+  # To be ported into apps/subsystems/ai/openclaw in one pass later.
+  # yamllint disable-line rule:indentation
+  - patch: |
+      $patch: delete
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: openclaw-config
+        namespace: openclaw
+    target:
+      kind: ConfigMap
+      name: openclaw-config
+      namespace: openclaw
+  # A: OpenClaw's CLI writes back to its own config file (e.g. `openclaw channels login`
+  # rewrites credentials into openclaw.json), which fails with EBUSY against the module's
+  # read-only ConfigMap subPath mount. Seed the writable `config-dir` emptyDir from the
+  # ConfigMap via an initContainer instead, and drop the main container's read-only
+  # subPath mount so /etc/openclaw is fully writable. OPENCLAW_CONFIG_PATH already points
+  # at the writable copy, so no env change is needed for this fix.
+  # yamllint disable-line rule:indentation
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: irrelevant
+      spec:
+        template:
+          spec:
+            initContainers:
+            - name: openclaw-config-seed
+              image: docker.io/ppatlabs/openclaw:2026.7.1@sha256:8efc9d2e7a02e137031534d82eeee94b66938d26a3013d96d42643e5ad69fedc
+              command:
+              - cp
+              - /etc/openclaw-seed/openclaw.json
+              - /etc/openclaw/openclaw.json
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                  - ALL
+              volumeMounts:
+              - name: config
+                mountPath: /etc/openclaw-seed
+                readOnly: true
+              - name: config-dir
+                mountPath: /etc/openclaw
+            containers:
+            - name: openclaw
+              volumeMounts:
+              - mountPath: /etc/openclaw/openclaw.json
+                $patch: delete
+    target:
+      kind: Deployment
+      name: openclaw
+      namespace: openclaw
+  # C: readiness was tied to /readyz, which only reports ready once WhatsApp is paired --
+  # decouple pod Ready from that optional channel by probing /healthz instead (same
+  # endpoint already used by the startup/liveness probes).
+  # env: OPENCLAW_DATA_DIR is not a real OpenClaw env var (no-op); the actual state dir
+  # override is OPENCLAW_STATE_DIR. Renamed here, same value.
+  # yamllint disable-line rule:indentation
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: irrelevant
+      spec:
+        template:
+          spec:
+            containers:
+            - name: openclaw
+              env:
+              - name: OPENCLAW_DATA_DIR
+                $patch: delete
+              - name: OPENCLAW_STATE_DIR
+                value: /home/node/.openclaw
+              readinessProbe:
+                httpGet:
+                  path: /healthz
+    target:
+      kind: Deployment
+      name: openclaw
+      namespace: openclaw

--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -206,18 +206,35 @@ spec:
       kind: ConfigMap
       name: openclaw-config
       namespace: openclaw
-  # A: OpenClaw's CLI writes back to its own config file (e.g. `openclaw channels login`
-  # rewrites credentials into openclaw.json), which fails with EBUSY against the module's
-  # read-only ConfigMap subPath mount. Seed the writable `config-dir` emptyDir from the
-  # ConfigMap via an initContainer instead, and drop the main container's read-only
-  # subPath mount so /etc/openclaw is fully writable. OPENCLAW_CONFIG_PATH already points
-  # at the writable copy, so no env change is needed for this fix.
+  # Consolidated openclaw Deployment patch -- all in-place edits to the openclaw Deployment
+  # live in this one strategic-merge entry (the module/PVC/ConfigMap/ES deletes stay
+  # separate since they target other resources). It does four things:
+  #  - Writable config seed (A): OpenClaw's CLI writes back to its own config file (e.g.
+  #    `openclaw channels login` rewrites credentials into openclaw.json), which fails with
+  #    EBUSY against the module's read-only ConfigMap subPath mount. An initContainer seeds
+  #    the writable `config-dir` emptyDir from the ConfigMap, and the main container's
+  #    read-only /etc/openclaw/openclaw.json subPath mount is dropped so /etc/openclaw is
+  #    fully writable. OPENCLAW_CONFIG_PATH already points at the writable copy.
+  #  - Readiness /healthz decouple (C): /readyz only reports ready once WhatsApp is paired;
+  #    probe /healthz instead (same endpoint startup/liveness already use) so pod Ready is
+  #    independent of that optional channel.
+  #  - STATE_DIR rename: OPENCLAW_DATA_DIR is not a real OpenClaw env var (no-op); the actual
+  #    state dir override is OPENCLAW_STATE_DIR. Renamed, same value.
+  #  - Config-coupled secret repoint (#740): the two secrets openclaw.json references --
+  #    OPENCLAW_HOOKS_TOKEN (hooks.token) and OWNER_WHATSAPP_NUMBER
+  #    (channels.whatsapp.allowFrom) -- now source from the cluster-owned
+  #    openclaw-config-secrets Secret (see the ES split patch below); the reloader annotation
+  #    lists both Secrets so a change to either restarts the pod. LITELLM_KEY /
+  #    OPENCLAW_GATEWAY_TOKEN stay on openclaw-secrets.
   # yamllint disable-line rule:indentation
-  - patch: |
+  - patch: |-
       apiVersion: apps/v1
       kind: Deployment
       metadata:
-        name: irrelevant
+        name: openclaw
+        namespace: openclaw
+        annotations:
+          secret.reloader.stakater.com/reload: openclaw-secrets,openclaw-config-secrets
       spec:
         template:
           spec:
@@ -242,37 +259,27 @@ spec:
                 mountPath: /etc/openclaw
             containers:
             - name: openclaw
-              volumeMounts:
-              - mountPath: /etc/openclaw/openclaw.json
-                $patch: delete
-    target:
-      kind: Deployment
-      name: openclaw
-      namespace: openclaw
-  # C: readiness was tied to /readyz, which only reports ready once WhatsApp is paired --
-  # decouple pod Ready from that optional channel by probing /healthz instead (same
-  # endpoint already used by the startup/liveness probes).
-  # env: OPENCLAW_DATA_DIR is not a real OpenClaw env var (no-op); the actual state dir
-  # override is OPENCLAW_STATE_DIR. Renamed here, same value.
-  # yamllint disable-line rule:indentation
-  - patch: |-
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: irrelevant
-      spec:
-        template:
-          spec:
-            containers:
-            - name: openclaw
               env:
-              - name: OPENCLAW_DATA_DIR
-                $patch: delete
+              - name: OPENCLAW_HOOKS_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: openclaw-config-secrets
+                    key: OPENCLAW_HOOKS_TOKEN
+              - name: OWNER_WHATSAPP_NUMBER
+                valueFrom:
+                  secretKeyRef:
+                    name: openclaw-config-secrets
+                    key: OWNER_WHATSAPP_NUMBER
               - name: OPENCLAW_STATE_DIR
                 value: /home/node/.openclaw
+              - name: OPENCLAW_DATA_DIR
+                $patch: delete
               readinessProbe:
                 httpGet:
                   path: /healthz
+              volumeMounts:
+              - mountPath: /etc/openclaw/openclaw.json
+                $patch: delete
     target:
       kind: Deployment
       name: openclaw
@@ -309,37 +316,4 @@ spec:
       group: external-secrets.io
       kind: ExternalSecret
       name: openclaw-secrets
-      namespace: openclaw
-  # Companion to the ES split above: point the two moved env vars at the new
-  # openclaw-config-secrets Secret (same keys), and add it to the reloader annotation so a
-  # change to either moved secret still restarts the pod. LITELLM_KEY /
-  # OPENCLAW_GATEWAY_TOKEN stay sourced from openclaw-secrets.
-  # yamllint disable-line rule:indentation
-  - patch: |-
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: openclaw
-        namespace: openclaw
-        annotations:
-          secret.reloader.stakater.com/reload: openclaw-secrets,openclaw-config-secrets
-      spec:
-        template:
-          spec:
-            containers:
-            - name: openclaw
-              env:
-              - name: OPENCLAW_HOOKS_TOKEN
-                valueFrom:
-                  secretKeyRef:
-                    name: openclaw-config-secrets
-                    key: OPENCLAW_HOOKS_TOKEN
-              - name: OWNER_WHATSAPP_NUMBER
-                valueFrom:
-                  secretKeyRef:
-                    name: openclaw-config-secrets
-                    key: OWNER_WHATSAPP_NUMBER
-    target:
-      kind: Deployment
-      name: openclaw
       namespace: openclaw

--- a/clusters/homelab/services/ai/kustomization.yaml
+++ b/clusters/homelab/services/ai/kustomization.yaml
@@ -11,3 +11,18 @@ configMapGenerator:
     annotations:
       kustomize.toolkit.fluxcd.io/substitute: disabled
     disableNameSuffixHash: true
+# Interim cluster-side ownership of openclaw's config (homelab-ops-kubernetes-clusters#740):
+# the module's own ConfigMap of the same name is deleted via a patch in
+# kustomizations/apps-ai.yaml so only this one exists. To be ported back into the
+# apps/subsystems/ai/openclaw module in one pass once the fixes below are proven out.
+- name: openclaw-config
+  namespace: openclaw
+  files:
+  - openclaw/openclaw.json
+  options:
+    annotations:
+      # openclaw.json's `${VAR}` tokens are expanded by OpenClaw itself from its own
+      # container env at startup, not by Flux -- without this, Flux's postBuild
+      # substitution would try (and fail) to resolve them before this ConfigMap is applied.
+      kustomize.toolkit.fluxcd.io/substitute: disabled
+    disableNameSuffixHash: true

--- a/clusters/homelab/services/ai/kustomization.yaml
+++ b/clusters/homelab/services/ai/kustomization.yaml
@@ -2,6 +2,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+resources:
+# Feature-coupled OpenClaw secrets, co-located with the cluster-owned openclaw.json
+# (homelab-ops-kubernetes-clusters#740). See the manifest header for the split rationale.
+- openclaw/externalsecret-openclaw-config-secrets.yaml
+
 configMapGenerator:
 - name: litellm-model-config
   namespace: ai

--- a/clusters/homelab/services/ai/openclaw/externalsecret-openclaw-config-secrets.yaml
+++ b/clusters/homelab/services/ai/openclaw/externalsecret-openclaw-config-secrets.yaml
@@ -1,0 +1,28 @@
+---
+# Feature-coupled OpenClaw secrets, co-located with the cluster-owned openclaw.json
+# (homelab-ops-kubernetes-clusters#740). These two are referenced by specific config
+# features -- the WhatsApp owner allowlist (channels.whatsapp.allowFrom) and the inbound
+# hooks token (hooks.token) -- so they live cluster-side alongside the config, keeping a
+# config change that needs one of them a single-repo change. The universal secrets
+# (LITELLM_KEY, OPENCLAW_GATEWAY_TOKEN) stay in the module's own openclaw-secrets ES.
+# Same BWS keys as before -- no new remote secrets. To be ported into the
+# apps/subsystems/ai/openclaw module later along with the config move.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openclaw-config-secrets
+  namespace: openclaw
+spec:
+  data:
+  - secretKey: OPENCLAW_HOOKS_TOKEN
+    remoteRef:
+      key: openclaw_hooks_token
+  # Owner's WhatsApp E.164 number for channels.whatsapp.allowFrom -- personal identifying
+  # data. Substituted into openclaw.json by OpenClaw at container startup, not by Flux.
+  - secretKey: OWNER_WHATSAPP_NUMBER
+    remoteRef:
+      key: openclaw_owner_whatsapp_number
+  refreshInterval: 24h
+  secretStoreRef:
+    name: bitwarden-secret-manager-store
+    kind: ClusterSecretStore

--- a/clusters/homelab/services/ai/openclaw/openclaw.json
+++ b/clusters/homelab/services/ai/openclaw/openclaw.json
@@ -1,0 +1,158 @@
+{
+  // All model calls are routed through the in-cluster LiteLLM gateway -- no direct
+  // provider API keys here.
+  "models": {
+    "providers": {
+      "litellm": {
+        "baseUrl": "http://litellm.ai.svc.cluster.local:4000/v1",
+        "apiKey": "${LITELLM_KEY}",
+        "api": "openai-completions",
+        "timeoutSeconds": 120,
+        // Each catalog entry must be an object with both `id` and a display `name` --
+        // a bare string or an id-only object fails schema validation
+        // ("models.providers.<id>.models.N[.name]: Invalid input").
+        "models": [
+          {
+            "id": "deepseek/deepseek-v4-pro",
+            "name": "DeepSeek v4 Pro",
+            // OpenRouter's DeepSeek-v4 endpoint rejects the `thinking` param
+            // OpenClaw sends by default (HTTP 400) -- "openrouter" compat mode
+            // omits it instead. See homelab-ops-kubernetes-clusters#740.
+            "compat": { "thinkingFormat": "openrouter" }
+          },
+          {
+            "id": "deepseek/deepseek-v4-flash",
+            "name": "DeepSeek v4 Flash",
+            "compat": { "thinkingFormat": "openrouter" }
+          },
+          { "id": "google/gemini-3.5-flash-lite", "name": "Gemini 3.5 Flash Lite" },
+          { "id": "openai/gpt-5-nano", "name": "GPT-5 Nano" }
+        ]
+      }
+    }
+  },
+
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "litellm/deepseek/deepseek-v4-pro",
+        "fallbacks": [
+          "litellm/google/gemini-3.5-flash-lite",
+          "litellm/openai/gpt-5-nano"
+        ]
+      }
+      // No memory/dreaming block here -- `agents.defaults` has no `memory` key (an unknown
+      // key fails the whole object's validation). Dreaming lives under
+      // `plugins.entries.memory-core.config.dreaming.enabled` and defaults to off, which is
+      // what we want day-one.
+    }
+  },
+
+  // WhatsApp-only (Baileys QR-pairing) for day one; Telegram is a trivial later add.
+  "channels": {
+    "whatsapp": {
+      "enabled": true,
+      "dmPolicy": "pairing",
+      "allowFrom": ["${OWNER_WHATSAPP_NUMBER}"],
+      // Groups are locked down by default: `groupPolicy: allowlist` means no group is
+      // active until its ID is explicitly added. Per-group `requireMention` lives under
+      // `channels.whatsapp.groups.<groupId>` (a map keyed by real group ID) and is set
+      // once a group is allowlisted -- there is no channel-wide requireMention toggle.
+      "groupPolicy": "allowlist"
+    }
+  },
+
+  "mcp": {
+    "servers": {
+      // Aggregated read-only tool access via LiteLLM's own /mcp endpoint.
+      "litellm-readonly": {
+        "url": "http://litellm.ai.svc.cluster.local:4000/mcp",
+        "transport": "streamable-http",
+        // `auth` is an enum whose only value is "oauth" (for the `openclaw mcp login`
+        // flow) -- a static bearer token goes in `headers` instead.
+        "headers": {
+          "Authorization": "Bearer ${LITELLM_KEY}"
+        }
+      },
+      // Direct to Home Assistant's MCP server (bypasses LiteLLM), restricted to
+      // read/get/list tools only -- writes stay disabled until Phase 2 approvals land.
+      "home-assistant": {
+        "url": "http://mcp-home-assistant.ai.svc.cluster.local:8086/mcp",
+        "transport": "streamable-http",
+        "toolFilter": {
+          "include": ["get_*", "list_*", "read_*"]
+        }
+      }
+    }
+  },
+
+  // Inbound point for n8n / Alertmanager relays (see n8n's notify-subworkflow.json).
+  "hooks": {
+    "enabled": true,
+    "token": "${OPENCLAW_HOOKS_TOKEN}",
+    "path": "/hooks/agent"
+  },
+
+  // Jobs are not declared statically here -- `cron.jobs` isn't part of the config schema
+  // (jobs live in the gateway's own state store). The daily-digest job is created once,
+  // post-deploy, via `openclaw cron add` (same pattern as the WhatsApp QR pairing step).
+  "cron": {
+    "enabled": true
+  },
+
+  "gateway": {
+    // Headless/server deploy: gateway.mode must be set explicitly or OpenClaw refuses to
+    // start ("Gateway start blocked: existing config is missing gateway.mode").
+    "mode": "local",
+    // `bind` is a mode enum (loopback|lan|tailnet|auto|custom), NOT a host:port string --
+    // "lan" listens on 0.0.0.0 so the kubelet probes, ClusterIP Service, and Ingress can
+    // reach the gateway on the pod IP. The listen port is a separate field.
+    "bind": "lan",
+    "port": 18789,
+    "auth": {
+      "mode": "token",
+      "token": "${OPENCLAW_GATEWAY_TOKEN}"
+    }
+  },
+
+  // Lockdown: computer/browser tool, elevated/shell/exec, and third-party in-process
+  // plugins are all disabled day-one. See ai/README.md Prerequisites for the roadmap.
+  "tools": {
+    "deny": ["exec", "browser"],
+    "elevated": {
+      "enabled": false
+    }
+  },
+
+  // plugins.allow is keyed by plugin ID (e.g. "whatsapp"), NOT the npm package name
+  // ("@openclaw/whatsapp") -- the package name is silently treated as "not found" and the
+  // real plugin ends up omitted from the allowlist. These two (the WhatsApp/Baileys channel
+  // + the operator Prometheus diagnostics endpoint) are baked into the custom image and
+  // reseeded into the PVC by its entrypoint on every start -- no runtime clawhub fetch.
+  "plugins": {
+    "allow": [
+      "whatsapp",
+      "diagnostics-prometheus"
+    ]
+  },
+
+  "skills": {
+    "workshop": {
+      "autonomous": {
+        "enabled": false
+      }
+    }
+  },
+
+  "logging": {
+    "redactSensitive": "tools"
+  },
+
+  // `diagnostics` has no `prometheus` sub-key -- the diagnostics-prometheus plugin
+  // (see `plugins.allow` above) self-registers its own endpoint (GET
+  // /api/diagnostics/prometheus, gateway operator auth) once diagnostics events are
+  // enabled.
+  "diagnostics": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
## Summary

Interim, cluster-side-only prototype fixes for OpenClaw (references #740). No changes to `homelab-ops-kubernetes-apps` — everything here lives in `apps-ai.yaml` patches plus new `services/ai/openclaw/` manifests. Intended to be ported into `apps/subsystems/ai/openclaw` in one pass later, once proven out on-cluster.

- **Config ownership**: `openclaw.json` moves from the module's ConfigMap to a cluster-owned one at `clusters/homelab/services/ai/openclaw/openclaw.json`, generated into the `openclaw` namespace the same way LiteLLM's `services/ai/conf.d/model-config.yaml` is generated into the `ai` namespace (via `config-services`' `configMapGenerator`). The module's own `openclaw-config` ConfigMap is deleted in `apps-ai.yaml` via `$patch: delete` so only the cluster-provided one exists — same dual-ownership pattern already used there for the `openclaw-data` PVC. ConfigMap name/namespace/key are unchanged (`openclaw-config` / `openclaw` / `openclaw.json`), so the Deployment's `config` volume and the `configmap.reloader.stakater.com/reload: openclaw-config` annotation need no changes.
- **A (writable config)**: the module mounted `openclaw.json` read-only via a ConfigMap subPath, which makes OpenClaw's CLI writeback (e.g. `channels login`) fail with `EBUSY`. Added an initContainer (`openclaw-config-seed`, same pinned image as the main container, container-scoped hardening: `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`) that `cp`s the ConfigMap (mounted read-only at `/etc/openclaw-seed`) into the writable `config-dir` emptyDir. Removed the main container's read-only subPath mount so `/etc/openclaw` is now fully writable. `OPENCLAW_CONFIG_PATH` is unchanged and still points at the writable copy.
- **B (deepseek thinking)**: added `compat.thinkingFormat: "openrouter"` to both DeepSeek-v4 catalog entries in the new cluster config, so OpenClaw omits the `thinking` param that OpenRouter's DeepSeek-v4 endpoint rejects with a 400.
- **C (readiness)**: `readinessProbe` now checks `/healthz` instead of `/readyz`, so the gateway reports Ready independent of WhatsApp pairing state.
- **env**: renamed `OPENCLAW_DATA_DIR` (not a real OpenClaw env var — a no-op) to `OPENCLAW_STATE_DIR`, same value (`/home/node/.openclaw`).

## Secret split

Now that `openclaw.json` is cluster-owned, its config-feature-coupled secrets move cluster-side too, co-located with the config, so a config change that needs one of them stays a single-repo change.

- **Module `openclaw-secrets` ES keeps the universal secrets**: `LITELLM_KEY` (← BWS `apikey_litellm_openclaw`) and `OPENCLAW_GATEWAY_TOKEN` (← BWS `openclaw_gateway_token`). Its two moved entries are removed via a JSON6902 patch in `apps-ai.yaml`.
- **New cluster ES `openclaw-config-secrets`** (`clusters/homelab/services/ai/openclaw/externalsecret-openclaw-config-secrets.yaml`, namespace `openclaw`, `bitwarden-secret-manager-store` ClusterSecretStore, `refreshInterval: 24h`) owns the feature-coupled `OPENCLAW_HOOKS_TOKEN` (← BWS `openclaw_hooks_token`, used by `hooks.token`) and `OWNER_WHATSAPP_NUMBER` (← BWS `openclaw_owner_whatsapp_number`, used by `channels.whatsapp.allowFrom`). Same BWS keys — no new remote secrets. Applied to namespace `openclaw` by `config-services` (the `openclaw` namespace is already allowlisted in the ClusterSecretStore conditions from #749).
- **Deployment**: the two moved env vars now source from `openclaw-config-secrets` (same keys); `LITELLM_KEY`/`OPENCLAW_GATEWAY_TOKEN` still source from `openclaw-secrets`. The `secret.reloader.stakater.com/reload` annotation now lists both Secrets so a change to either restarts the pod.

> Note on patch mechanism for the ES data removal: a strategic-merge `$patch: delete` keyed by `secretKey` does **not** work here — `ExternalSecret` is a CRD with no schema known to kustomize, so a schema-less strategic merge can't match `spec.data` list items by key and replaces the whole list (dropping the kept entries too). Used JSON6902 remove-by-index instead, guarded with `test` ops on `secretKey` so it fails loudly if the module ever reorders its `data` entries. All other patches are clean strategic merges.

## Test plan

- [x] `flux build kustomization apps-ai --dry-run` (against apps-ai-v0.6.7) renders cleanly: openclaw Deployment has the initContainer, no read-only `openclaw.json` subPath mount, `readinessProbe.httpGet.path: /healthz`, env `OPENCLAW_STATE_DIR` (no `OPENCLAW_DATA_DIR`); `OPENCLAW_HOOKS_TOKEN`/`OWNER_WHATSAPP_NUMBER` sourced from `openclaw-config-secrets`, `LITELLM_KEY`/`OPENCLAW_GATEWAY_TOKEN` from `openclaw-secrets`; reloader annotation lists both Secrets; module `openclaw-secrets` ES has only `LITELLM_KEY` + `OPENCLAW_GATEWAY_TOKEN`; module `openclaw-config` ConfigMap absent. No env has both `value` and `valueFrom`.
- [x] Diffed full before/after render: only the openclaw namespace changed (deployment + configmap/ES); litellm/n8n/mcp/everything else byte-identical.
- [x] `flux build kustomization config-services --dry-run` renders the cluster `openclaw-config` ConfigMap (with both deepseek `compat.thinkingFormat` fixes) and the new `openclaw-config-secrets` ES in namespace `openclaw` with the two moved entries.
- [x] `kubeconform -strict` clean on both renders.
- [x] `pre-commit run --files <changed>` passes (added a `check-json` exclude for `openclaw.json`, which is JS-style JSON5 with comments consumed by OpenClaw itself, not strict JSON — mirrors the `.yamllint` ignore the apps module already has).

🤖 Generated with [Claude Code](https://claude.com/claude-code)