### PR TITLE
fix(cluster-homelab): openclaw control-ui origin + security-audit hardening

### DIFF
--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -229,6 +229,9 @@ spec:
   #  - Control UI origin: OPENCLAW_CONTROL_UI_ORIGIN feeds gateway.controlUi.allowedOrigins
   #    in openclaw.json (expanded by OpenClaw itself, not Flux). ${domain_name} is a Flux
   #    postBuild var resolved after spec.patches, same as the ingress hostname.
+  #  - Config perms (`openclaw security audit` finding fs.config.perms_world_readable,
+  #    CRITICAL): the seed initContainer now chmods the copied config to 600 (shell form,
+  #    since a chmod needs a second command after the cp).
   # yamllint disable-line rule:indentation
   - patch: |-
       apiVersion: apps/v1
@@ -244,10 +247,13 @@ spec:
             initContainers:
             - name: openclaw-config-seed
               image: docker.io/ppatlabs/openclaw:2026.7.1@sha256:8efc9d2e7a02e137031534d82eeee94b66938d26a3013d96d42643e5ad69fedc
+              # chmod 600 per `openclaw security audit` finding fs.config.perms_world_readable
+              # (CRITICAL): the ConfigMap-seeded copy lands 644 by default; the file is owned
+              # by uid 1000 (the gateway's runAsUser), so 600 stays readable by the gateway.
               command:
-              - cp
-              - /etc/openclaw-seed/openclaw.json
-              - /etc/openclaw/openclaw.json
+              - sh
+              - -c
+              - cp /etc/openclaw-seed/openclaw.json /etc/openclaw/openclaw.json && chmod 600 /etc/openclaw/openclaw.json
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true

--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -226,6 +226,9 @@ spec:
   #    openclaw-config-secrets Secret (see the ES split patch below); the reloader annotation
   #    lists both Secrets so a change to either restarts the pod. LITELLM_KEY /
   #    OPENCLAW_GATEWAY_TOKEN stay on openclaw-secrets.
+  #  - Control UI origin: OPENCLAW_CONTROL_UI_ORIGIN feeds gateway.controlUi.allowedOrigins
+  #    in openclaw.json (expanded by OpenClaw itself, not Flux). ${domain_name} is a Flux
+  #    postBuild var resolved after spec.patches, same as the ingress hostname.
   # yamllint disable-line rule:indentation
   - patch: |-
       apiVersion: apps/v1
@@ -272,6 +275,8 @@ spec:
                     key: OWNER_WHATSAPP_NUMBER
               - name: OPENCLAW_STATE_DIR
                 value: /home/node/.openclaw
+              - name: OPENCLAW_CONTROL_UI_ORIGIN
+                value: https://openclaw.${domain_name}
               - name: OPENCLAW_DATA_DIR
                 $patch: delete
               readinessProbe:

--- a/clusters/homelab/services/ai/openclaw/openclaw.json
+++ b/clusters/homelab/services/ai/openclaw/openclaw.json
@@ -112,6 +112,19 @@
     "auth": {
       "mode": "token",
       "token": "${OPENCLAW_GATEWAY_TOKEN}"
+    },
+    // bind=lan requires the Control UI's browser origin to be listed explicitly (no
+    // wildcards allowed) or the gateway rejects it with "Browser origin not allowed".
+    // ${OPENCLAW_CONTROL_UI_ORIGIN} is expanded by OpenClaw itself from the container
+    // env at startup (NOT a Flux postBuild var) -- same mechanism as ${LITELLM_KEY} /
+    // ${OWNER_WHATSAPP_NUMBER} above. Localhost entries stay so port-forward/in-cluster
+    // access keeps working.
+    "controlUi": {
+      "allowedOrigins": [
+        "${OPENCLAW_CONTROL_UI_ORIGIN}",
+        "http://localhost:18789",
+        "http://127.0.0.1:18789"
+      ]
     }
   },
 

