### PR TITLE
fix(cluster-homelab): prototype obsidian-local-rest-api bindingHost fix

### DIFF
--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -101,3 +101,31 @@ spec:
       kind: Grafana
       name: mcp-grafana-token
       namespace: ai
+  # Cluster-side prototype of an unverified image fix, ahead of a module release -- see
+  # homelab-ops-kubernetes-apps CLAUDE.md's "prototype cluster-side, then upstream" workflow.
+  #
+  # PROBLEM: the obsidian-local-rest-api plugin (coddingtonbear/obsidian-local-rest-api,
+  # bundled at 5.0.2) defaults its listener to 127.0.0.1 (DefaultBindingHost, applied to both
+  # the HTTPS and plaintext listeners). Loopback-only breaks two things at once: the kubelet's
+  # startup/readiness/liveness probes connect to the pod IP, not loopback, so they all fail and
+  # liveness restarts the container in a crash loop; and the two mcp-obsidian-* pods that proxy
+  # this API run on a different node, so they can never reach it either way.
+  #
+  # FIX: this digest forces `bindingHost: "0.0.0.0"` in the plugin's settings. Binding wider is
+  # not the security boundary and was never meant to be -- that boundary is the ClusterIP
+  # Service with no ingress, the NetworkPolicy admitting only the mcp-obsidian-* pods, and the
+  # plugin's own bearer token.
+  #
+  # This is a prototype: the digest has not shipped in a module release, only verified live.
+  # Retire this patch -- and carry the digest into
+  # apps/subsystems/ai/obsidian-vault/obsidian/deployment.yaml -- the next time apps-ai's tag
+  # is bumped past apps-ai-v0.6.13.
+  # yamllint disable-line rule:indentation
+  - patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: docker.io/ppatlabs/obsidian:1.12.7@sha256:81bbdf129b65c0787ba4b0d25b4d4e8d0688f7dfad3bd1b24bacaa73e7341266
+    target:
+      kind: Deployment
+      name: obsidian
+      namespace: obsidian-vault


### PR DESCRIPTION
## Summary

- Cluster-side prototype (`spec.patches`) overriding the `obsidian` Deployment's image in `obsidian-vault` to a digest that forces the obsidian-local-rest-api plugin's `bindingHost` to `0.0.0.0`.
- The plugin defaults to `127.0.0.1`, which fails kubelet's pod-IP probes (crash loop) and is unreachable from the two `mcp-obsidian-*` pods, which run on a different node.
- Access control is unaffected: ClusterIP Service with no ingress, NetworkPolicy admitting only the `mcp-obsidian-*` pods, plus the plugin's bearer token.

## Why cluster-side, not a module bump

The digest carries an unverified behavioural fix, not a version increment. Nothing in `apps-ai`'s CI can confirm it works: chainsaw has no readiness assertion on this container, and kind's CNI enforces no NetworkPolicy, so the cross-node reachability this fix is for is structurally untestable there. This follows the repo's established prototype-live-then-upstream workflow — see this pattern in prior `apps-ai.yaml` patches.

**This patch must be retired** (and the digest carried into `apps/subsystems/ai/obsidian-vault/obsidian/deployment.yaml`) the next time `apps-ai`'s pinned tag is bumped past `apps-ai-v0.6.13`.

## Test plan

- [x] `pre-commit run --files clusters/homelab/kustomizations/apps-ai.yaml` passes.
- [ ] CI green (one known-red `diff (homelab, helmrelease)` check expected — pre-existing flux-local/LiteLLM OCI-chart tooling limitation, unrelated to this change).
- [ ] After merge: confirm `obsidian` pod reaches `Ready` and stops restarting.
- [ ] After merge: confirm `auto-trust` logs the REST API on a non-loopback address.
- [ ] After merge: confirm an `mcp-obsidian-*` pod (different node) can actually reach port 27124.

**Not merging this myself** — opening for review/merge by the repo owner, then will verify the live reconcile.