### PR TITLE
chore(cluster-nas): deploy infra-clusterops-core (v0.3.0 -> v0.3.1)

### DIFF
--- a/clusters/nas/sources/infra-clusterops-core.yaml
+++ b/clusters/nas/sources/infra-clusterops-core.yaml
@@ -12,5 +12,5 @@ spec:
     !/infrastructure/subsystems/clusterops-core
   interval: 1m0s
   ref:
-    tag: infra-clusterops-core-v0.3.0
+    tag: infra-clusterops-core-v0.3.1
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git


### PR DESCRIPTION
## What this does

Bumps `clusters/nas/sources/infra-clusterops-core.yaml` `ref.tag` from `infra-clusterops-core-v0.3.0` to `infra-clusterops-core-v0.3.1`, which adopts `CancelHealthCheckOnNewRevision` on kustomize-controller (helm-controller is untouched).

This is the **nas half** of the staged rollout in #763 — homelab is deliberately held back on v0.3.0 pending a 48h soak on nas before it gets the same bump.

## Post-merge verification

```bash
kubectl -n flux-system get deploy kustomize-controller \
  -o jsonpath='{.spec.template.spec.containers[0].args}' | tr ',' '\n'
# expect StrictPostBuildSubstitutions=true AND CancelHealthCheckOnNewRevision=true

kubectl -n flux-system get deploy helm-controller \
  -o jsonpath='{.spec.template.spec.containers[0].args}' | tr ',' '\n'
# expect OOMWatch only -- byte-identical to before
```

## References

- #763 — rollout issue (this repo)
- ppat/homelab-ops-kubernetes-apps#3320 — decision record

## CI notes

Known-red across all modules in this repo: both `diff-changes` variants and `validate-k8s-manifests`. Real signal is the lint job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
