### PR TITLE
chore(cluster-homelab): deploy apps-ai (v0.6.10 -> v0.6.11)

### DIFF
--- a/clusters/homelab/sources/apps-ai.yaml
+++ b/clusters/homelab/sources/apps-ai.yaml
@@ -14,5 +14,5 @@ spec:
     !/apps/subsystems/ai
   interval: 1m0s
   ref:
-    tag: apps-ai-v0.6.10
+    tag: apps-ai-v0.6.11
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git


### PR DESCRIPTION
Deploys `apps-ai-v0.6.11` to homelab, shipping the new self-hosted `mcp-github` MCP server fronted by LiteLLM.

Refs ppat/homelab-ops-kubernetes-apps#3423
Refs #779

## What lands

- `mcp-github` — self-hosted `github/github-mcp-server` behind the LiteLLM gateway, read-broad with a narrow explicit `--tools` allowlist for writes (issue create/update, issue and PR comments, sub-issue linking, PR review-thread replies, gist creation).
- The pod holds no GitHub credential of its own; LiteLLM injects the PAT as a bearer token on every call via the new `github_mcp` entry (`auth_type: bearer_token`), sourced from `GITHUB_MCP_PAT` in `litellm-secrets`, which now pulls the `github_pat_mcp` key from `bitwarden-secret-manager-store`. That key is already provisioned.

No other cluster-side changes were required: `spec.ignore` on the `apps-ai` `GitRepository` includes the whole `/apps/subsystems/ai` directory (not an allowlist of individual component paths), so the new `mcp-github/` subdirectory is picked up automatically. No new `postBuild.substitute` variable was introduced, and none of the existing `spec.patches` (CNPG `Cluster` affinity/restore, the mcp-grafana `Grafana` generator) touch the new Deployment/Service/ExternalSecret.

## Post-merge verification (once Flux reconciles)

- LiteLLM's `/mcp-server-list`-equivalent (or the model list) shows a `github_mcp` entry; overall registered tool count is 48.
- Confirm the following tools are **absent** from mcp-github's exposed set: `merge_pull_request`, `push_files`, `create_or_update_file`, `actions_run_trigger`.
- The bare-origin `mcp-github` Service URL (`http://mcp-github.ai.svc.cluster.local:8082`, no `/mcp` suffix — this server mounts its MCP handler at root, unlike its siblings) is not independently exercised by CI; verify manually via LiteLLM.

Refs ppat/homelab-ops-kubernetes-apps#3423
Refs #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFHZdfXyXBSMepyjw9thW2