### PR TITLE
fix(cluster-homelab): strip secondsToLive from the grafana generator

### DIFF
--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -82,3 +82,22 @@ spec:
       group: postgresql.cnpg.io
       kind: Cluster
       namespace: n8n
+  # The Grafana generator's spec.serviceAccount.secondsToLive exists in the external-secrets
+  # CRD bundle the module targets, but not in the older CRD this cluster currently has
+  # installed, so server-side apply rejects the whole Kustomization with "field not declared
+  # in schema". Strip it here until the operator is upgraded.
+  #
+  # Cost of running without it: the generator mints a new token on every refresh and does not
+  # delete the previous one, so tokens accumulate on the Grafana service account instead of
+  # expiring on their own. Tolerable briefly, which is why this is a stopgap rather than a
+  # change to the module -- remove this patch once the CRD carries the field.
+  # yamllint disable-line rule:indentation
+  - patch: |
+      - op: remove
+        path: /spec/serviceAccount/secondsToLive
+    target:
+      group: generators.external-secrets.io
+      version: v1alpha1
+      kind: Grafana
+      name: mcp-grafana-token
+      namespace: ai


### PR DESCRIPTION
Unblocks `apps-ai`, which is currently failing to reconcile on homelab.

## Problem

```
Grafana/ai/mcp-grafana-token dry-run failed: failed to create typed patch object
(ai/mcp-grafana-token; generators.external-secrets.io/v1alpha1, Kind=Grafana):
.spec.serviceAccount.secondsToLive: field not declared in schema
```

The module's Grafana generator sets `spec.serviceAccount.secondsToLive`. The external-secrets CRD bundle the module targets (v2.8.0) declares that field — verified by parsing the bundle — but the CRD actually installed on this cluster is older and does not. Server-side apply rejects the object, and because it fails at dry-run the **entire Kustomization** fails, not just that one resource. Nothing from `apps-ai-v0.6.10` has rolled out.

## Fix

Strip the field via a cluster-side patch rather than changing the module. The module is correct against the version it targets; the real fix is upgrading external-secrets on this cluster, which is a separate change with its own risk (CRD replacement on a live operator).

## Cost of running without it

`secondsToLive` is what bounds token lifetime. Without it the generator mints a new token on every refresh and never deletes the previous one, so tokens accumulate on the `mcp-grafana` Grafana service account rather than expiring. That is tolerable for a short window and is precisely why this is scoped as a stopgap — the patch should be removed once the CRD carries the field.

## Follow-up

Once external-secrets is upgraded here, drop this patch and let the module's own value apply. Tracked alongside the rest of the rollout in #770.

🤖 Generated with [Claude Code](https://claude.com/claude-code)