### PR TITLE
feat(kubernetes-api): read-only ClusterRole for the kubernetes MCP servers

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -106,6 +106,58 @@ jobs:
     with:
       git_ref: ${{ github.head_ref || github.ref }}
 
+  rbac-clusterrole-readonly:
+    needs: [detect-changes]
+    if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).kubernetes_any_changed == 'true' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    env:
+      # Pinned to the Kyverno CLI release matching the appVersion of the
+      # kyverno chart deployed by infra-security-core (see the apps repo's
+      # infrastructure/subsystems/security-core/kyverno/helm-release-kyverno.yaml),
+      # so the CLI's policy engine matches what's actually running.
+      KYVERNO_CLI_VERSION: v1.18.2
+      KYVERNO_CLI_SHA256: cb2feb8356149fd2fe774c894ccf0969f4a60a83867dd913af724f74ffbbc18b
+    steps:
+    - name: Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        fetch-depth: 1
+        persist-credentials: false
+
+    - name: Install Kyverno CLI
+      shell: bash
+      # yamllint disable-line rule:indentation
+      run: |
+        set -euo pipefail
+        curl -sL -o /tmp/kyverno-cli.tar.gz \
+          "https://github.com/kyverno/kyverno/releases/download/${KYVERNO_CLI_VERSION}/kyverno-cli_${KYVERNO_CLI_VERSION}_linux_x86_64.tar.gz"
+        echo "${KYVERNO_CLI_SHA256}  /tmp/kyverno-cli.tar.gz" | sha256sum -c -
+        mkdir -p "${RUNNER_TEMP}/kyverno-cli"
+        tar -xzf /tmp/kyverno-cli.tar.gz -C "${RUNNER_TEMP}/kyverno-cli" kyverno
+        echo "${RUNNER_TEMP}/kyverno-cli" >> "$GITHUB_PATH"
+
+    - name: Validate RBAC ClusterRoles are read-only (Kyverno CLI, no cluster required)
+      shell: bash
+      # yamllint disable-line rule:indentation
+      run: |
+        set -uo pipefail
+        # One `kyverno apply` invocation per cluster directory: every cluster
+        # defines a ClusterRole named mcp-kubernetes-readonly, and since
+        # ClusterRoles are cluster-scoped (no namespace to disambiguate them),
+        # loading two clusters' rbac/ directories into a single invocation
+        # makes the CLI's resource cache collide same-named resources from
+        # different clusters together, silently dropping one.
+        status=0
+        for dir in clusters/*/cluster/rbac; do
+          echo "::group::${dir}"
+          if ! kyverno apply ci/policy-tests/rbac-clusterrole-readonly.yaml --resource "${dir}/" --detailed-results; then
+            status=1
+          fi
+          echo "::endgroup::"
+        done
+        exit "${status}"
+
   renovate-config-check:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).renovate_any_changed == 'true' }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -106,58 +106,6 @@ jobs:
     with:
       git_ref: ${{ github.head_ref || github.ref }}
 
-  rbac-clusterrole-readonly:
-    needs: [detect-changes]
-    if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).kubernetes_any_changed == 'true' }}
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    env:
-      # Pinned to the Kyverno CLI release matching the appVersion of the
-      # kyverno chart deployed by infra-security-core (see the apps repo's
-      # infrastructure/subsystems/security-core/kyverno/helm-release-kyverno.yaml),
-      # so the CLI's policy engine matches what's actually running.
-      KYVERNO_CLI_VERSION: v1.18.2
-      KYVERNO_CLI_SHA256: cb2feb8356149fd2fe774c894ccf0969f4a60a83867dd913af724f74ffbbc18b
-    steps:
-    - name: Checkout
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        fetch-depth: 1
-        persist-credentials: false
-
-    - name: Install Kyverno CLI
-      shell: bash
-      # yamllint disable-line rule:indentation
-      run: |
-        set -euo pipefail
-        curl -sL -o /tmp/kyverno-cli.tar.gz \
-          "https://github.com/kyverno/kyverno/releases/download/${KYVERNO_CLI_VERSION}/kyverno-cli_${KYVERNO_CLI_VERSION}_linux_x86_64.tar.gz"
-        echo "${KYVERNO_CLI_SHA256}  /tmp/kyverno-cli.tar.gz" | sha256sum -c -
-        mkdir -p "${RUNNER_TEMP}/kyverno-cli"
-        tar -xzf /tmp/kyverno-cli.tar.gz -C "${RUNNER_TEMP}/kyverno-cli" kyverno
-        echo "${RUNNER_TEMP}/kyverno-cli" >> "$GITHUB_PATH"
-
-    - name: Validate RBAC ClusterRoles are read-only (Kyverno CLI, no cluster required)
-      shell: bash
-      # yamllint disable-line rule:indentation
-      run: |
-        set -uo pipefail
-        # One `kyverno apply` invocation per cluster directory: every cluster
-        # defines a ClusterRole named mcp-kubernetes-readonly, and since
-        # ClusterRoles are cluster-scoped (no namespace to disambiguate them),
-        # loading two clusters' rbac/ directories into a single invocation
-        # makes the CLI's resource cache collide same-named resources from
-        # different clusters together, silently dropping one.
-        status=0
-        for dir in clusters/*/cluster/rbac; do
-          echo "::group::${dir}"
-          if ! kyverno apply ci/policy-tests/rbac-clusterrole-readonly.yaml --resource "${dir}/" --detailed-results; then
-            status=1
-          fi
-          echo "::endgroup::"
-        done
-        exit "${status}"
-
   renovate-config-check:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).renovate_any_changed == 'true' }}

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -2,11 +2,13 @@
 # yamllint disable rule:line-length
 # Static analysis of security invariants — distinct from lint.yaml (which
 # only checks style/formatting via yamllint/markdownlint/commitlint/etc).
-# rbac-clusterroles statically validates the read-only RBAC ClusterRoles in
-# clusters/*/cluster/rbac/ against ci/policy-tests/rbac-clusterrole-readonly.yaml
-# using the Kyverno CLI (`kyverno apply`, no cluster required). That policy
-# is test-only: it lives under ci/ and, unlike policies/**, is never wired
-# up to a Flux Kustomization or applied to a cluster.
+# rbac-clusterroles statically validates the read-only RBAC ClusterRoles and
+# their ClusterRoleBindings in clusters/*/cluster/rbac/ against the two
+# policies in ci/policy-tests/ (rbac-clusterrole-readonly.yaml and
+# rbac-clusterrolebinding-roleref.yaml) using the Kyverno CLI (`kyverno
+# apply`, no cluster required). Those policies are test-only: they live
+# under ci/ and, unlike policies/**, are never wired up to a Flux
+# Kustomization or applied to a cluster.
 name: static-analysis
 
 on:
@@ -75,7 +77,7 @@ jobs:
           # just a pass/fail summary count. --remove-color strips ANSI codes
           # that would otherwise print as raw escape sequences in the
           # non-interactive Actions log.
-          if ! mise exec -- kyverno apply ci/policy-tests/rbac-clusterrole-readonly.yaml --resource "${dir}/" --table --detailed-results --remove-color; then
+          if ! mise exec -- kyverno apply ci/policy-tests/rbac-clusterrole-readonly.yaml ci/policy-tests/rbac-clusterrolebinding-roleref.yaml --resource "${dir}/" --table --detailed-results --remove-color; then
             status=1
           fi
           echo "::endgroup::"

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -66,7 +66,16 @@ jobs:
         status=0
         for dir in clusters/*/cluster/rbac; do
           echo "::group::${dir}"
-          if ! mise exec -- kyverno apply ci/policy-tests/rbac-clusterrole-readonly.yaml --resource "${dir}/" --detailed-results; then
+          echo "Resource files loaded from ${dir}:"
+          find "${dir}" -maxdepth 1 -type f -name '*.yaml' | sort
+          echo
+          # --table + --detailed-results renders one row per (rule, resource)
+          # pair with its pass/fail outcome and message, so the log itself
+          # shows every rule that ran against every matched resource, not
+          # just a pass/fail summary count. --remove-color strips ANSI codes
+          # that would otherwise print as raw escape sequences in the
+          # non-interactive Actions log.
+          if ! mise exec -- kyverno apply ci/policy-tests/rbac-clusterrole-readonly.yaml --resource "${dir}/" --table --detailed-results --remove-color; then
             status=1
           fi
           echo "::endgroup::"

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -38,28 +38,21 @@ jobs:
       # kyverno chart deployed by infra-security-core (see the apps repo's
       # infrastructure/subsystems/security-core/kyverno/helm-release-kyverno.yaml),
       # so the CLI's policy engine matches what's actually running.
-      KYVERNO_CLI_VERSION: v1.18.2
-      KYVERNO_CLI_SHA256: cb2feb8356149fd2fe774c894ccf0969f4a60a83867dd913af724f74ffbbc18b
+      # renovate: datasource=github-releases depName=kyverno/kyverno
+      KYVERNO_CLI_VERSION: "v1.18.2"
     steps:
-    - name: Checkout
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: Setup repository and tools
+      uses: ppat/homelab-ops-actions/actions/setup-repository-tools@f1ae73db4ab080b7e8dc66d078e5905d5ca526cb # v2.1.0
       with:
-        fetch-depth: 1
-        persist-credentials: false
-
-    - name: Install Kyverno CLI
-      shell: bash
-      # yamllint disable-line rule:indentation
-      run: |
-        set -euo pipefail
-        curl -sL -o /tmp/kyverno-cli.tar.gz \
-          "https://github.com/kyverno/kyverno/releases/download/${KYVERNO_CLI_VERSION}/kyverno-cli_${KYVERNO_CLI_VERSION}_linux_x86_64.tar.gz"
-        echo "${KYVERNO_CLI_SHA256}  /tmp/kyverno-cli.tar.gz" | sha256sum -c -
-        mkdir -p "${RUNNER_TEMP}/kyverno-cli"
-        tar -xzf /tmp/kyverno-cli.tar.gz -C "${RUNNER_TEMP}/kyverno-cli" kyverno
-        echo "${RUNNER_TEMP}/kyverno-cli" >> "$GITHUB_PATH"
+        current_git_ref: ${{ github.head_ref || github.ref }}
+        current_repository: ${{ github.repository }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        mise_toml: |
+          [tools]
+          kyverno = "${{ env.KYVERNO_CLI_VERSION }}"
 
     - name: Validate RBAC ClusterRoles are read-only (Kyverno CLI, no cluster required)
+      working-directory: ./current
       shell: bash
       # yamllint disable-line rule:indentation
       run: |
@@ -73,7 +66,7 @@ jobs:
         status=0
         for dir in clusters/*/cluster/rbac; do
           echo "::group::${dir}"
