### PR TITLE
chore(cluster-homelab): deploy apps-ai (v0.6.9 -> v0.6.10)

### DIFF
--- a/clusters/homelab/sources/apps-ai.yaml
+++ b/clusters/homelab/sources/apps-ai.yaml
@@ -14,5 +14,5 @@ spec:
     !/apps/subsystems/ai
   interval: 1m0s
   ref:
-    tag: apps-ai-v0.6.9
+    tag: apps-ai-v0.6.10
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git


### PR DESCRIPTION
Deploys `apps-ai-v0.6.10` to homelab. Cluster-side RBAC prerequisite already landed in #771.

Refs ppat/homelab-ops-kubernetes-apps#3410, ppat/homelab-ops-kubernetes-apps#3411, ppat/homelab-ops-kubernetes-apps#3412. Rollout tracked in #770.

## What lands

- `mcp-kubernetes` → `mcp-kubernetes-homelab`, now bound to the purpose-built `mcp-kubernetes-readonly` ClusterRole this cluster already carries (from #771) instead of the stock `view` role. The module no longer ships its own binding — which is why #771 had to land first.
- New `mcp-kubernetes-nas`, reading the nas cluster via the kubeconfig stored as `kubeconfig_nas_mcp`.
- `mcp-grafana`'s token is now minted and rotated by the ESO `Grafana` generator, fixing the 401 caused by Grafana's service accounts living on an emptyDir.
- `mcp-servers-ingress` — the first enforced NetworkPolicy here, restricting ingress to the eight MCP servers to the LiteLLM pod (plus Prometheus).

## Expect these on reconcile

| Change | Effect |
|---|---|
| LiteLLM alias `kubernetes_mcp` → `kubernetes_homelab_mcp` | Any virtual key scoped to the old name stops working until updated |
| n8n SSRF allowlist drops `mcp-*` | Any n8n workflow calling an MCP server directly, rather than via the gateway, breaks |
| Grafana token now generator-minted | The hand-created service account is no longer used; a fresh one is created automatically |

## Post-merge checks

Selector sanity, since a wrong LiteLLM selector would deny all eight MCP servers at once:

```
kubectl -n ai get pods -l app.kubernetes.io/name=litellm,app.kubernetes.io/instance=litellm   # expect the litellm pod
kubectl -n ai get pods -l app.kubernetes.io/component=mcp-server                              # expect 8
```

Then: Grafana MCP `list_datasources` succeeds; k8s MCP `nodes_top` works and Secret reads are refused; NAS MCP lists nas nodes; MCP pods stay Ready.

## Rollback

Revert this commit. Deleting the NetworkPolicy by hand only holds until the next reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)