### PR TITLE
chore(cluster-homelab): give openclaw access to the github mcp server

### DIFF
--- a/clusters/homelab/services/ai/openclaw/openclaw.json
+++ b/clusters/homelab/services/ai/openclaw/openclaw.json
@@ -91,6 +91,13 @@
           "Authorization": "Bearer ${LITELLM_KEY}"
         }
       },
+      "github": {
+        "url": "http://litellm.ai.svc.cluster.local:4000/github_mcp/mcp",
+        "transport": "streamable-http",
+        "headers": {
+          "Authorization": "Bearer ${LITELLM_KEY}"
+        }
+      },
       "grafana": {
         "url": "http://litellm.ai.svc.cluster.local:4000/grafana_mcp/mcp",
         "transport": "streamable-http",

--- a/clusters/homelab/sources/apps-ai.yaml
+++ b/clusters/homelab/sources/apps-ai.yaml
@@ -14,5 +14,5 @@ spec:
     !/apps/subsystems/ai
   interval: 1m0s
   ref:
-    tag: apps-ai-v0.6.10
+    tag: apps-ai-v0.6.11
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git


### PR DESCRIPTION
apps-ai v0.6.11 shipped the `mcp-github` server and #780 rolled it out, but OpenClaw's `mcp.servers` block lives in this repo rather than in the module — so it needed registering separately. This was missed in the #780 rollout.

## What changed

One entry added to `clusters/homelab/services/ai/openclaw/openclaw.json`:

```json
"github": {
  "url": "http://litellm.ai.svc.cluster.local:4000/github_mcp/mcp",
  "transport": "streamable-http",
  "headers": { "Authorization": "Bearer ${LITELLM_KEY}" }
}
```

## Notes for review

- **Proxied through LiteLLM**, matching all four existing entries. OpenClaw never reaches an MCP server directly, so virtual-key scoping remains the access-control boundary and the `mcp-servers-ingress` NetworkPolicy stays intact.
- **No `toolFilter`.** The write boundary is the `--tools` allowlist on `mcp-github` itself; duplicating it here would create a second source of truth that drifts out of sync. Same reasoning as not mirroring it into LiteLLM's `allowed_tools`.
- Path uses the LiteLLM **server name** (`github_mcp`), not the alias (`github`), consistent with the other four entries.
- OpenClaw gets a deliberate subset of the MCP fleet — the `kubernetes_*` and `unifi_*` servers are still not registered here. This adds GitHub only.

## Still required out-of-band

OpenClaw's LiteLLM virtual key must be updated to include the `github_mcp` server — registering it here does not by itself grant the key access.

Refs ppat/homelab-ops-kubernetes-apps#3423
Refs #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFHZdfXyXBSMepyjw9thW2