### PR TITLE
chore(cluster-homelab): deploy infra-clusterops-core (v0.3.0 -> v0.3.1)

### DIFF
--- a/clusters/homelab/sources/infra-clusterops-core.yaml
+++ b/clusters/homelab/sources/infra-clusterops-core.yaml
@@ -12,5 +12,5 @@ spec:
     !/infrastructure/subsystems/clusterops-core
   interval: 1m0s
   ref:
-    tag: infra-clusterops-core-v0.3.0
+    tag: infra-clusterops-core-v0.3.1
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git


### PR DESCRIPTION
## What this does

Bumps `clusters/homelab/sources/infra-clusterops-core.yaml` `ref.tag` from `infra-clusterops-core-v0.3.0` to `infra-clusterops-core-v0.3.1`.

This is the **homelab half** of the staged rollout in #763. nas landed first (#767), merged, and verified live clean: both feature gates present on kustomize-controller, helm-controller unchanged, Flux v2.9.3, zero pod restarts, all Kustomizations Ready. This completes the rollout.

homelab is the larger cluster (19 module Kustomizations vs nas's 11) with a 6-deep `dependsOn` chain, so this is the higher-exposure half of the rollout.

The release carries **two** changes, both riding the same tag:

- `--feature-gates=CancelHealthCheckOnNewRevision=true` added to kustomize-controller's args (helm-controller is untouched).
- Flux distribution bump v2.9.2 -> v2.9.3.

Both revert together if the tag is rolled back.

## Post-merge verification

```bash
kubectl -n flux-system get deploy kustomize-controller \
  -o jsonpath='{.spec.template.spec.containers[0].args}' | tr ',' '\n'
# expect StrictPostBuildSubstitutions=true AND CancelHealthCheckOnNewRevision=true

kubectl -n flux-system get deploy helm-controller \
  -o jsonpath='{.spec.template.spec.containers[0].args}' | tr ',' '\n'
# expect OOMWatch only -- byte-identical to before

kubectl get ns flux-system -o jsonpath='{.metadata.labels.app\.kubernetes\.io/version}'
# expect v2.9.3

kubectl -n flux-system get pods -o custom-columns='NAME:.metadata.name,RESTARTS:.status.containerStatuses[0].restartCount'
# expect no unexpected restarts post-rollout
```

## References

- #763 — rollout issue (this repo)
- ppat/homelab-ops-kubernetes-apps#3320 — decision record

## CI notes

Known-red across all modules in this repo: both `diff-changes` variants and `validate-k8s-manifests` — though these actually passed clean on #767, so treat a red here as worth a look rather than automatically ignorable. Real signal is the lint job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