--- a/clusters/homelab/services/ai/openclaw/openclaw.json
+++ b/clusters/homelab/services/ai/openclaw/openclaw.json
@@ -180,5 +180,33 @@
   // enabled.
   "diagnostics": {
     "enabled": true
+  },
+
+  // Accepted risk: the pod's `fsGroup: 1000` (apps/subsystems/ai/openclaw/deployment.yaml,
+  // required so the non-root, uid-1000 gateway can write its PVC-backed state) makes these
+  // three PVC paths group-writable/group-readable by design -- there's no fsGroup mode that
+  // keeps a shared PVC writable for uid 1000 without also grouping in gid 1000. Only that one
+  // gateway process ever runs as gid 1000, so this is not exploitable in this single-tenant,
+  // single-operator pod (see OpenClaw's own "personal assistant trust model" note:
+  // docs.openclaw.ai/gateway/security -- one trusted operator boundary per gateway; someone
+  // able to touch Gateway host state is already treated as a trusted operator). Leave the
+  // deep-probe `operator.read` finding and any other future finding unsuppressed.
+  "security": {
+    "audit": {
+      "suppressions": [
+        {
+          "checkId": "fs.credentials_dir.perms_writable",
+          "reason": "fsGroup:1000 group-writable credentials dir; single-tenant pod, gid 1000 is only the gateway."
+        },
+        {
+          "checkId": "fs.state_dir.perms_group_writable",
+          "reason": "fsGroup:1000 group-writable state dir; single-tenant pod, gid 1000 is only the gateway."
+        },
+        {
+          "checkId": "fs.sessions_store.perms_readable",
+          "reason": "fsGroup:1000 group-readable sessions store; single-tenant pod, gid 1000 is only the gateway."
+        }
+      ]
+    }
   }
 }

--- a/clusters/homelab/services/ai/openclaw/openclaw.json
+++ b/clusters/homelab/services/ai/openclaw/openclaw.json
@@ -87,10 +87,16 @@
   },
 
   // Inbound point for n8n / Alertmanager relays (see n8n's notify-subworkflow.json).
+  // allowedAgentIds/defaultSessionKey per `openclaw security audit` findings
+  // hooks.allowed_agent_ids_unrestricted (CRITICAL) / hooks.default_session_key_unset (WARN):
+  // without an explicit allowlist, hook requests can target any agent; "main" is the
+  // gateway's only configured agent id (agents.defaults has no named agent map here).
   "hooks": {
     "enabled": true,
     "token": "${OPENCLAW_HOOKS_TOKEN}",
-    "path": "/hooks/agent"
+    "path": "/hooks/agent",
+    "allowedAgentIds": ["main"],
+    "defaultSessionKey": "hook:ingress"
   },
 
   // Jobs are not declared statically here -- `cron.jobs` isn't part of the config schema
@@ -111,7 +117,14 @@
     "port": 18789,
     "auth": {
       "mode": "token",
-      "token": "${OPENCLAW_GATEWAY_TOKEN}"
+      "token": "${OPENCLAW_GATEWAY_TOKEN}",
+      // Per `openclaw security audit` finding gateway.auth_no_rate_limit (WARN): throttle
+      // gateway login/auth attempts to reduce token brute-force risk.
+      "rateLimit": {
+        "maxAttempts": 10,
+        "windowMs": 60000,
+        "lockoutMs": 300000
+      }
     },
     // bind=lan requires the Control UI's browser origin to be listed explicitly (no
     // wildcards allowed) or the gateway rejects it with "Browser origin not allowed".


