### PR TITLE
feat(cluster-homelab): enable openclaw memory (lancedb), lobster, web tools, and DM isolation

### DIFF
--- a/clusters/homelab/services/ai/openclaw/openclaw.json
+++ b/clusters/homelab/services/ai/openclaw/openclaw.json
@@ -1,6 +1,4 @@
 {
-  // All model calls are routed through the in-cluster LiteLLM gateway -- no direct
-  // provider API keys here.
   "models": {
     "providers": {
       "litellm": {
@@ -8,9 +6,6 @@
         "apiKey": "${LITELLM_KEY}",
         "api": "openai-completions",
         "timeoutSeconds": 120,
-        // Each catalog entry must be an object with both `id` and a display `name` --
-        // a bare string or an id-only object fails schema validation
-        // ("models.providers.<id>.models.N[.name]: Invalid input").
         "models": [
           {
             "id": "deepseek/deepseek-v4-pro",
@@ -25,8 +20,18 @@
             "name": "DeepSeek v4 Flash",
             "compat": { "thinkingFormat": "openrouter" }
           },
-          { "id": "google/gemini-3.5-flash-lite", "name": "Gemini 3.5 Flash Lite" },
-          { "id": "openai/gpt-5-nano", "name": "GPT-5 Nano" }
+          {
+            "id": "google/gemini-3.5-flash-lite",
+            "name": "Gemini 3.5 Flash Lite"
+          },
+          {
+            "id": "openai/gpt-5-nano",
+            "name": "OpenAI GPT-5 Nano"
+          },
+          {
+            "id": "openrouter/openai/text-embedding-3-small",
+            "name": "OpenAI Text Embedding 3 Small"
+          }
         ]
       }
     }
@@ -34,53 +39,59 @@
 
   "agents": {
     "defaults": {
+      "bootstrapMaxChars": 20000,
+      "bootstrapTotalMaxChars": 150000,
+      "contextInjection": "always",
       "model": {
         "primary": "litellm/deepseek/deepseek-v4-pro",
         "fallbacks": [
+          "deepseek/deepseek-v4-flash",
           "litellm/google/gemini-3.5-flash-lite",
           "litellm/openai/gpt-5-nano"
         ]
       }
-      // No memory/dreaming block here -- `agents.defaults` has no `memory` key (an unknown
-      // key fails the whole object's validation). Dreaming lives under
-      // `plugins.entries.memory-core.config.dreaming.enabled` and defaults to off, which is
-      // what we want day-one.
     }
   },
 
-  // WhatsApp-only (Baileys QR-pairing) for day one; Telegram is a trivial later add.
   "channels": {
+    "telegram": {
+      "enabled": false,
+      "dmPolicy": "pairing",
+      "groupPolicy": "allowlist"
+    },
     "whatsapp": {
       "enabled": true,
       "dmPolicy": "pairing",
-      "allowFrom": ["${OWNER_WHATSAPP_NUMBER}"],
+      "allowFrom": [
+        "${OWNER_WHATSAPP_NUMBER}"
+      ],
       // Groups are locked down by default: `groupPolicy: allowlist` means no group is
       // active until its ID is explicitly added. Per-group `requireMention` lives under
       // `channels.whatsapp.groups.<groupId>` (a map keyed by real group ID) and is set
       // once a group is allowlisted -- there is no channel-wide requireMention toggle.
-      "groupPolicy": "allowlist"
+      "groupPolicy": "allowlist",
+      "selfChatMode": true
     }
   },
 
   "mcp": {
     "servers": {
-      // Aggregated read-only tool access via LiteLLM's own /mcp endpoint.
       "litellm-readonly": {
         "url": "http://litellm.ai.svc.cluster.local:4000/mcp",
         "transport": "streamable-http",
-        // `auth` is an enum whose only value is "oauth" (for the `openclaw mcp login`
-        // flow) -- a static bearer token goes in `headers` instead.
         "headers": {
           "Authorization": "Bearer ${LITELLM_KEY}"
         }
       },
-      // Direct to Home Assistant's MCP server (bypasses LiteLLM), restricted to
-      // read/get/list tools only -- writes stay disabled until Phase 2 approvals land.
       "home-assistant": {
         "url": "http://mcp-home-assistant.ai.svc.cluster.local:8086/mcp",
         "transport": "streamable-http",
         "toolFilter": {
-          "include": ["get_*", "list_*", "read_*"]
+          "include": [
+            "get_*",
+            "list_*",
+            "read_*"
+          ]
         }
       }
     }
@@ -95,7 +106,9 @@
     "enabled": true,
     "token": "${OPENCLAW_HOOKS_TOKEN}",
     "path": "/hooks/agent",
-    "allowedAgentIds": ["main"],
+    "allowedAgentIds": [
+      "main"
+    ],
     "defaultSessionKey": "hook:ingress"
   },
 
@@ -107,12 +120,7 @@
   },
 
   "gateway": {
-    // Headless/server deploy: gateway.mode must be set explicitly or OpenClaw refuses to
-    // start ("Gateway start blocked: existing config is missing gateway.mode").
     "mode": "local",
-    // `bind` is a mode enum (loopback|lan|tailnet|auto|custom), NOT a host:port string --
-    // "lan" listens on 0.0.0.0 so the kubelet probes, ClusterIP Service, and Ingress can
-    // reach the gateway on the pod IP. The listen port is a separate field.
     "bind": "lan",
     "port": 18789,
     "auth": {
@@ -126,12 +134,10 @@
         "lockoutMs": 300000
       }
     },
+    "bundledDiscovery": "compat",
     // bind=lan requires the Control UI's browser origin to be listed explicitly (no
     // wildcards allowed) or the gateway rejects it with "Browser origin not allowed".
-    // ${OPENCLAW_CONTROL_UI_ORIGIN} is expanded by OpenClaw itself from the container
-    // env at startup (NOT a Flux postBuild var) -- same mechanism as ${LITELLM_KEY} /
-    // ${OWNER_WHATSAPP_NUMBER} above. Localhost entries stay so port-forward/in-cluster
-    // access keeps working.
+    // Localhost entries stay so port-forward/in-cluster access keeps working.
     "controlUi": {
       "allowedOrigins": [
         "${OPENCLAW_CONTROL_UI_ORIGIN}",
@@ -142,29 +148,111 @@
   },
 
   // Lockdown: computer/browser tool, elevated/shell/exec, and third-party in-process
-  // plugins are all disabled day-one. See ai/README.md Prerequisites for the roadmap.
+  // plugins are all disabled.
   "tools": {
-    "deny": ["exec", "browser"],
+    "deny": [
+      "exec",
+      "browser"
+    ],
     "elevated": {
       "enabled": false
+    },
+    "web": {
+      "search": {
+        "enabled": true
+      },
+      "fetch": {
+        "enabled": true
+      }
     }
   },
 
   // plugins.allow is keyed by plugin ID (e.g. "whatsapp"), NOT the npm package name
   // ("@openclaw/whatsapp") -- the package name is silently treated as "not found" and the
-  // real plugin ends up omitted from the allowlist. These two (the WhatsApp/Baileys channel
-  // + the operator Prometheus diagnostics endpoint) are baked into the custom image and
-  // reseeded into the PVC by its entrypoint on every start -- no runtime clawhub fetch.
+  // real plugin ends up omitted from the allowlist.
   "plugins": {
     "allow": [
-      "whatsapp",
-      "diagnostics-prometheus"
-    ]
+      "diagnostics-prometheus",
+      "litellm",
+      "lobster",
+      "memory-lancedb",
+      "telegram",
+      "whatsapp"
+    ],
+    "slots": {
+      "memory": "memory-lancedb"
+    },
+    "entries": {
+      "diagnostics-prometheus": {
+        "enabled": true
+      },
+      "litellm": {
+        "enabled": true
+      },
+      "lobster": {
+        "enabled": true
+      },
+      "memory-lancedb": {
+        "enabled": true,
+        "config": {
+          "autoCapture": true,
+          "autoRecall": true,
+          "dreaming": {
+            "enabled": true
+          },
+          "embedding": {
+            "provider": "litellm",
+            "model": "openrouter/openai/text-embedding-3-small"
+          }
+        }
+      },
+      "telegram": {
+        "enabled": true
+      },
+      "whatsapp": {
+        "enabled": true
+      }
+    }
   },
 
   "skills": {
     "workshop": {
       "autonomous": {
+        "enabled": false
+      }
+    },
+    "entries": {
+      "1password": {
+        "enabled": false
+      },
+      "apple-notes": {
+        "enabled": false
+      },
+      "bear-notes": {
+        "enabled": false
+      },
+      "clawhub": {
+        "enabled": false
+      },
+      "gemini": {
+        "enabled": false
+      },
+      "eightctl": {
+        "enabled": false
+      },
+      "notion": {
+        "enabled": false
+      },
+      "ordercli": {
+        "enabled": false
+      },
+      "oracle": {
+        "enabled": false
+      },
+      "trello": {
+        "enabled": false
+      },
+      "things-mac": {
         "enabled": false
       }
     }
@@ -203,5 +291,9 @@
         }
       ]
     }
+  },
+
+  "session": {
+    "dmScope": "per-channel-peer"
   }
 }


### PR DESCRIPTION
Expand the cluster-owned openclaw.json now that the extra plugins are baked into the image:

- Memory:
  - enable memory-lancedb (plugins.slots.memory) with:
    - autoRecall on,
    - autoCapture off,
    - dreaming on,
    - embeddings via LiteLLM (new catalog entry openrouter/openai/text-embedding-3-small).
- Enable the lobster action-approval plugin.
- Enable the built-in web.search and web.fetch tools.
- Isolate DM sessions per sender (session.dmScope: per-channel-peer), clearing the channels.whatsapp.dm.scope_main_multiuser audit finding; enable whatsapp selfChatMode.
- Add a (disabled) telegram channel + plugin entry for a later trivial enable.
- gateway.bundledDiscovery: compat (quiets the legacy plugins.allow warning).
- Tune agents.defaults context (bootstrapMaxChars/bootstrapTotalMaxChars/ contextInjection) and add deepseek-v4-flash to the model fallbacks.
- Explicitly disable unused skills; drop stale explanatory comments.