### PR TITLE
feat(cluster-homelab): storage, secret-store, and module rollout for BRAIN vault

### DIFF
--- a/clusters/homelab/cluster/secrets/bitwarden-secret-store.yaml
+++ b/clusters/homelab/cluster/secrets/bitwarden-secret-store.yaml
@@ -40,6 +40,7 @@ spec:
     - minio
     - monitoring
     - n8n
+    - obsidian-vault
     - openclaw
     - pihole
     - tailscale

--- a/clusters/homelab/sources/apps-ai.yaml
+++ b/clusters/homelab/sources/apps-ai.yaml
@@ -14,5 +14,5 @@ spec:
     !/apps/subsystems/ai
   interval: 1m0s
   ref:
-    tag: apps-ai-v0.6.11
+    tag: apps-ai-v0.6.13
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git

--- a/clusters/homelab/storage/apps/pvc/ai/kustomization.yaml
+++ b/clusters/homelab/storage/apps/pvc/ai/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - openwebui.yaml
 - n8n-data.yaml
 - openclaw-data.yaml
+- vault-data.yaml
 
 patches:
 # yamllint disable-line rule:indentation

--- a/clusters/homelab/storage/apps/pvc/ai/vault-data.yaml
+++ b/clusters/homelab/storage/apps/pvc/ai/vault-data.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vault-data
+  namespace: obsidian-vault
+  labels:
+    app.kubernetes.io/name: obsidian-vault
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: sc-longhorn-rwx
+  volumeMode: Filesystem


### PR DESCRIPTION
## Summary

Closes ppat/homelab-ops-kubernetes-clusters#785. Part of the BRAIN vault platform (ppat/homelab-ops-kubernetes-apps#3439). Supplies the cluster-side prerequisites the `apps-ai` module's vault workloads need before they can reconcile, **and** bumps the `apps-ai` module itself to the release that ships those workloads, so the two arrive together:

- **`vault-data` PVC** — `ReadWriteMany` on `sc-longhorn-rwx`, 5Gi, pre-provisioned under `clusters/homelab/storage/apps/pvc/ai/` (mirroring `openwebui.yaml`/`n8n-data.yaml`/`openclaw-data.yaml`, since the vault workloads land inside the `apps-ai` module even though they run in their own `obsidian-vault` namespace). RWX is required because three processes mount the volume concurrently on disjoint/read-only slices (Obsidian read-write, a maintenance worker read-only, a git committer read-only-content/write-only-git-dir) — RWO would force them onto one node.
- **Snapshot + backup opt-in** — the PVC inherits `recurring-job.longhorn.io/source`, `recurring-job-group.longhorn.io/default`, `-snapshot-ops`, and `-backup-ops` labels for free from the existing untargeted patch block in `ai/kustomization.yaml` (it applies to every PVC in that file, no name filter needed). This matters because `sc-longhorn-rwx`'s own `recurringJobSelector` only wires `default` + `snapshot-ops` — without the explicit `backup-ops` label there would be no offsite backup, a gap that would only surface during the later recovery drill.
- **Secret-store allow-list** — added `obsidian-vault` to `bitwarden-secret-store.yaml`'s `conditions[].namespaces` (alphabetically, between `n8n` and `openclaw`), so ExternalSecrets in the new namespace resolve instead of sitting not-ready indefinitely.
- **Module bump** — `sources/apps-ai.yaml` pinned tag `apps-ai-v0.6.12` → `apps-ai-v0.6.13`. That release ships the vault substrate itself: the `obsidian-vault` namespace, its network policies, headless Obsidian, and the two scoped MCP instances.

## Naming: `brain` → what these things actually are

While this PR was open, the module renamed its BRAIN-vault resources on the principle that the project codename belongs in the content/tooling repos, not in infrastructure naming:

- Namespace `obsidian-brain` → **`obsidian-vault`**. `obsidian-system` was considered and rejected — in this fleet the `-system` suffix marks operators/control-planes other namespaces consume (`kube-system`, `flux-system`, `longhorn-system`, `cnpg-system`, `dragonfly-system`); this workload manages nothing on anyone's behalf, so the suffix would misinform. `obsidian-vault` matches how every app namespace here is named: function, no suffix.
- PVC `brain-vault` → **`vault-data`**. The volume holds the vault's markdown content, deliberately *not* Obsidian's own application state (that lives on an ephemeral `emptyDir`, re-established idempotently every start). Naming it after the application would misdescribe it and invite config to land on it. `-data` is the established suffix here (`n8n-data`, `openclaw-data`, `home-assistant-data`).