-          if ! kyverno apply ci/policy-tests/rbac-clusterrole-readonly.yaml --resource "${dir}/" --detailed-results; then
+          if ! mise exec -- kyverno apply ci/policy-tests/rbac-clusterrole-readonly.yaml --resource "${dir}/" --detailed-results; then
             status=1
           fi
           echo "::endgroup::"

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -13,9 +13,11 @@ on:
   pull_request:
     paths:
     - '.github/workflows/static-analysis.yaml'
-    - 'clusters/**/*.yaml'
-    - 'ci/**/*.yaml'
-    - 'policies/**/*.yaml'
+    # Scoped to exactly what this analyses and what does the analysing -- the RBAC
+    # manifests under test and the policy asserting their invariants. Broader globs would
+    # run it on every clusters/ or ci/ edit for no signal.
+    - 'clusters/*/cluster/rbac/**'
+    - 'ci/policy-tests/**'
   schedule:
   - cron: '0 5 * * 1'
   workflow_dispatch:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -1,0 +1,79 @@
+---
+# yamllint disable rule:line-length
+# Static analysis of security invariants — distinct from lint.yaml (which
+# only checks style/formatting via yamllint/markdownlint/commitlint/etc).
+# rbac-clusterroles statically validates the read-only RBAC ClusterRoles in
+# clusters/*/cluster/rbac/ against ci/policy-tests/rbac-clusterrole-readonly.yaml
+# using the Kyverno CLI (`kyverno apply`, no cluster required). That policy
+# is test-only: it lives under ci/ and, unlike policies/**, is never wired
+# up to a Flux Kustomization or applied to a cluster.
+name: static-analysis
+
+on:
+  pull_request:
+    paths:
+    - '.github/workflows/static-analysis.yaml'
+    - 'clusters/**/*.yaml'
+    - 'ci/**/*.yaml'
+    - 'policies/**/*.yaml'
+  schedule:
+  - cron: '0 5 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  rbac-clusterroles:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    env:
+      # Pinned to the Kyverno CLI release matching the appVersion of the
+      # kyverno chart deployed by infra-security-core (see the apps repo's
+      # infrastructure/subsystems/security-core/kyverno/helm-release-kyverno.yaml),
+      # so the CLI's policy engine matches what's actually running.
+      KYVERNO_CLI_VERSION: v1.18.2
+      KYVERNO_CLI_SHA256: cb2feb8356149fd2fe774c894ccf0969f4a60a83867dd913af724f74ffbbc18b
+    steps:
+    - name: Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        fetch-depth: 1
+        persist-credentials: false
+
+    - name: Install Kyverno CLI
+      shell: bash
+      # yamllint disable-line rule:indentation
+      run: |
+        set -euo pipefail
+        curl -sL -o /tmp/kyverno-cli.tar.gz \
+          "https://github.com/kyverno/kyverno/releases/download/${KYVERNO_CLI_VERSION}/kyverno-cli_${KYVERNO_CLI_VERSION}_linux_x86_64.tar.gz"
+        echo "${KYVERNO_CLI_SHA256}  /tmp/kyverno-cli.tar.gz" | sha256sum -c -
+        mkdir -p "${RUNNER_TEMP}/kyverno-cli"
+        tar -xzf /tmp/kyverno-cli.tar.gz -C "${RUNNER_TEMP}/kyverno-cli" kyverno
+        echo "${RUNNER_TEMP}/kyverno-cli" >> "$GITHUB_PATH"
+
+    - name: Validate RBAC ClusterRoles are read-only (Kyverno CLI, no cluster required)
+      shell: bash
+      # yamllint disable-line rule:indentation
+      run: |
+        set -uo pipefail
+        # One `kyverno apply` invocation per cluster directory: every cluster
+        # defines a ClusterRole named mcp-kubernetes-readonly, and since
+        # ClusterRoles are cluster-scoped (no namespace to disambiguate them),
+        # loading two clusters' rbac/ directories into a single invocation
+        # makes the CLI's resource cache collide same-named resources from
+        # different clusters together, silently dropping one.
+        status=0
+        for dir in clusters/*/cluster/rbac; do
+          echo "::group::${dir}"
+          if ! kyverno apply ci/policy-tests/rbac-clusterrole-readonly.yaml --resource "${dir}/" --detailed-results; then
+            status=1
+          fi
+          echo "::endgroup::"
+        done
+        exit "${status}"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -229,8 +229,47 @@ diff.
 `cluster/rbac/` binds two Kubernetes API groups (`homelab-admins`,
 `homelab-users`) — backed by the OIDC identity provider from the apps repo's
 `security-extra` module — to the built-in `cluster-admin` and `view`
-`ClusterRole`s via `ClusterRoleBinding`s. These are cluster-wide and unrelated
-to any single module.
+`ClusterRole`s via `ClusterRoleBinding`s, plus any other cluster-wide
+`ClusterRole`/`ClusterRoleBinding` a specific identity needs. These are
+cluster-wide and unrelated to any single module: a cluster-wide grant is
+cluster policy, decided at the point of use, the same way `dependsOn` is (see
+[Wiring a module into a cluster](#wiring-a-module-into-a-cluster)) — a module
+ships only its own namespaced `ServiceAccount`, never a `ClusterRole` that
+binds itself into the wider cluster.
+
+Prefer an explicit read-only allow-list over binding the built-in `view`
+role. `view` excludes all cluster-scoped resources outright and only picks up
+namespaced CRDs whose operator opted in via the
+`rbac.authorization.k8s.io/aggregate-to-view` label, which most operators on
+a CRD-heavy cluster never set — so on this cluster `view` is both too narrow
+to be useful and misleading about its own coverage. Where an identity needs
+broad read-only visibility, build an explicit `ClusterRole` instead.
+
+RBAC allows and denies by kind, never by content: any kind that can embed
+another kind's content defeats a kind-level exclusion — wrapper kinds, or
+controller-written state/snapshot kinds that carry another kind's payload.
+When a group mixes credential-bearing and benign kinds, enumerate kinds
+rather than wildcarding the group, and re-check the enumeration whenever the
+operator adds a kind. `get`/`list`/`watch` is also not uniformly a read-only
+boundary: the API server maps HTTP method to RBAC verb for `*/proxy`
+subresources, and kubelet exposes GET routes for exec/attach/portForward, so
+`get` on `nodes/proxy` is code-execution-equivalent — treat proxy
+subresources as write access.
+
+Identities bound here must not live in `kube-system`: it's conventionally
+exempted from Pod Security Admission and from policy-engine namespace
+selectors, so a `ServiceAccount` placed there can silently inherit exemptions
+never intended for it. Where cross-cluster access forces a long-lived
+`ServiceAccount` token `Secret` (no in-cluster pod to hand a short-lived
+projected token to), document next to the `Secret` that revocation is
+deleting it — immediate, unlike a JWT that stays valid until its own expiry
+lapses.
+
+Identical RBAC across clusters aids review, but a cluster holding
+higher-value data warrants a narrower grant; where two clusters' otherwise-
+identical roles diverge, the narrower one should carry a comment stating it's
+a strict subset of the other and naming the exact divergence — the subset
+property itself isn't something CI can check.
 
 ## Policy enforcement
 

--- a/ci/policy-tests/rbac-clusterrole-readonly.yaml
+++ b/ci/policy-tests/rbac-clusterrole-readonly.yaml
@@ -36,12 +36,14 @@ metadata:
     policies.kyverno.io/title: RBAC ClusterRole Read-Only Invariants (CI test only)
     policies.kyverno.io/category: CI
     policies.kyverno.io/severity: high
-    policies.kyverno.io/subject: ClusterRole
+    policies.kyverno.io/subject: ClusterRole, ClusterRoleBinding
     policies.kyverno.io/description: >-
       Statically validates that the read-only RBAC ClusterRoles under
       clusters/*/cluster/rbac/ cannot mutate cluster state, cannot
       exec/attach/portForward via nodes/proxy, cannot read core Secrets, and
-      cannot read plaintext-bearing generators.external-secrets.io kinds.
+      cannot read plaintext-bearing generators.external-secrets.io kinds —
+      and that no ClusterRoleBinding subject named mcp-kubernetes* is ever
+      pointed at anything other than the mcp-kubernetes-readonly ClusterRole.
       Run only via `kyverno apply` in CI; not deployed to a cluster.
 spec:
   validationFailureAction: Enforce
@@ -75,6 +77,33 @@ spec:
             only ever probe its own permissions) and confers no
             cross-identity information — and only when the rule grants
             nothing else alongside it.
+  - name: mcp-kubernetes-serviceaccount-must-bind-readonly-role
+    match:
+      any:
+      - resources:
+          kinds:
+          - ClusterRoleBinding
+    validate:
+      cel:
+        expressions:
+        - expression: >-
+            !has(object.subjects) ||
+            !object.subjects.exists(s, s.kind == 'ServiceAccount' && s.name.startsWith('mcp-kubernetes')) ||
+            (object.roleRef.kind == 'ClusterRole' && object.roleRef.name == 'mcp-kubernetes-readonly')
+          message: >-
+            A ClusterRoleBinding has a ServiceAccount subject named
+            mcp-kubernetes* but its roleRef is not exactly {kind: ClusterRole,
+            name: mcp-kubernetes-readonly}. The four rules above only
+            constrain what is inside the mcp-kubernetes-readonly ClusterRole
+            itself — they say nothing about which role a binding actually
+            points an identity at. Repointing roleRef.name (e.g. to
+            cluster-admin) leaves that ClusterRole's rules untouched and
+            still perfectly read-only, while handing the same ServiceAccount
+            whatever roleRef now names instead: the single edit that most
+            completely defeats this entire policy's purpose while leaving
+            every other invariant here intact. Point roleRef at {kind:
+            ClusterRole, name: mcp-kubernetes-readonly}, or rename the
+            ServiceAccount if it genuinely needs different access.
   - name: no-nodes-proxy
     match:
       any:

--- a/ci/policy-tests/rbac-clusterrole-readonly.yaml
+++ b/ci/policy-tests/rbac-clusterrole-readonly.yaml
@@ -11,6 +11,15 @@
 # to catch a regression on the read-only RBAC ClusterRoles (currently
 # mcp-kubernetes-readonly.yaml on both clusters) before merge.
 #
+# Constrains what is INSIDE the mcp-kubernetes-readonly ClusterRole: no verb
+# outside get/list/watch, no nodes/proxy, no core Secrets, and an allow-list
+# on generators.external-secrets.io. The companion policy
+# rbac-clusterrolebinding-roleref.yaml (test-rbac-clusterrolebinding-roleref)
+# constrains which role is actually BOUND to the mcp-kubernetes ServiceAccount
+# — this file says nothing about that. Both must pass for the read-only
+# guarantee to hold: a role can be perfectly read-only in isolation and still
+# be defeated by a binding that points a subject at a different role instead.
+#
 # Written with CEL (`validate.cel.expressions`), not the JMESPath
 # `deny.conditions`/`pattern` style used elsewhere in policies/: Kyverno's
 # JMESPath condition operators (In/AnyIn/AllIn/Equals/...) wildcard-match
@@ -36,15 +45,15 @@ metadata:
     policies.kyverno.io/title: RBAC ClusterRole Read-Only Invariants (CI test only)
     policies.kyverno.io/category: CI
     policies.kyverno.io/severity: high
-    policies.kyverno.io/subject: ClusterRole, ClusterRoleBinding
+    policies.kyverno.io/subject: ClusterRole
     policies.kyverno.io/description: >-
       Statically validates that the read-only RBAC ClusterRoles under
       clusters/*/cluster/rbac/ cannot mutate cluster state, cannot
       exec/attach/portForward via nodes/proxy, cannot read core Secrets, and
-      cannot read plaintext-bearing generators.external-secrets.io kinds —
-      and that no ClusterRoleBinding subject named mcp-kubernetes* is ever
-      pointed at anything other than the mcp-kubernetes-readonly ClusterRole.
-      Run only via `kyverno apply` in CI; not deployed to a cluster.
+      cannot read plaintext-bearing generators.external-secrets.io kinds.
+      Companion to rbac-clusterrolebinding-roleref.yaml, which validates
+      which role is actually bound to the mcp-kubernetes ServiceAccount. Run
+      only via `kyverno apply` in CI; not deployed to a cluster.
 spec:
   validationFailureAction: Enforce
   background: false
@@ -77,33 +86,6 @@ spec:
             only ever probe its own permissions) and confers no
             cross-identity information — and only when the rule grants
             nothing else alongside it.
-  - name: mcp-kubernetes-serviceaccount-must-bind-readonly-role
-    match:
-      any:
-      - resources:
-          kinds:
-          - ClusterRoleBinding
-    validate:
-      cel:
-        expressions:
-        - expression: >-
-            !has(object.subjects) ||
-            !object.subjects.exists(s, s.kind == 'ServiceAccount' && s.name.startsWith('mcp-kubernetes')) ||
-            (object.roleRef.kind == 'ClusterRole' && object.roleRef.name == 'mcp-kubernetes-readonly')
-          message: >-
-            A ClusterRoleBinding has a ServiceAccount subject named
-            mcp-kubernetes* but its roleRef is not exactly {kind: ClusterRole,
-            name: mcp-kubernetes-readonly}. The four rules above only
-            constrain what is inside the mcp-kubernetes-readonly ClusterRole
-            itself — they say nothing about which role a binding actually
-            points an identity at. Repointing roleRef.name (e.g. to
-            cluster-admin) leaves that ClusterRole's rules untouched and
-            still perfectly read-only, while handing the same ServiceAccount
-            whatever roleRef now names instead: the single edit that most
-            completely defeats this entire policy's purpose while leaving
-            every other invariant here intact. Point roleRef at {kind:
-            ClusterRole, name: mcp-kubernetes-readonly}, or rename the
-            ServiceAccount if it genuinely needs different access.
   - name: no-nodes-proxy
     match:
       any:

--- a/ci/policy-tests/rbac-clusterrole-readonly.yaml
+++ b/ci/policy-tests/rbac-clusterrole-readonly.yaml
@@ -1,0 +1,138 @@
+---
+# TEST-ONLY Kyverno policy. This is NOT one of the policy groups in
+# policies/ (see policies/README.md) and is never applied to a cluster:
+# - It lives under ci/, which no Flux Kustomization in clusters/*/kustomization.yaml
+#   or clusters/*/kustomizations/*.yaml ever points `spec.path` at.
+# - Only policies/** is wired up via the policy-* Kustomizations
+#   (clusters/*/kustomizations/policy-*.yaml); ci/** has no equivalent.
+# It exists solely to be run offline with `kyverno apply` (no cluster
+# required) in CI — see the `rbac-clusterrole-readonly` job in
+# .github/workflows/lint.yaml — against clusters/*/cluster/rbac/*.yaml, to
+# catch a regression on the read-only RBAC ClusterRoles (currently
+# mcp-kubernetes-readonly.yaml on both clusters) before merge.
+#
+# Written with CEL (`validate.cel.expressions`), not the JMESPath
+# `deny.conditions`/`pattern` style used elsewhere in policies/: Kyverno's
+# JMESPath condition operators (In/AnyIn/AllIn/Equals/...) wildcard-match
+# any operand containing "*" against every string on the other side, so a
+# ClusterRole rule with `resources: ["*"]` or `verbs: ["*"]` — exactly the
+# shape rule 1 below must catch — silently satisfies a JMESPath "does not
+# contain nodes/proxy" or "is a subset of {get,list,watch}" check instead of
+# failing it. CEL's `in` and `==` are literal string comparisons with no
+# such wildcard behavior, so it's the only reliable way to test for the
+# literal "*" as RBAC data rather than as a glob pattern.
+#
+# Deliberately out of scope: the invariant that clusters/nas's ClusterRole
+# must stay a strict subset of clusters/homelab's. Kyverno validates one
+# resource at a time and has no way to compare two files against each other,
+# so that property is documented instead, in the header comment of
+# clusters/nas/cluster/rbac/mcp-kubernetes-readonly.yaml — diff the two
+# files by hand when reviewing a change to either.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: test-rbac-clusterrole-readonly
+  annotations:
+    policies.kyverno.io/title: RBAC ClusterRole Read-Only Invariants (CI test only)
+    policies.kyverno.io/category: CI
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: ClusterRole
+    policies.kyverno.io/description: >-
+      Statically validates that the read-only RBAC ClusterRoles under
+      clusters/*/cluster/rbac/ cannot mutate cluster state, cannot
+      exec/attach/portForward via nodes/proxy, cannot read core Secrets, and
+      cannot read plaintext-bearing generators.external-secrets.io kinds.
+      Run only via `kyverno apply` in CI; not deployed to a cluster.
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+  - name: verbs-must-be-read-only
+    match:
+      any:
+      - resources:
+          kinds:
+          - ClusterRole
+    validate:
+      cel:
+        expressions:
+        - expression: >-
+            object.rules.all(r,
+            r.verbs.all(v, v in ['get', 'list', 'watch']) ||
+            (r.apiGroups == ['authorization.k8s.io'] &&
+            r.resources == ['selfsubjectaccessreviews'] &&
+            r.verbs.all(v, v in ['get', 'list', 'watch', 'create']))
+            )
+          message: >-
+            A rule grants a verb outside {get, list, watch}. A dedicated
+            read-only ClusterRole must not be able to mutate cluster state
+            or escalate privileges: create/update/patch/delete
+            /deletecollection/impersonate/escalate/bind (and the "*"
+            wildcard, which includes all of them) all do one or the other,
+            so none of them belong here. The sole permitted exception is
+            "create" on selfsubjectaccessreviews in apiGroup
+            authorization.k8s.io — that call is self-scoped (a caller can
+            only ever probe its own permissions) and confers no
+            cross-identity information — and only when the rule grants
+            nothing else alongside it.
+  - name: no-nodes-proxy
+    match:
+      any:
+      - resources:
+          kinds:
+          - ClusterRole
+    validate:
+      cel:
+        expressions:
+        - expression: "!object.rules.exists(r, 'nodes/proxy' in r.resources)"
+          message: >-
+            A rule grants the nodes/proxy resource. That is exec-equivalent,
+            not read-only: the API server maps HTTP method to RBAC verb for
+            proxy subresources, and the kubelet registers GET routes (not
+            only POST) for /exec/, /attach/, and /portForward/ — so even
+            "get" on nodes/proxy lets the holder execute commands inside a
+            container via the node's kubelet API. Remove nodes/proxy from
+            resources.
+  - name: no-core-secrets
+    match:
+      any:
+      - resources:
+          kinds:
+          - ClusterRole
+    validate:
+      cel:
+        expressions:
+        - expression: "!object.rules.exists(r, ('' in r.apiGroups) && ('secrets' in r.resources))"
+          message: >-
+            A rule grants core Secrets (apiGroup ""). A read-only role must
+            never read Secrets: get/list/watch on Secrets exposes every
+            credential, token, and certificate cluster-wide — far more
+            blast radius than any read-only tool needs. Remove secrets from
+            resources.
+  - name: generators-external-secrets-io-allowlist
+    match:
+      any:
+      - resources:
+          kinds:
+          - ClusterRole
+    validate:
+      cel:
+        expressions:
+        - expression: >-
+            !object.rules.exists(r,
+            ('generators.external-secrets.io' in r.apiGroups) &&
+            r.resources.exists(res, res in ['*', 'fakes', 'webhooks', 'clustergenerators', 'generatorstates']))
+          message: >-
+            The generators.external-secrets.io rule grants a resource kind
+            that must stay excluded, or the "*" wildcard that would
+            re-admit all of them. fakes.spec.data is literal plaintext
+            key/value pairs, and webhooks.spec.headers are free-form
+            strings that can carry an inline API key. clustergenerators and
+            generatorstates are excluded too, because RBAC allows/denies by
+            kind, never by content: a ClusterGenerator wrapping kind: Fake
+            carries the identical plaintext spec.data in a different
+            envelope, and a GeneratorState is a snapshot of a generator's
+            manifest plus its own (potentially lease-bearing) output —
+            denying fakes/webhooks alone does not deny either wrapper. Use
+            an explicit resource allow-list instead of "*", and keep
+            fakes/webhooks/clustergenerators/generatorstates off it.

--- a/ci/policy-tests/rbac-clusterrole-readonly.yaml
+++ b/ci/policy-tests/rbac-clusterrole-readonly.yaml
@@ -6,9 +6,9 @@
 # - Only policies/** is wired up via the policy-* Kustomizations
 #   (clusters/*/kustomizations/policy-*.yaml); ci/** has no equivalent.
 # It exists solely to be run offline with `kyverno apply` (no cluster
-# required) in CI — see the `rbac-clusterrole-readonly` job in
-# .github/workflows/lint.yaml — against clusters/*/cluster/rbac/*.yaml, to
-# catch a regression on the read-only RBAC ClusterRoles (currently
+# required) in CI — see the `rbac-clusterroles` job in
+# .github/workflows/static-analysis.yaml — against clusters/*/cluster/rbac/*.yaml,
+# to catch a regression on the read-only RBAC ClusterRoles (currently
 # mcp-kubernetes-readonly.yaml on both clusters) before merge.
 #
 # Written with CEL (`validate.cel.expressions`), not the JMESPath

--- a/ci/policy-tests/rbac-clusterrolebinding-roleref.yaml
+++ b/ci/policy-tests/rbac-clusterrolebinding-roleref.yaml
@@ -1,0 +1,82 @@
+---
+# TEST-ONLY Kyverno policy. This is NOT one of the policy groups in
+# policies/ (see policies/README.md) and is never applied to a cluster:
+# - It lives under ci/, which no Flux Kustomization in clusters/*/kustomization.yaml
+#   or clusters/*/kustomizations/*.yaml ever points `spec.path` at.
+# - Only policies/** is wired up via the policy-* Kustomizations
+#   (clusters/*/kustomizations/policy-*.yaml); ci/** has no equivalent.
+# It exists solely to be run offline with `kyverno apply` (no cluster
+# required) in CI — see the `rbac-clusterroles` job in
+# .github/workflows/static-analysis.yaml — against clusters/*/cluster/rbac/*.yaml,
+# to catch a regression on the ClusterRoleBinding for the read-only RBAC role
+# (currently mcp-kubernetes-readonly.yaml on both clusters) before merge.
+#
+# Constrains which role is actually BOUND to any ServiceAccount named
+# mcp-kubernetes*: its ClusterRoleBinding must point roleRef at exactly
+# {kind: ClusterRole, name: mcp-kubernetes-readonly}. The companion policy
+# rbac-clusterrole-readonly.yaml (test-rbac-clusterrole-readonly) constrains
+# what is INSIDE that ClusterRole — no verb outside get/list/watch, no
+# nodes/proxy, no core Secrets, and an allow-list on
+# generators.external-secrets.io — but says nothing about which role a
+# binding points an identity at. Both must pass for the read-only guarantee
+# to hold: a role can be perfectly read-only in isolation and still be
+# defeated by a binding that points a subject at a different role instead.
+#
+# Written with CEL (`validate.cel.expressions`), not the JMESPath
+# `deny.conditions`/`pattern` style used elsewhere in policies/: Kyverno's
+# JMESPath condition operators (In/AnyIn/AllIn/Equals/...) wildcard-match
+# any operand containing "*" against every string on the other side. This
+# rule's own comparisons (roleRef.kind, roleRef.name, subjects[].name) never
+# contain a literal "*", so the bug the companion policy hit — a ClusterRole
+# rule with verbs: ["*"] silently satisfying a JMESPath "is a subset of"
+# check — can't reproduce here today. Keep this rule in CEL anyway: a future
+# edit that adds any check involving a wildcarded field would reintroduce
+# the same failure mode if rewritten in JMESPath.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: test-rbac-clusterrolebinding-roleref
+  annotations:
+    policies.kyverno.io/title: RBAC ClusterRoleBinding RoleRef Invariant (CI test only)
+    policies.kyverno.io/category: CI
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: ClusterRoleBinding
+    policies.kyverno.io/description: >-
+      Statically validates that no ClusterRoleBinding subject named
+      mcp-kubernetes* is ever pointed at anything other than the
+      mcp-kubernetes-readonly ClusterRole. Companion to
+      rbac-clusterrole-readonly.yaml, which validates that the
+      mcp-kubernetes-readonly ClusterRole's own rules stay read-only. Run
+      only via `kyverno apply` in CI; not deployed to a cluster.
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+  - name: mcp-kubernetes-serviceaccount-must-bind-readonly-role
+    match:
+      any:
+      - resources:
+          kinds:
+          - ClusterRoleBinding
+    validate:
+      cel:
+        expressions:
+        - expression: >-
+            !has(object.subjects) ||
+            !object.subjects.exists(s, s.kind == 'ServiceAccount' && s.name.startsWith('mcp-kubernetes')) ||
+            (object.roleRef.kind == 'ClusterRole' && object.roleRef.name == 'mcp-kubernetes-readonly')
+          message: >-
+            A ClusterRoleBinding has a ServiceAccount subject named
+            mcp-kubernetes* but its roleRef is not exactly {kind: ClusterRole,
+            name: mcp-kubernetes-readonly}. The rules in the companion
+            rbac-clusterrole-readonly.yaml policy only constrain what is
+            inside the mcp-kubernetes-readonly ClusterRole itself — they say
+            nothing about which role a binding actually points an identity
+            at. Repointing roleRef.name (e.g. to cluster-admin) leaves that
+            ClusterRole's rules untouched and still perfectly read-only,
+            while handing the same ServiceAccount whatever roleRef now names
+            instead: the single edit that most completely defeats this
+            entire policy pair's purpose while leaving every other
+            invariant intact. Point roleRef at {kind: ClusterRole, name:
+            mcp-kubernetes-readonly}, or rename the ServiceAccount if it
+            genuinely needs different access.

--- a/clusters/homelab/cluster/rbac/kustomization.yaml
+++ b/clusters/homelab/cluster/rbac/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
 - kubernetes-api-admin.yaml
 - kubernetes-api-readonly.yaml
+- mcp-kubernetes-readonly.yaml

--- a/clusters/homelab/cluster/rbac/mcp-kubernetes-readonly.yaml
+++ b/clusters/homelab/cluster/rbac/mcp-kubernetes-readonly.yaml
@@ -4,9 +4,10 @@
 # picks up namespaced CRDs whose operator opted in via the
 # rbac.authorization.k8s.io/aggregate-to-view label — inadequate on a cluster
 # running ~160 CRDs, most of which never set that label. Read-only by
-# construction (verbs never exceed get/list/watch, except two narrow,
-# individually-justified exceptions below); core Secrets are deliberately
-# absent from every rule.
+# construction: every rule is get/list/watch except one exception,
+# selfsubjectaccessreviews:create, which is self-scoped (a caller can only
+# ever probe its own permissions) and confers no cross-identity information.
+# Core Secrets are deliberately absent from every rule.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -20,6 +21,12 @@ rules:
   - events
   - limitranges
   - namespaces
+  # nodes/proxy deliberately absent: the API server maps HTTP method to RBAC
+  # verb for proxy subresources, and the kubelet registers GET routes (not
+  # only POST) for /exec/, /attach/ and /portForward/, so "get" on that
+  # subresource is exec-equivalent, not read-only. Trade-off: the nodes_log
+  # and nodes_stats_summary MCP tools 403 at call time; nodes_top is
+  # unaffected (needs only nodes:list + metrics.k8s.io).
   - nodes
   - nodes/status
   - persistentvolumeclaims
@@ -38,15 +45,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  # required by the nodes_log and nodes_stats_summary tools, which hit the
-  # kubelet via /api/v1/nodes/{name}/proxy/. Accepted trade-off — kubelet GET
-  # can reach host log files; scoped to "get" and revocable.
-  - nodes/proxy
-  verbs:
-  - get
 - apiGroups:
   - apps
   resources:
@@ -254,11 +252,12 @@ rules:
   # - hub.traefik.io: Traefik Hub, unlicensed/unused; APIAuth/AccessControlPolicy
   #   hold auth config
   # - monitoring.grafana.com: Grafana Agent Operator, unused
+  # - generators.external-secrets.io: granted separately below, by explicit
+  #   resource list rather than "*" (some generator kinds carry plaintext)
   - acme.cert-manager.io
   - cert-manager.io
   - trust.cert-manager.io
   - external-secrets.io
-  - generators.external-secrets.io
   - externaldns.k8s.io
   - source.toolkit.fluxcd.io
   - kustomize.toolkit.fluxcd.io
@@ -273,9 +272,15 @@ rules:
   - policies.kyverno.io
   - reports.kyverno.io
   - wgpolicyk8s.io
+  # Middleware.spec.headers.customRequestHeaders can carry an inline
+  # "Authorization: Bearer ..." header, and spec.plugin config is free-form —
+  # both are residual read-only exposure. spec.basicAuth takes only a secret
+  # reference, not inline credentials.
   - traefik.io
   - frrk8s.metallb.io
   - gateway.networking.k8s.io
+  # ProxyClass.spec.statefulSet.pod.tailscaleContainer.env accepts inline
+  # env vars (e.g. TS_AUTHKEY) — residual read-only exposure.
   - tailscale.com
   - autoscaling.k8s.io
   - deviceplugin.intel.com
@@ -285,6 +290,34 @@ rules:
   - k3s.cattle.io
   resources:
   - "*"
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - generators.external-secrets.io
+  resources:
+  # explicit allow-list instead of "*": fakes.spec.data is literal plaintext
+  # key/value pairs, and webhooks.spec.headers are free-form strings that can
+  # carry an inline API key — both excluded. grafanas is granted: it exposes
+  # only a plaintext admin username (spec.auth.basic.username), never the
+  # password, which stays in an unreadable Secret.
+  - acraccesstokens
+  - beyondtrustworkloadcredentialsdynamicsecrets
+  - cloudsmithaccesstokens
+  - clustergenerators
+  - ecrauthorizationtokens
+  - gcraccesstokens
+  - generatorstates
+  - githubaccesstokens
+  - grafanas
+  - mfas
+  - passwords
+  - quayaccesstokens
+  - sshkeys
+  - stssessiontokens
+  - uuids
+  - vaultdynamicsecrets
   verbs:
   - get
   - list

--- a/clusters/homelab/cluster/rbac/mcp-kubernetes-readonly.yaml
+++ b/clusters/homelab/cluster/rbac/mcp-kubernetes-readonly.yaml
@@ -1,0 +1,321 @@
+---
+# Replaces apps-ai's mcp-kubernetes-homelab ClusterRoleBinding to the stock "view"
+# ClusterRole: "view" excludes all cluster-scoped resources outright and only
+# picks up namespaced CRDs whose operator opted in via the
+# rbac.authorization.k8s.io/aggregate-to-view label — inadequate on a cluster
+# running ~160 CRDs, most of which never set that label. Read-only by
+# construction (verbs never exceed get/list/watch, except two narrow,
+# individually-justified exceptions below); core Secrets are deliberately
+# absent from every rule.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mcp-kubernetes-readonly
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - limitranges
+  - namespaces
+  - nodes
+  - nodes/status
+  - persistentvolumeclaims
+  - persistentvolumes
+  - pods
+  - pods/log
+  - pods/status
+  - podtemplates
+  - replicationcontrollers
+  - resourcequotas
+  # secrets deliberately absent
+  - serviceaccounts
+  - services
+  - services/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  # required by the nodes_log and nodes_stats_summary tools, which hit the
+  # kubelet via /api/v1/nodes/{name}/proxy/. Accepted trade-off — kubelet GET
+  # can reach host log files; scoped to "get" and revocable.
+  - nodes/proxy
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  - daemonsets
+  - daemonsets/status
+  - deployments
+  - deployments/scale
+  - deployments/status
+  - replicasets
+  - replicasets/scale
+  - replicasets/status
+  - statefulsets
+  - statefulsets/scale
+  - statefulsets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - cronjobs/status
+  - jobs
+  - jobs/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - ingressclasses
+  - networkpolicies
+  - ipaddresses
+  - servicecidrs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  - csinodes
+  - csistoragecapacities
+  - storageclasses
+  - volumeattachments
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - node.k8s.io
+  resources:
+  - runtimeclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  - mutatingadmissionpolicies
+  - mutatingadmissionpolicybindings
+  - validatingadmissionpolicies
+  - validatingadmissionpolicybindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - flowcontrol.apiserver.k8s.io
+  resources:
+  - flowschemas
+  - prioritylevelconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - deviceclasses
+  - resourceclaims
+  - resourceclaimtemplates
+  - resourceslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  # read-only visibility into the permission graph aids debugging and
+  # confers no escalation
+  - roles
+  - rolebindings
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  # required by the resources_list tool for namespace defaulting (upstream
+  # pkg/kubernetes/resources.go). Deliberately excludes
+  # subjectaccessreviews/localsubjectaccessreviews and all of
+  # authentication.k8s.io, which are RBAC and token-validation oracles.
+  - selfsubjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  # deliberately absent from this group-wide "*" grant:
+  # - helm.cattle.io: HelmChart.spec.valuesContent is inline plaintext Helm
+  #   values that can carry credentials
+  # - hub.traefik.io: Traefik Hub, unlicensed/unused; APIAuth/AccessControlPolicy
+  #   hold auth config
+  # - monitoring.grafana.com: Grafana Agent Operator, unused
+  - acme.cert-manager.io
+  - cert-manager.io
+  - trust.cert-manager.io
+  - external-secrets.io
+  - generators.external-secrets.io
+  - externaldns.k8s.io
+  - source.toolkit.fluxcd.io
+  - kustomize.toolkit.fluxcd.io
+  - helm.toolkit.fluxcd.io
+  - notification.toolkit.fluxcd.io
+  - postgresql.cnpg.io
+  - barmancloud.cnpg.io
+  - longhorn.io
+  - dragonflydb.io
+  - monitoring.coreos.com
+  - kyverno.io
+  - policies.kyverno.io
+  - reports.kyverno.io
+  - wgpolicyk8s.io
+  - traefik.io
+  - frrk8s.metallb.io
+  - gateway.networking.k8s.io
+  - tailscale.com
+  - autoscaling.k8s.io
+  - deviceplugin.intel.com
+  - fpga.intel.com
+  - nfd.k8s-sigs.io
+  - upgrade.cattle.io
+  - k3s.cattle.io
+  resources:
+  - "*"
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metallb.io
+  resources:
+  # bgppeers deliberately excluded: BGPPeer.spec.password is a plaintext BGP
+  # password; MetalLB here runs L2-only so nothing is lost
+  - bfdprofiles
+  - bgpadvertisements
+  - communities
+  - configurationstates
+  - ipaddresspools
+  - l2advertisements
+  - servicebgpstatuses
+  - servicel2statuses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mcp-kubernetes-readonly
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mcp-kubernetes-readonly
+subjects:
+- kind: ServiceAccount
+  name: mcp-kubernetes-homelab
+  namespace: ai

--- a/clusters/homelab/cluster/rbac/mcp-kubernetes-readonly.yaml
+++ b/clusters/homelab/cluster/rbac/mcp-kubernetes-readonly.yaml
@@ -302,13 +302,29 @@ rules:
   # carry an inline API key — both excluded. grafanas is granted: it exposes
   # only a plaintext admin username (spec.auth.basic.username), never the
   # password, which stays in an unreadable Secret.
+  #
+  # clustergenerators and generatorstates are ALSO excluded, not just
+  # fakes/webhooks, because RBAC allows and denies by kind, never by content:
+  # any kind that can embed another kind's content defeats a kind-level
+  # exclusion.
+  # - ClusterGenerator.spec is {kind, generator}, where generator
+  #   (GeneratorSpec) inlines fakeSpec/webhookSpec as struct fields (upstream
+  #   apis/generators/v1alpha1/types_cluster.go) — a ClusterGenerator with
+  #   kind: Fake carries the identical plaintext spec.data in a different
+  #   envelope, so denying fakes while allowing clustergenerators achieves
+  #   nothing. Field-level conditioning ("allow ClusterGenerator unless
+  #   spec.kind is Fake") isn't an option either — RBAC has no concept of it.
+  # - GeneratorState.spec.resource is a snapshot of the generator manifest at
+  #   the time the state was produced, and spec.state is the generator's
+  #   output (per the external-secrets v2.8.0 CRD bundle this repo pins) —
+  #   for vaultdynamicsecrets, which this role does grant, that output is
+  #   lease material. GeneratorStates are written by the controller, not a
+  #   person, so they appear without anyone choosing to create one.
   - acraccesstokens
   - beyondtrustworkloadcredentialsdynamicsecrets
   - cloudsmithaccesstokens
-  - clustergenerators
   - ecrauthorizationtokens
   - gcraccesstokens
-  - generatorstates
   - githubaccesstokens
   - grafanas
   - mfas

--- a/clusters/nas/cluster/rbac/kustomization.yaml
+++ b/clusters/nas/cluster/rbac/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
 - kubernetes-api-admin.yaml
 - kubernetes-api-readonly.yaml
+- mcp-kubernetes-readonly.yaml

--- a/clusters/nas/cluster/rbac/mcp-kubernetes-readonly.yaml
+++ b/clusters/nas/cluster/rbac/mcp-kubernetes-readonly.yaml
@@ -1,0 +1,345 @@
+---
+# ClusterRole rules kept byte-identical to clusters/homelab/cluster/rbac/mcp-kubernetes-readonly.yaml.
+# Replaces a binding to the stock "view" ClusterRole: "view" excludes all
+# cluster-scoped resources outright and only picks up namespaced CRDs whose
+# operator opted in via the rbac.authorization.k8s.io/aggregate-to-view
+# label — inadequate on a cluster running ~160 CRDs, most of which never set
+# that label. Read-only by construction (verbs never exceed get/list/watch,
+# except two narrow, individually-justified exceptions below); core Secrets
+# are deliberately absent from every rule.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mcp-kubernetes-readonly
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - limitranges
+  - namespaces
+  - nodes
+  - nodes/status
+  - persistentvolumeclaims
+  - persistentvolumes
+  - pods
+  - pods/log
+  - pods/status
+  - podtemplates
+  - replicationcontrollers
+  - resourcequotas
+  # secrets deliberately absent
+  - serviceaccounts
+  - services
+  - services/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  # required by the nodes_log and nodes_stats_summary tools, which hit the
+  # kubelet via /api/v1/nodes/{name}/proxy/. Accepted trade-off — kubelet GET
+  # can reach host log files; scoped to "get" and revocable.
+  - nodes/proxy
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  - daemonsets
+  - daemonsets/status
+  - deployments
+  - deployments/scale
+  - deployments/status
+  - replicasets
+  - replicasets/scale
+  - replicasets/status
+  - statefulsets
+  - statefulsets/scale
+  - statefulsets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - cronjobs/status
+  - jobs
+  - jobs/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - ingressclasses
+  - networkpolicies
+  - ipaddresses
+  - servicecidrs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  - csinodes
+  - csistoragecapacities
+  - storageclasses
+  - volumeattachments
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - node.k8s.io
+  resources:
+  - runtimeclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  - mutatingadmissionpolicies
+  - mutatingadmissionpolicybindings
+  - validatingadmissionpolicies
+  - validatingadmissionpolicybindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - flowcontrol.apiserver.k8s.io
+  resources:
+  - flowschemas
+  - prioritylevelconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - deviceclasses
+  - resourceclaims
+  - resourceclaimtemplates
+  - resourceslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  # read-only visibility into the permission graph aids debugging and
+  # confers no escalation
+  - roles
+  - rolebindings
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  # required by the resources_list tool for namespace defaulting (upstream
+  # pkg/kubernetes/resources.go). Deliberately excludes
+  # subjectaccessreviews/localsubjectaccessreviews and all of
+  # authentication.k8s.io, which are RBAC and token-validation oracles.
+  - selfsubjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  # deliberately absent from this group-wide "*" grant:
+  # - helm.cattle.io: HelmChart.spec.valuesContent is inline plaintext Helm
+  #   values that can carry credentials
+  # - hub.traefik.io: Traefik Hub, unlicensed/unused; APIAuth/AccessControlPolicy
+  #   hold auth config
+  # - monitoring.grafana.com: Grafana Agent Operator, unused
+  - acme.cert-manager.io
+  - cert-manager.io
+  - trust.cert-manager.io
+  - external-secrets.io
+  - generators.external-secrets.io
+  - externaldns.k8s.io
+  - source.toolkit.fluxcd.io
+  - kustomize.toolkit.fluxcd.io
+  - helm.toolkit.fluxcd.io
+  - notification.toolkit.fluxcd.io
+  - postgresql.cnpg.io
+  - barmancloud.cnpg.io
+  - longhorn.io
+  - dragonflydb.io
+  - monitoring.coreos.com
+  - kyverno.io
+  - policies.kyverno.io
+  - reports.kyverno.io
+  - wgpolicyk8s.io
+  - traefik.io
+  - frrk8s.metallb.io
+  - gateway.networking.k8s.io
+  - tailscale.com
+  - autoscaling.k8s.io
+  - deviceplugin.intel.com
+  - fpga.intel.com
+  - nfd.k8s-sigs.io
+  - upgrade.cattle.io
+  - k3s.cattle.io
+  resources:
+  - "*"
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metallb.io
+  resources:
+  # bgppeers deliberately excluded: BGPPeer.spec.password is a plaintext BGP
+  # password; MetalLB here runs L2-only so nothing is lost
+  - bfdprofiles
+  - bgpadvertisements
+  - communities
+  - configurationstates
+  - ipaddresspools
+  - l2advertisements
+  - servicebgpstatuses
+  - servicel2statuses
+  verbs:
+  - get
+  - list
+  - watch
+---
+# No apps-ai module runs on nas, so (unlike homelab) the ServiceAccount lives
+# here rather than in an apps repo module. kube-system is used for lack of a
+# more specific namespace: nas has no "ai"-equivalent namespace, and this
+# identity isn't tied to any workload running on this cluster.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mcp-kubernetes-nas
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mcp-kubernetes-readonly
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mcp-kubernetes-readonly
+subjects:
+- kind: ServiceAccount
+  name: mcp-kubernetes-nas
+  namespace: kube-system
+---
+# Kubernetes 1.24+ no longer auto-creates a ServiceAccount token Secret, so
+# this is minted explicitly: a remote MCP server running on the homelab
+# cluster needs a durable bearer token to reach nas's API server (no
+# in-cluster pod to use a projected/bound token). The minted token is
+# assembled into a kubeconfig and stored in Bitwarden as kubeconfig_nas_mcp.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mcp-kubernetes-nas-token
+  namespace: kube-system
+  annotations:
+    kubernetes.io/service-account.name: mcp-kubernetes-nas
+type: kubernetes.io/service-account-token

--- a/clusters/nas/cluster/rbac/mcp-kubernetes-readonly.yaml
+++ b/clusters/nas/cluster/rbac/mcp-kubernetes-readonly.yaml
@@ -1,7 +1,14 @@
 ---
-# ClusterRole rules kept identical to clusters/homelab/cluster/rbac/mcp-kubernetes-readonly.yaml,
-# EXCEPT for a handful of apiGroups deliberately dropped from the group-wide
-# "*" rule below — see the comment there for what and why. Replaces a
+# This ClusterRole MUST remain a strict subset of
+# clusters/homelab/cluster/rbac/mcp-kubernetes-readonly.yaml: every rule here
+# is intended to be identical to homelab's, and the ONLY permitted divergence
+# is the declared exclusion set on the group-wide "*" rule below —
+# longhorn.io, tailscale.com, deviceplugin.intel.com, fpga.intel.com — dropped
+# because nas structurally does not run the operators that own them (see the
+# comment on that rule for why each one is excluded). Anything granted on
+# this file that is NOT granted on the homelab file is a bug. This property
+# isn't testable (Kyverno can't express a cross-file subset check), so diff
+# the two files directly when reviewing a change to either. Replaces a
 # binding to the stock "view" ClusterRole: "view" excludes all cluster-scoped
 # resources outright and only picks up namespaced CRDs whose operator opted
 # in via the rbac.authorization.k8s.io/aggregate-to-view label — inadequate
@@ -319,13 +326,29 @@ rules:
   # carry an inline API key — both excluded. grafanas is granted: it exposes
   # only a plaintext admin username (spec.auth.basic.username), never the
   # password, which stays in an unreadable Secret.
+  #
+  # clustergenerators and generatorstates are ALSO excluded, not just
+  # fakes/webhooks, because RBAC allows and denies by kind, never by content:
+  # any kind that can embed another kind's content defeats a kind-level
+  # exclusion.
+  # - ClusterGenerator.spec is {kind, generator}, where generator
+  #   (GeneratorSpec) inlines fakeSpec/webhookSpec as struct fields (upstream
+  #   apis/generators/v1alpha1/types_cluster.go) — a ClusterGenerator with
+  #   kind: Fake carries the identical plaintext spec.data in a different
+  #   envelope, so denying fakes while allowing clustergenerators achieves
+  #   nothing. Field-level conditioning ("allow ClusterGenerator unless
+  #   spec.kind is Fake") isn't an option either — RBAC has no concept of it.
+  # - GeneratorState.spec.resource is a snapshot of the generator manifest at
+  #   the time the state was produced, and spec.state is the generator's
+  #   output (per the external-secrets v2.8.0 CRD bundle this repo pins) —
+  #   for vaultdynamicsecrets, which this role does grant, that output is
+  #   lease material. GeneratorStates are written by the controller, not a
+  #   person, so they appear without anyone choosing to create one.
   - acraccesstokens
   - beyondtrustworkloadcredentialsdynamicsecrets
   - cloudsmithaccesstokens
-  - clustergenerators
   - ecrauthorizationtokens
   - gcraccesstokens
-  - generatorstates
   - githubaccesstokens
   - grafanas
   - mfas

--- a/clusters/nas/cluster/rbac/mcp-kubernetes-readonly.yaml
+++ b/clusters/nas/cluster/rbac/mcp-kubernetes-readonly.yaml
@@ -1,12 +1,17 @@
 ---
-# ClusterRole rules kept byte-identical to clusters/homelab/cluster/rbac/mcp-kubernetes-readonly.yaml.
-# Replaces a binding to the stock "view" ClusterRole: "view" excludes all
-# cluster-scoped resources outright and only picks up namespaced CRDs whose
-# operator opted in via the rbac.authorization.k8s.io/aggregate-to-view
-# label — inadequate on a cluster running ~160 CRDs, most of which never set
-# that label. Read-only by construction (verbs never exceed get/list/watch,
-# except two narrow, individually-justified exceptions below); core Secrets
-# are deliberately absent from every rule.
+# ClusterRole rules kept identical to clusters/homelab/cluster/rbac/mcp-kubernetes-readonly.yaml,
+# EXCEPT for a handful of apiGroups deliberately dropped from the group-wide
+# "*" rule below — see the comment there for what and why. Replaces a
+# binding to the stock "view" ClusterRole: "view" excludes all cluster-scoped
+# resources outright and only picks up namespaced CRDs whose operator opted
+# in via the rbac.authorization.k8s.io/aggregate-to-view label — inadequate
+# on a cluster running ~160 CRDs, most of which never set that label.
+# Read-only by construction: every rule is get/list/watch except one
+# exception, selfsubjectaccessreviews:create, which is self-scoped (a caller
+# can only ever probe its own permissions) and confers no cross-identity
+# information. Core Secrets are deliberately absent from every rule, though
+# note configmaps and pods/log ARE granted cluster-wide (including in the
+# bitwarden namespace) — see the comment on those resources below.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -15,11 +20,22 @@ rules:
 - apiGroups:
   - ""
   resources:
+  # configmaps and pods/log are granted cluster-wide, with no per-namespace
+  # carve-out for bitwarden — a deliberate accepted trade-off. Excluding one
+  # namespace's worth of ConfigMaps/logs would mean abandoning this
+  # ClusterRole for a set of per-namespace Roles, which this repo's RBAC
+  # model doesn't otherwise do.
   - configmaps
   - endpoints
   - events
   - limitranges
   - namespaces
+  # nodes/proxy deliberately absent: the API server maps HTTP method to RBAC
+  # verb for proxy subresources, and the kubelet registers GET routes (not
+  # only POST) for /exec/, /attach/ and /portForward/, so "get" on that
+  # subresource is exec-equivalent, not read-only. Trade-off: the nodes_log
+  # and nodes_stats_summary MCP tools 403 at call time; nodes_top is
+  # unaffected (needs only nodes:list + metrics.k8s.io).
   - nodes
   - nodes/status
   - persistentvolumeclaims
@@ -38,15 +54,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  # required by the nodes_log and nodes_stats_summary tools, which hit the
-  # kubelet via /api/v1/nodes/{name}/proxy/. Accepted trade-off — kubelet GET
-  # can reach host log files; scoped to "get" and revocable.
-  - nodes/proxy
-  verbs:
-  - get
 - apiGroups:
   - apps
   resources:
@@ -254,37 +261,80 @@ rules:
   # - hub.traefik.io: Traefik Hub, unlicensed/unused; APIAuth/AccessControlPolicy
   #   hold auth config
   # - monitoring.grafana.com: Grafana Agent Operator, unused
+  # - generators.external-secrets.io: granted separately below, by explicit
+  #   resource list rather than "*" (some generator kinds carry plaintext)
+  #
+  # This nas copy additionally excludes four groups that clusters/homelab's
+  # copy grants, because nas structurally does not run the operators that
+  # own them — bitwarden lives here, so groups it doesn't run are not
+  # granted, to avoid this identity silently gaining read the moment someone
+  # installs the matching operator later:
+  # - longhorn.io: nas storage is NFS + MinIO, no Longhorn
+  # - tailscale.com: networking-extra (Tailscale operator) is not deployed
+  #   on nas
+  # - deviceplugin.intel.com / fpga.intel.com: kubernetes-extra is not
+  #   deployed on nas
   - acme.cert-manager.io
   - cert-manager.io
   - trust.cert-manager.io
   - external-secrets.io
-  - generators.external-secrets.io
   - externaldns.k8s.io
   - source.toolkit.fluxcd.io
   - kustomize.toolkit.fluxcd.io
   - helm.toolkit.fluxcd.io
   - notification.toolkit.fluxcd.io
+  # Harbor (apps-harbor) depends on infra-database-core (CloudNativePG) and
+  # DragonflyDB
   - postgresql.cnpg.io
   - barmancloud.cnpg.io
-  - longhorn.io
   - dragonflydb.io
+  # nas is getting prometheus exporters and promtail/alloy
   - monitoring.coreos.com
   - kyverno.io
   - policies.kyverno.io
   - reports.kyverno.io
   - wgpolicyk8s.io
+  # Middleware.spec.headers.customRequestHeaders can carry an inline
+  # "Authorization: Bearer ..." header, and spec.plugin config is free-form —
+  # both are residual read-only exposure. spec.basicAuth takes only a secret
+  # reference, not inline credentials.
   - traefik.io
   - frrk8s.metallb.io
   - gateway.networking.k8s.io
-  - tailscale.com
   - autoscaling.k8s.io
-  - deviceplugin.intel.com
-  - fpga.intel.com
   - nfd.k8s-sigs.io
   - upgrade.cattle.io
   - k3s.cattle.io
   resources:
   - "*"
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - generators.external-secrets.io
+  resources:
+  # explicit allow-list instead of "*": fakes.spec.data is literal plaintext
+  # key/value pairs, and webhooks.spec.headers are free-form strings that can
+  # carry an inline API key — both excluded. grafanas is granted: it exposes
+  # only a plaintext admin username (spec.auth.basic.username), never the
+  # password, which stays in an unreadable Secret.
+  - acraccesstokens
+  - beyondtrustworkloadcredentialsdynamicsecrets
+  - cloudsmithaccesstokens
+  - clustergenerators
+  - ecrauthorizationtokens
+  - gcraccesstokens
+  - generatorstates
+  - githubaccesstokens
+  - grafanas
+  - mfas
+  - passwords
+  - quayaccesstokens
+  - sshkeys
+  - stssessiontokens
+  - uuids
+  - vaultdynamicsecrets
   verbs:
   - get
   - list
@@ -308,14 +358,22 @@ rules:
   - watch
 ---
 # No apps-ai module runs on nas, so (unlike homelab) the ServiceAccount lives
-# here rather than in an apps repo module. kube-system is used for lack of a
-# more specific namespace: nas has no "ai"-equivalent namespace, and this
-# identity isn't tied to any workload running on this cluster.
+# here rather than in an apps repo module, in its own dedicated namespace
+# rather than kube-system: kube-system is conventionally exempted from PSA
+# enforcement and from Kyverno namespace selectors, so an identity placed
+# there could silently inherit future exemptions never intended for it.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mcp-access
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: mcp-kubernetes-nas
-  namespace: kube-system
+  namespace: mcp-access
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -328,18 +386,24 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: mcp-kubernetes-nas
-  namespace: kube-system
+  namespace: mcp-access
 ---
 # Kubernetes 1.24+ no longer auto-creates a ServiceAccount token Secret, so
 # this is minted explicitly: a remote MCP server running on the homelab
 # cluster needs a durable bearer token to reach nas's API server (no
 # in-cluster pod to use a projected/bound token). The minted token is
 # assembled into a kubeconfig and stored in Bitwarden as kubeconfig_nas_mcp.
+# This token is long-lived and non-expiring: automated rotation is
+# deliberately deferred until there is a consistent mechanism for it, so for
+# now rotation is a manual mint-and-reupload. Revocation, however, is
+# immediate and simple — `kubectl delete secret` on this object invalidates
+# the token straight away, unlike a JWT with a baked-in expiry that stays
+# valid until it lapses on its own.
 apiVersion: v1
 kind: Secret
 metadata:
   name: mcp-kubernetes-nas-token
-  namespace: kube-system
+  namespace: mcp-access
   annotations:
     kubernetes.io/service-account.name: mcp-kubernetes-nas
 type: kubernetes.io/service-account-token


### PR DESCRIPTION
Closes #769. Cluster side of ppat/homelab-ops-kubernetes-apps#3411 and ppat/homelab-ops-kubernetes-apps#3412.

## Why

`mcp-kubernetes` was bound to the stock `view` ClusterRole. `view` excludes all cluster-scoped resources and only picks up CRDs whose operators set the `rbac.authorization.k8s.io/aggregate-to-view` label — so on a cluster running ~160 CRDs it could not read nodes, node metrics, PersistentVolumes, StorageClasses, CRDs, APIServices, or anything from CloudNativePG, Longhorn, Prometheus Operator, MetalLB, Traefik, Tailscale or VPA.

Root of the design: use standard Kubernetes RBAC as the primary control instead of the MCP server's own `denied_resources` config. That config matches Group/Version/Kind by exact string equality with no wildcard support, so it cannot scale across this many CRDs.

## What

A purpose-built `mcp-kubernetes-readonly` ClusterRole — an explicit read-only allow-list over the standard built-in groups, `metrics.k8s.io`, and 29 CRD groups.

Verbs never exceed `get/list/watch`, with exactly one exception:

| Exception | Verb | Why |
|---|---|---|
| `selfsubjectaccessreviews` | `create` | Required by the server's `resources_list` for namespace defaulting. Deliberately excludes `subjectaccessreviews`/`localsubjectaccessreviews` and all of `authentication.k8s.io`, which are RBAC and token-validation oracles. |

`nodes/proxy` is deliberately **not** granted, despite motivating this work. The API server maps HTTP method to RBAC verb for proxy subresources, and the kubelet registers GET routes — not only POST — for `/exec/`, `/attach/` and `/portForward/`. So `get` on `nodes/proxy` would authorise `GET /api/v1/nodes/<node>/proxy/exec/<ns>/<pod>/<container>?command=…`, i.e. it's exec-equivalent, not read-only — it would have been the only non-read-only rule in the role. Consequence: `nodes_log` and `nodes_stats_summary` don't work; `nodes_top` does — it only needs `nodes: list` plus `metrics.k8s.io` — which covers the node resource-usage visibility that motivated this work.

Core `secrets` are absent from every rule. Also excluded, each documented inline where it matters:

- `helm.cattle.io` — `HelmChart.spec.valuesContent` is inline plaintext Helm values that can carry credentials
- `hub.traefik.io` — Traefik Hub, unlicensed/unused; `APIAuth`/`AccessControlPolicy` hold auth config
- `monitoring.grafana.com` — Grafana Agent Operator, unused
- `metallb.io/bgppeers` — `BGPPeer.spec.password` is a plaintext BGP password; MetalLB runs L2-only here, so the group is granted by explicit resource list instead of `*`
- `generators.external-secrets.io/fakes`, `.../webhooks` — `Fake.spec.data` is literal plaintext key/value pairs; `Webhook.spec.headers` are free-form strings that can carry an inline API key

`external-secrets.io` is fully readable: its specs reference secrets by name and never contain values, and the generated Secrets themselves remain blocked. `generators.external-secrets.io` is readable only as an explicit kind list rather than group-wide, per the exclusions above; it does include `grafanas`, with a stated trade-off — it exposes a plaintext Grafana admin username, the password staying in an unreadable Secret.

## Placement

This lives here rather than in the module because a cluster-wide grant is cluster policy, matching the existing `kubernetes-api-admin.yaml` / `kubernetes-api-readonly.yaml` convention. The apps-ai module now ships only its namespaced ServiceAccount.

## nas cluster

nas gets its own variant of the ClusterRole rather than a copy of homelab's, and deliberately so — nas hosts the self-hosted Bitwarden instance, so it carries a higher bar. It drops `longhorn.io`, `tailscale.com`, `deviceplugin.intel.com` and `fpga.intel.com` (nothing on nas uses them — nas is NFS + MinIO, no `*-extra` modules, no `infra-storage-core`), while keeping `monitoring.coreos.com` (prometheus exporters plus promtail/alloy are landing there), `dragonflydb.io` and the CNPG groups (Harbor). This trades away the byte-identical-across-clusters property the existing `kubernetes-api-admin`/`kubernetes-api-readonly` convention has — which aids review — for not silently granting read on an operator installed on nas later. `configmaps` and `pods/log` stay granted cluster-wide on nas, including in the bitwarden namespace: a deliberate accepted trade-off, since RBAC has no deny and excluding one namespace would mean abandoning the ClusterRole for per-namespace Roles.

nas additionally gets a dedicated ServiceAccount — in its own `mcp-access` namespace, not `kube-system`, since `kube-system` is conventionally exempted from PSA enforcement and Kyverno namespace selectors and could silently inherit future exemptions — and a long-lived `kubernetes.io/service-account-token` Secret, so the remote MCP server running on homelab can authenticate against the nas API server.

## Accepted residual risks

Documented so they stay revisitable: `configmaps` and pod specs disclose Secret names and mount paths, and would expose any credential a future contributor inlines — an audit of both repos found none today, but that is a discipline guarantee, not a technical one. `traefik.io/Middleware`'s inline surface is `spec.headers.customRequestHeaders` (can carry an `Authorization: Bearer …` value) and the free-form `spec.plugin` config — not `spec.basicAuth`, which on this CRD only ever takes a `secret` reference, never inline credentials. `monitoring.coreos.com/AlertmanagerConfig` can embed webhook URLs. On homelab, `tailscale.com/ProxyClass.spec.statefulSet.pod.tailscaleContainer.env` accepts inline env vars, `TS_AUTHKEY` being the obvious one (not applicable to nas, which drops the group).

## Still manual (tracked in #770)

Minting the nas token, assembling the kubeconfig into Bitwarden as `kubeconfig_nas_mcp`, and confirming the nas API server address resolves from inside a homelab pod. Automated rotation of the nas token is deliberately deferred until there's a consistent rotation mechanism worth building; revocation is `kubectl delete secret` and effective immediately. With `nodes/proxy` dropped, this token is genuinely read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
