### PR TITLE
feat(cluster-homelab): deploy apps-ai v0.6.9 + watch litellm-model-config for prompt re-render

### DIFF
--- a/clusters/homelab/services/ai/kustomization.yaml
+++ b/clusters/homelab/services/ai/kustomization.yaml
@@ -15,6 +15,12 @@ configMapGenerator:
   options:
     annotations:
       kustomize.toolkit.fluxcd.io/substitute: disabled
+    # helm-controller only re-reconciles the litellm HelmRelease on a change to this valuesFrom
+    # ConfigMap when it carries this label. Without it, a model-config.yaml edit isn't applied
+    # until the HR's reconcile interval; with it, the HR re-renders instantly and the chart's
+    # own checksum/config annotation rolls the litellm pod with the new model catalog.
+    labels:
+      reconcile.fluxcd.io/watch: "Enabled"
     disableNameSuffixHash: true
 # Interim cluster-side ownership of openclaw's config (homelab-ops-kubernetes-clusters#740):
 # the module's own ConfigMap of the same name is deleted via a patch in

--- a/clusters/homelab/sources/apps-ai.yaml
+++ b/clusters/homelab/sources/apps-ai.yaml
@@ -14,5 +14,5 @@ spec:
     !/apps/subsystems/ai
   interval: 1m0s
   ref:
-    tag: apps-ai-v0.6.8
+    tag: apps-ai-v0.6.9
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git


### PR DESCRIPTION
## Changes
- **Bump `sources/apps-ai.yaml` v0.6.8 → v0.6.9** — deploys the openclaw entrypoint-retighten image (`fad0268b`) + `fsGroupChangePolicy: OnRootMismatch`, and the litellm Deployment's Stakater Reloader annotation (secret rotation).
- **Label `litellm-model-config` with `reconcile.fluxcd.io/watch: "Enabled"`** — helm-controller only watches a `valuesFrom` ConfigMap (and re-renders the HR instantly on its change) when it carries this label. Without it, a `model-config.yaml` edit was only applied on the HR's reconcile interval. With it: edit → instant HR re-render → the chart's `checksum/config` rolls the litellm pod with the new model catalog.

## The LiteLLM reload split (for the record)
- **`valuesFrom` config** (`litellm-model-config`) → Flux watch-label + the chart's built-in `checksum/config`. (Reloader can't trigger a HR re-render, so it's the wrong tool here.)
- **`env`/`envFrom` secrets** (`litellm-secrets`, CNPG DB cred) → Stakater Reloader (in the module, v0.6.9); the chart doesn't checksum those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyhJGPFxahn68H5Kv35obL
