### PR TITLE
fix(cluster-homelab): point syslog-ng at the monolithic loki service

### DIFF
--- a/clusters/homelab/kustomizations/infra-observability-extra.yaml
+++ b/clusters/homelab/kustomizations/infra-observability-extra.yaml
@@ -19,7 +19,13 @@ spec:
   wait: true
   postBuild:
     substitute:
-      syslogng_loki_url: "loki-write.logging.svc.cluster.local:9095"
+      # loki-write belonged to Loki's simple-scalable topology and stopped existing when the
+      # install moved to monolithic mode, so syslog-ng has been timing out and discarding
+      # everything arriving on the syslog LoadBalancer ports. Corrected here rather than
+      # waiting on the module release, because this value overrides the module default and
+      # would keep the fixed default from taking effect. Drop this override once the module
+      # release carrying the same value is rolled out.
+      syslogng_loki_url: "loki.logging.svc.cluster.local:9095"
       secret_store: bitwarden-secret-manager-store
     substituteFrom:
     - kind: Secret


### PR DESCRIPTION
syslog-ng has been silently discarding external device syslog since Loki moved to monolithic mode. Module-side fix: ppat/homelab-ops-kubernetes-apps#3420.

## Problem

```
syslog-ng[1]: Time out connecting to Loki; url='loki-write.logging.svc.cluster.local:9095'
```

Repeating every few seconds. `loki-write` is a Service from Loki's **simple-scalable** topology, removed when ppat/homelab-ops-kubernetes-apps#3326 switched the install to monolithic. syslog-ng is the sink for device syslog arriving on the `syslog-tcp` / `syslog-udp` LoadBalancer endpoints (601/514), so **that traffic has been dropped ever since**.

It went unnoticed because promtail scrapes the systemd journal independently. Loki kept receiving journal streams and the logging stack looked healthy — the dead path was specifically the one carrying logs from outside the cluster.

## Why this repo and not just the module

`syslogng_loki_url` is set here as a postBuild substitution, which **overrides the module default**. Correcting the default alone would leave this cluster broken. Fixing it here also restores delivery on the next reconcile rather than waiting for the module release to be cut and rolled out.

The module is corrected in parallel to the same value, so this override becomes redundant — the inline comment says to drop it once that release is rolled out.

## Verifying after merge

```
kubectl -n logging logs -l app.kubernetes.io/name=syslog --tail=20
```

The timeout lines should stop. Then confirm arrival in Loki — note Grafana's Loki datasource is broken by the same migration and is fixed in the module PR, so query via the Loki service directly until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)