This PR has been updated to match: the PVC file is renamed `brain-vault.yaml` → `vault-data.yaml` with `name: vault-data`/`namespace: obsidian-vault` (its `app.kubernetes.io/name` label now also tracks `obsidian-vault`, following the sibling-file convention where that label names the app/namespace rather than the PVC, e.g. `n8n-data.yaml` labels `n8n`, `openclaw-data.yaml` labels `openclaw`), the secret-store allow-list entry is renamed, and the pinned module tag is bumped to the release carrying the module-side rename.

## ⚠️ Module release status — verify before merging

`apps-ai-v0.6.13` **did not exist yet** as of this update (module PR making the renames was still in flight; latest published release was `apps-ai-v0.6.12`). The pin here is the *predicted* patch version — `refactor` commits do trigger a release in this repo, and this package has `bump-minor-pre-major`/`bump-patch-for-minor-pre-major` set, so a non-breaking refactor takes a patch bump. **Do not merge until confirming the tag exists:**

```bash
gh release list --repo ppat/homelab-ops-kubernetes-apps | grep apps-ai
```

A Flux `GitRepository` pinned to a nonexistent tag fails to reconcile outright.

**CI reflects this today:** both `diff (homelab, kustomization)` and `diff (homelab, helmrelease)` are currently red. Both fail at the same `Prepare external sources [after]` step — `.github/scripts/prepare-sources.sh` runs `git checkout apps-ai-v0.6.13` against a local clone of the apps repo, which fails outright since that tag doesn't exist, before the flux-local diff itself ever runs. This supersedes the "only `diff (homelab, helmrelease)` is red" baseline from earlier in this PR's life: once the tag exists, `Prepare external sources` will succeed for both jobs, `diff (homelab, kustomization)` should go green, and `diff (homelab, helmrelease)` should return to the previously-verified, unrelated failure mode below (not a regression from this PR):

> flux-local runs `helm template --version sha256:…` against LiteLLM's digest-pinned OCI chart, which is not a valid semver constraint — a pre-existing tooling limitation on this fleet, verified independent of this PR.

## Expected noise on first reconcile

Storage (`storage/apps/pvc/ai/`) and the `apps-ai` module are reconciled by two separate, independent Flux Kustomizations with no `dependsOn` between them. Even with both changes landing in this one PR, `vault-data` may still be applied before `obsidian-vault` exists on the very first reconcile and will retry with `namespace not found` until the module Kustomization catches up — the same benign ordering artefact `openclaw-data` already exhibits. Not a failure; don't read the retry as one.

## Also verified (no action taken)

A parallel investigation confirmed NetworkPolicy is enforced on `homelab` (k3s flannel `wireguard-native`, `--disable-network-policy` absent from all four control-plane nodes' `k3s.io/node-args`, no Calico/Cilium CRDs, six live NetworkPolicy objects). The vault design calls for default-deny ingress in `obsidian-vault` — first namespace to depend on that posture. Sign-off on the connectivity test that corroborates this belongs to #786, which keeps its scope as the recurring "bump the pinned tag + wire the new substrate" ticket for every future BRAIN vault phase; nothing to change on that front here.

## Test plan

- [x] `pre-commit run --all-files` clean (yamllint, markdownlint, shellcheck, kubeconform via `validate-kubernetes-manifests`)
- [x] `kustomize build clusters/homelab/storage/apps/pvc/ai` confirms `vault-data` renders with all four Longhorn labels and `ReadWriteMany`/`sc-longhorn-rwx`/5Gi
- [x] Verified `obsidian-vault` sorts between `n8n` and `openclaw` in the secret-store allow-list, same slot the old `obsidian-brain` entry occupied
- [x] Confirmed `apps-ai-v0.6.13` does not exist yet via `gh release list` (latest is `v0.6.12`) — flagged above, pin left at the predicted value
- [x] CI green except `diff (homelab, kustomization)` and `diff (homelab, helmrelease)`, both currently failing only because `apps-ai-v0.6.13` doesn't exist yet (see above) — everything else (yamllint, kubeconform, pre-commit, commit-messages, affected-clusters) is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