### PR DESCRIPTION
## Summary
- Fixes the Control UI's "Browser origin not allowed" error when visiting `https://openclaw.<domain>` post-#750: OpenClaw's gateway (`bind=lan`) only allows browser origins explicitly listed in `gateway.controlUi.allowedOrigins`, and the cluster `openclaw.json` didn't set that field, so only the auto-seeded `localhost:18789` origins were allowed. Wildcards aren't supported — a full origin is required.
- Applies four fixes from the operator's `openclaw security audit` run against the live gateway:
  - **`hooks.allowed_agent_ids_unrestricted` (CRITICAL)**: hook requests (n8n/Alertmanager relays) could target any agent with no allowlist. Add `hooks.allowedAgentIds: ["main"]` — the gateway's only configured agent id (`agents.defaults` here has no named agent map).
  - **`hooks.default_session_key_unset` (WARN)**: add `hooks.defaultSessionKey: "hook:ingress"` as a stable fallback session key for hook deliveries.
  - **`gateway.auth_no_rate_limit` (WARN)**: add `gateway.auth.rateLimit: {maxAttempts: 10, windowMs: 60000, lockoutMs: 300000}` to throttle gateway auth attempts.
  - **`fs.config.perms_world_readable` (CRITICAL)**: the ConfigMap-seeded `/etc/openclaw/openclaw.json` landed at mode 644. The `openclaw-config-seed` initContainer now chmods it to 600 after copying (shell form: `cp ... && chmod 600 ...`); the file is owned by uid 1000 (the gateway's runAsUser), so 600 stays readable.
- **Accepted + suppressed** the three PVC filesystem-perms findings called out as out-of-scope above (`fs.credentials_dir.perms_writable` CRITICAL, `fs.state_dir.perms_group_writable` WARN, `fs.sessions_store.perms_readable` WARN): they're an unavoidable consequence of the pod's `fsGroup: 1000` (`apps/subsystems/ai/openclaw`'s Deployment, required for the non-root uid-1000 gateway to write its PVC-backed state) — there's no fsGroup mode that keeps a shared PVC writable for uid 1000 without also grouping in gid 1000. Only the gateway process ever runs as gid 1000, so this isn't exploitable in this single-tenant, single-operator pod (matches OpenClaw's own "personal assistant trust model" — one trusted operator boundary per gateway). Suppressed via the schema-native `security.audit.suppressions` array (`checkId` exact match) rather than just documenting the acceptance, so the audit's own summary/counts stay accurate. The deep-probe `operator.read` finding is deliberately left unsuppressed, pending a separate operator decision.

### Files changed
- `clusters/homelab/services/ai/openclaw/openclaw.json`: add `gateway.controlUi.allowedOrigins` (`${OPENCLAW_CONTROL_UI_ORIGIN}` + two localhost origins), `hooks.allowedAgentIds`, `hooks.defaultSessionKey`, `gateway.auth.rateLimit`, and `security.audit.suppressions` (the three fsGroup-related findings above, each with an inline `reason`).
- `clusters/homelab/kustomizations/apps-ai.yaml`: consolidated openclaw Deployment patch gains `OPENCLAW_CONTROL_UI_ORIGIN` env and switches the `openclaw-config-seed` initContainer to shell form to chmod the seeded config to 600. Still a single patch entry for the Deployment.

## Test plan
- [x] `openclaw config validate` (openclaw@2026.7.1, `${VAR}`s dummy-substituted) against the resulting `openclaw.json`: `valid: true`, no schema errors. `hooks.allowedAgentIds`, `hooks.defaultSessionKey`, `gateway.auth.rateLimit`, and `security.audit.suppressions` all match the v2026.7.1 schema exactly as proposed — no shape corrections needed (`security.audit.suppressions` verified against the shipped `dist/zod-schema-*.js`: `{checkId, titleIncludes?, detailIncludes?, reason?}`, exact `checkId` match, no prefix matching).
- [x] `openclaw security audit` against the same dummy-substituted config: `hooks.allowed_agent_ids_unrestricted`, `hooks.default_session_key_unset`, and `gateway.auth_no_rate_limit` no longer appear (confirmed present in a pre-fix baseline run of the same config). The remaining `fs.config.perms_world_readable` finding is expected from the local test file's own perms, not the JSON content — that's fixed cluster-side by the initContainer chmod.
- [x] `openclaw security audit --deep` before/after, using a local harness reproducing the fsGroup-style permission conditions (group-writable state/credentials dirs, group-readable sessions store): before shows exactly `fs.credentials_dir.perms_writable`, `fs.state_dir.perms_group_writable`, `fs.sessions_store.perms_readable` plus 5 unrelated harness-only findings (short dummy tokens, no live gateway, etc.); after adding the suppressions, all three move into `suppressedFindings` with their `reason`, all 5 unrelated findings are unchanged, and the only additions are two expected self-documenting findings the suppression mechanism itself always surfaces when suppressions are configured (`config.insecure_or_dangerous_flags`, `security.audit.suppressions.active`) — by design, so a suppressed finding never goes unnoticed.
- [x] `flux build kustomization apps-ai --dry-run`: openclaw Deployment env includes `OPENCLAW_CONTROL_UI_ORIGIN`; the `openclaw-config-seed` initContainer command is `sh -c "cp ... && chmod 600 ..."`; Deployment is still modified by exactly one patch entry.
- [x] `flux build kustomization config-services --dry-run`: `openclaw-config` ConfigMap's `openclaw.json` has `gateway.controlUi.allowedOrigins`, `hooks.allowedAgentIds`, `hooks.defaultSessionKey`, `gateway.auth.rateLimit`, and `security.audit.suppressions`, all `${VAR}`s left literal, and parses as valid JSON5.
- [x] `kubeconform -strict` on both dry-run renders: all resources valid.
- [x] `pre-commit run --files clusters/homelab/services/ai/openclaw/openclaw.json clusters/homelab/kustomizations/apps-ai.yaml clusters/homelab/services/ai/kustomization.yaml` — all hooks pass, including the `validate-k8s` kubeconform check.

Refs #740.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
