### PR TITLE
feat(cluster-homelab): enable web search and doc/article extraction for openclaw

### DIFF
--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -82,6 +82,37 @@ spec:
       group: postgresql.cnpg.io
       kind: Cluster
       namespace: n8n
+  # openclaw.json's `${VAR}` tokens are expanded by OpenClaw from its own container env at
+  # startup. Pulling the cluster-owned openclaw-plugin-secrets Secret in wholesale via envFrom
+  # keeps adding a plugin credential a single-repo change -- add the key to that ExternalSecret
+  # and reference `${VAR}` in openclaw.json -- instead of also editing the apps-ai module to
+  # declare another secretKeyRef env entry. Strategic merge rather than JSON6902 so the
+  # container is matched by name instead of by index; envFrom has no patch merge key and the
+  # module's Deployment declares none, so this adds the list rather than replacing anything.
+  # The Secret is read only at container start, and openclaw-config is generated with
+  # disableNameSuffixHash, so neither a new key here nor a config edit rolls the pod on its
+  # own -- restart the deployment after adding a credential.
+  # yamllint disable-line rule:indentation
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: openclaw
+        namespace: openclaw
+      spec:
+        template:
+          spec:
+            containers:
+            - name: openclaw
+              envFrom:
+              - secretRef:
+                  name: openclaw-plugin-secrets
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: openclaw
+      namespace: openclaw
   # The Grafana generator's spec.serviceAccount.secondsToLive exists in the external-secrets
   # CRD bundle the module targets, but not in the older CRD this cluster currently has
   # installed, so server-side apply rejects the whole Kustomization with "field not declared

--- a/clusters/homelab/services/ai/kustomization.yaml
+++ b/clusters/homelab/services/ai/kustomization.yaml
@@ -6,6 +6,9 @@ resources:
 # Feature-coupled OpenClaw secrets, co-located with the cluster-owned openclaw.json
 # (homelab-ops-kubernetes-clusters#740). See the manifest header for the split rationale.
 - openclaw/externalsecret-openclaw-config-secrets.yaml
+# Plugin credentials referenced only from openclaw.json, pulled into the container wholesale
+# via an envFrom patch in kustomizations/apps-ai.yaml so new keys need no apps-ai change.
+- openclaw/externalsecret-openclaw-plugin-secrets.yaml
 
 configMapGenerator:
 - name: litellm-model-config

--- a/clusters/homelab/services/ai/openclaw/externalsecret-openclaw-plugin-secrets.yaml
+++ b/clusters/homelab/services/ai/openclaw/externalsecret-openclaw-plugin-secrets.yaml
@@ -1,0 +1,26 @@
+---
+# Credentials referenced ONLY from openclaw.json's `${VAR}` tokens, never from the apps-ai
+# module's own manifests. Kept in a separate ExternalSecret from openclaw-config-secrets
+# because the whole Secret is pulled into the container via `envFrom` (patched onto the
+# Deployment in kustomizations/apps-ai.yaml) rather than key-by-key `secretKeyRef`. That is
+# what makes adding a plugin credential a single-repo change: add the key here, reference
+# `${VAR}` in openclaw.json, done -- no apps-ai edit to declare another env var.
+#
+# Because it's envFrom, every key here lands in the container env under its own name, so
+# secretKey must be a valid env identifier and should match the `${VAR}` used in the config.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openclaw-plugin-secrets
+  namespace: openclaw
+spec:
+  data:
+  # Brave Search API key for the brave web-search provider plugin
+  # (plugins.entries.brave.config.webSearch.apiKey in openclaw.json).
+  - secretKey: BRAVE_API_KEY
+    remoteRef:
+      key: openclaw_brave_api_key
+  refreshInterval: 24h
+  secretStoreRef:
+    name: bitwarden-secret-manager-store
+    kind: ClusterSecretStore

--- a/clusters/homelab/services/ai/openclaw/openclaw.json
+++ b/clusters/homelab/services/ai/openclaw/openclaw.json
@@ -197,14 +197,13 @@
     },
     "web": {
       "search": {
-        // Pinned explicitly. Key-free providers never win provider auto-detection, so
-        // allowlisting the duckduckgo plugin alone leaves web search non-functional -- with
-        // `enabled: true` and no provider resolvable there is nothing to route to.
-        // duckduckgo is the default here because it needs no credentials. To switch: set this
-        // to "brave" once BRAVE_API_KEY is in the secret, or "searxng" once a SearXNG instance
-        // is deployed in-cluster (both plugins are already baked into the image).
+        // Pinned explicitly rather than left to auto-detection. duckduckgo stays allowlisted
+        // as a key-free fallback, but key-free providers never win auto-detection, so the
+        // provider in use is always whatever is named here. Switch to "searxng" once a
+        // SearXNG instance is deployed in-cluster (that plugin is already baked into the
+        // image and allowlisted), or "duckduckgo" to drop the third-party dependency.
         "enabled": true,
-        "provider": "duckduckgo"
+        "provider": "brave"
       },
       "fetch": {
         "enabled": true
@@ -243,12 +242,18 @@
       "memory": "memory-lancedb"
     },
     "entries": {
-      // Enabled but unconfigured: brave needs BRAVE_API_KEY and searxng needs a deployed
-      // instance before either can serve `tools.web.search.provider`. Neither being ready is
-      // why duckduckgo is the pinned provider for now; both are listed so flipping the
-      // provider is a one-line change.
+      // The active web-search provider (tools.web.search.provider above). BRAVE_API_KEY comes
+      // from the openclaw-plugin-secrets ExternalSecret, pulled into the container wholesale
+      // via the envFrom patch in kustomizations/apps-ai.yaml and expanded here by OpenClaw at
+      // startup. searxng is allowlisted below but unconfigured -- it needs an in-cluster
+      // instance before it can take over.
       "brave": {
-        "enabled": true
+        "enabled": true,
+        "config": {
+          "webSearch": {
+            "apiKey": "${BRAVE_API_KEY}"
+          }
+        }
       },
       "diagnostics-prometheus": {
         "enabled": true

--- a/clusters/homelab/services/ai/openclaw/openclaw.json
+++ b/clusters/homelab/services/ai/openclaw/openclaw.json
@@ -220,18 +220,25 @@
   // (/app/dist/extensions) rather than installed by this repo's Dockerfile -- but bundled is
   // not enabled: a non-empty `allow` is a hard gate that bundled plugins do not bypass, even
   // ones whose manifest sets `enabledByDefault: true`. They load only because they are listed
-  // here. brave, diffs and searxng are npm installs baked in by the image.
-  // Deliberately absent despite being available in the image (see tools.deny for both):
+  // here. brave and searxng are npm installs baked in by the image.
+  // Deliberately absent despite being available in the image:
+  //   diffs      - its useful mode (mode=file, rendering a diff to PNG/PDF for delivery over a
+  //                chat channel) needs Chromium, which the -slim base image strips along with
+  //                Puppeteer. That leaves only mode=view, a gateway-hosted HTML viewer whose
+  //                links default to loopback and need `security.allowRemoteViewer` (default
+  //                false) plus a `viewerBaseUrl` before they resolve anywhere useful --
+  //                i.e. exposing tokenised viewer URLs through the ingress for a convenience
+  //                plugin. Revisit if the image ever moves off -slim.
   //   xai        - its only unique capability is x_search over X posts. Needs XAI_API_KEY and
   //                direct egress to api.x.ai, the one model-vendor path that would bypass
   //                LiteLLM and its spend tracking, and xAI bills X Search per call ($5/1000)
   //                with no per-day cap available in plugin config. Not worth it for now.
-  //   voice-call - baked in for a future outbound-alerting path, not wired yet.
+  //   voice-call - baked in for a future outbound-alerting path, not wired yet. See tools.deny;
+  //                code_execution is likewise pre-denied on xai's behalf.
   "plugins": {
     "allow": [
       "brave",
       "diagnostics-prometheus",
-      "diffs",
       "document-extract",
       "duckduckgo",
       "litellm",
@@ -261,9 +268,6 @@
         }
       },
       "diagnostics-prometheus": {
-        "enabled": true
-      },
-      "diffs": {
         "enabled": true
       },
       // Parses untrusted PDFs/attachments in-process via clawpdf. Acceptable only because

--- a/clusters/homelab/services/ai/openclaw/openclaw.json
+++ b/clusters/homelab/services/ai/openclaw/openclaw.json
@@ -173,17 +173,38 @@
 
   // Lockdown: computer/browser tool, elevated/shell/exec, and third-party in-process
   // plugins are all disabled.
+  //
+  // `deny` is matched on TOOL NAME, not plugin id, so a plugin can be allowlisted while the
+  // dangerous tool it registers stays unavailable. Two entries beyond the original lockdown:
+  //   code_execution - registered by the xai plugin (below), runs model-authored code in a
+  //                    remote xAI sandbox. `xai.config.codeExecution.enabled: false` already
+  //                    turns it off; this is the belt-and-braces that survives a default flip.
+  //   voice_call     - registered by the voice-call plugin, which is baked into the image but
+  //                    NOT allowlisted yet, so this is pre-emptive. That plugin has no outbound
+  //                    destination allowlist, so the agent must never hold the dialling tool;
+  //                    alerts should be driven from n8n/Alertmanager via the
+  //                    `voicecall.initiate` gateway RPC with `to` omitted (falls back to the
+  //                    configured `toNumber`). Denying the tool does not block that RPC path.
   "tools": {
     "deny": [
+      "browser",
+      "code_execution",
       "exec",
-      "browser"
+      "voice_call"
     ],
     "elevated": {
       "enabled": false
     },
     "web": {
       "search": {
-        "enabled": true
+        // Pinned explicitly. Key-free providers never win provider auto-detection, so
+        // allowlisting the duckduckgo plugin alone leaves web search non-functional -- with
+        // `enabled: true` and no provider resolvable there is nothing to route to.
+        // duckduckgo is the default here because it needs no credentials. To switch: set this
+        // to "brave" once BRAVE_API_KEY is in the secret, or "searxng" once a SearXNG instance
+        // is deployed in-cluster (both plugins are already baked into the image).
+        "enabled": true,
+        "provider": "duckduckgo"
       },
       "fetch": {
         "enabled": true
@@ -194,21 +215,55 @@
   // plugins.allow is keyed by plugin ID (e.g. "whatsapp"), NOT the npm package name
   // ("@openclaw/whatsapp") -- the package name is silently treated as "not found" and the
   // real plugin ends up omitted from the allowlist.
+  //
+  // document-extract, duckduckgo, web-readability and xai are BUNDLED in the base image
+  // (/app/dist/extensions) rather than installed by this repo's Dockerfile -- but bundled is
+  // not enabled: a non-empty `allow` is a hard gate that bundled plugins do not bypass, even
+  // ones whose manifest sets `enabledByDefault: true`. They load only because they are listed
+  // here. brave, diffs and searxng are npm installs baked in by the image.
+  // voice-call is baked into the image but deliberately NOT allowlisted yet (see tools.deny).
   "plugins": {
     "allow": [
+      "brave",
       "diagnostics-prometheus",
+      "diffs",
+      "document-extract",
+      "duckduckgo",
       "litellm",
       "lobster",
       "memory-core",
       "memory-lancedb",
+      "searxng",
       "telegram",
-      "whatsapp"
+      "web-readability",
+      "whatsapp",
+      "xai"
     ],
     "slots": {
       "memory": "memory-lancedb"
     },
     "entries": {
+      // Enabled but unconfigured: brave needs BRAVE_API_KEY and searxng needs a deployed
+      // instance before either can serve `tools.web.search.provider`. Neither being ready is
+      // why duckduckgo is the pinned provider for now; both are listed so flipping the
+      // provider is a one-line change.
+      "brave": {
+        "enabled": true
+      },
       "diagnostics-prometheus": {
+        "enabled": true
+      },
+      "diffs": {
+        "enabled": true
+      },
+      // Parses untrusted PDFs/attachments in-process via clawpdf. Acceptable only because
+      // WhatsApp DMs are pairing-gated to OWNER_WHATSAPP_NUMBER and groupPolicy is allowlist,
+      // so the set of senders who can reach the parser is effectively just the operator.
+      // Revisit if channels.whatsapp.allowFrom is ever widened.
+      "document-extract": {
+        "enabled": true
+      },
+      "duckduckgo": {
         "enabled": true
       },
       "litellm": {
@@ -232,11 +287,39 @@
           }
         }
       },
+      "searxng": {
+        "enabled": true
+      },
       "telegram": {
+        "enabled": true
+      },
+      // Extracts readable article text from web_fetch HTML responses via @mozilla/readability
+      // + linkedom (pure JS, no native code). Net reduction in prompt-injection surface: the
+      // model sees article text instead of raw HTML with nav, ads and inline script.
+      "web-readability": {
         "enabled": true
       },
       "whatsapp": {
         "enabled": true
+      },
+      // Enabled ONLY for the x_search tool (searching X posts) -- nothing else provides it.
+      // xAI is NOT a model provider here; every model routes through LiteLLM. Both tools this
+      // plugin registers are dormant by default ("with each tool's enabled setting omitted,
+      // OpenClaw exposes it only for an active xAI model", and no xAI model is ever active),
+      // so xSearch.enabled is the explicit opt-in that makes x_search usable alongside the
+      // LiteLLM models -- and codeExecution stays off, reinforced by tools.deny.
+      // Requires XAI_API_KEY (or xAI OAuth) and direct egress to api.x.ai, which is the one
+      // model-vendor call path that bypasses LiteLLM. Accepted for x_search only.
+      "xai": {
+        "enabled": true,
+        "config": {
+          "xSearch": {
+            "enabled": true
+          },
+          "codeExecution": {
+            "enabled": false
+          }
+        }
       }
     },
     "bundledDiscovery": "allowlist"

--- a/clusters/homelab/services/ai/openclaw/openclaw.json
+++ b/clusters/homelab/services/ai/openclaw/openclaw.json
@@ -176,9 +176,10 @@
   //
   // `deny` is matched on TOOL NAME, not plugin id, so a plugin can be allowlisted while the
   // dangerous tool it registers stays unavailable. Two entries beyond the original lockdown:
-  //   code_execution - registered by the xai plugin (below), runs model-authored code in a
-  //                    remote xAI sandbox. `xai.config.codeExecution.enabled: false` already
-  //                    turns it off; this is the belt-and-braces that survives a default flip.
+  //   code_execution - registered by the xai plugin, which is bundled in the base image but
+  //                    deliberately NOT allowlisted, so this is pre-emptive. It runs
+  //                    model-authored code in a remote xAI sandbox; keep it denied if xai is
+  //                    ever enabled, since allowlisting the plugin alone would expose it.
   //   voice_call     - registered by the voice-call plugin, which is baked into the image but
   //                    NOT allowlisted yet, so this is pre-emptive. That plugin has no outbound
   //                    destination allowlist, so the agent must never hold the dialling tool;
@@ -215,12 +216,17 @@
   // ("@openclaw/whatsapp") -- the package name is silently treated as "not found" and the
   // real plugin ends up omitted from the allowlist.
   //
-  // document-extract, duckduckgo, web-readability and xai are BUNDLED in the base image
+  // document-extract, duckduckgo and web-readability are BUNDLED in the base image
   // (/app/dist/extensions) rather than installed by this repo's Dockerfile -- but bundled is
   // not enabled: a non-empty `allow` is a hard gate that bundled plugins do not bypass, even
   // ones whose manifest sets `enabledByDefault: true`. They load only because they are listed
   // here. brave, diffs and searxng are npm installs baked in by the image.
-  // voice-call is baked into the image but deliberately NOT allowlisted yet (see tools.deny).
+  // Deliberately absent despite being available in the image (see tools.deny for both):
+  //   xai        - its only unique capability is x_search over X posts. Needs XAI_API_KEY and
+  //                direct egress to api.x.ai, the one model-vendor path that would bypass
+  //                LiteLLM and its spend tracking, and xAI bills X Search per call ($5/1000)
+  //                with no per-day cap available in plugin config. Not worth it for now.
+  //   voice-call - baked in for a future outbound-alerting path, not wired yet.
   "plugins": {
     "allow": [
       "brave",
@@ -235,8 +241,7 @@
       "searxng",
       "telegram",
       "web-readability",
-      "whatsapp",
-      "xai"
+      "whatsapp"
     ],
     "slots": {
       "memory": "memory-lancedb"
@@ -306,25 +311,6 @@
       },
       "whatsapp": {
         "enabled": true
-      },
-      // Enabled ONLY for the x_search tool (searching X posts) -- nothing else provides it.
-      // xAI is NOT a model provider here; every model routes through LiteLLM. Both tools this
-      // plugin registers are dormant by default ("with each tool's enabled setting omitted,
-      // OpenClaw exposes it only for an active xAI model", and no xAI model is ever active),
-      // so xSearch.enabled is the explicit opt-in that makes x_search usable alongside the
-      // LiteLLM models -- and codeExecution stays off, reinforced by tools.deny.
-      // Requires XAI_API_KEY (or xAI OAuth) and direct egress to api.x.ai, which is the one
-      // model-vendor call path that bypasses LiteLLM. Accepted for x_search only.
-      "xai": {
-        "enabled": true,
-        "config": {
-          "xSearch": {
-            "enabled": true
-          },
-          "codeExecution": {
-            "enabled": false
-          }
-        }
       }
     },
     "bundledDiscovery": "allowlist"


### PR DESCRIPTION
Depends on ppat/images#542 (merged), which bakes `brave`, `searxng`, `diffs` and `voice-call` into the image.

> [!NOTE]
> Rebased onto `main` @ 85c0493 (`apps-ai v0.6.15`), which pins `ppatlabs/openclaw:2026.7.1@sha256:c43e1c99…` — the digest published by #542. The image now contains `brave`, `searxng`, `diffs` and `voice-call`, so this PR is safe to merge.

## Web search was configured but dead

`tools.web.search.enabled` was already `true`, but **no web-search provider plugin was allowlisted**, so there was nothing to route queries to. Key-free providers never win auto-detection, so allowlisting `duckduckgo` alone wouldn't have fixed it either — the provider is now pinned explicitly.

## Changes

**`plugins.allow`** +5: `brave`, `document-extract`, `duckduckgo`, `searxng`, `web-readability`.

`document-extract`, `duckduckgo` and `web-readability` are bundled in the base image rather than installed by the image build — but bundled is not enabled. A non-empty `allow` is a hard gate that bundled plugins do not bypass, even ones whose manifest sets `enabledByDefault: true` (`bundled-compat.ts`: `if (allowSet && !allowSet.has(pluginId)) continue`). They load only because they're listed here.

Plugin **ids** are used throughout, not npm package names — `brave`, not `brave-plugin`; `searxng`, not `searxng-plugin`. Verified against ClawHub `runtimeId`. This is the trap the existing comment in this file already warns about.

**`tools.web.search.provider: "brave"`**, with `BRAVE_API_KEY` wired (below). `duckduckgo` stays allowlisted as a key-free fallback; `searxng` is allowlisted but unconfigured until an in-cluster instance exists.

**New `openclaw-plugin-secrets` ExternalSecret** holding `BRAVE_API_KEY`, pulled into the container wholesale via an `envFrom` patch on the apps-ai Deployment. The existing `openclaw-config-secrets` keys reach the container through key-by-key `secretKeyRef` entries declared in the apps-ai module, so every new config-only credential needed a matching change in that repo just to declare the env var. This removes that: adding a plugin credential is now *add key here + reference `${VAR}` in openclaw.json*, with no apps-ai edit. The two ExternalSecrets are kept separate because only this one is consumed wholesale.

The Deployment patch is a strategic merge rather than the JSON6902 style used elsewhere in `apps-ai.yaml`, so the container is matched by name instead of index. Dry-run against the module's real `deployment.yaml` confirms `envFrom` lands and the existing `env` block is untouched.

**`tools.deny`** +2, both pre-emptive (neither registering plugin is allowlisted):
- `code_execution` — from the `xai` plugin. If xai is ever enabled, allowlisting it alone would otherwise expose remote sandboxed code execution.
- `voice_call` — from `voice-call`, baked into the image for a future outbound-alerting path. That plugin has no outbound destination allowlist, so the agent must never hold the dialling tool. Denying the tool does not block the `voicecall.initiate` gateway RPC that n8n/Alertmanager would use with `to` omitted.

## diffs considered and dropped

Its useful mode (`mode=file`, rendering a diff to PNG/PDF for delivery over WhatsApp) needs Chromium, which the `-slim` base image strips along with Puppeteer. That leaves `mode=view`, a gateway-hosted HTML viewer whose links default to loopback and need both `viewerBaseUrl` and `security.allowRemoteViewer` (default `false`) — i.e. exposing tokenised viewer URLs through the ingress for a convenience plugin. It stays baked into the image, so enabling it later is config-only. Revisit if the image moves off `-slim`.

## xai considered and dropped

Its only unique capability is `x_search` over X posts; everything else is already covered by LiteLLM-routed models. Not worth enabling: it needs direct egress to `api.x.ai` — the one model-vendor path bypassing LiteLLM's spend tracking — bills X Search per call ($5/1000) on top of tokens, and exposes no per-day cap in plugin config. With web search now feeding untrusted page content into the agent's context, repeated `x_search` calls are also a cheap thing for an injection to induce.

## Security notes

- **Prompt injection is the real exposure here.** Web search pipes untrusted internet text into an agent holding Home Assistant, UniFi, GitHub and k8s MCP tools. OpenClaw marks results `externalContent.untrusted: true` and re-wraps provider prose at the core boundary so results can't spoof the trust marker — and `lobster` action-approval gating is already enabled, which is the control that matters most now.
- **`web-readability` is net protective**: the model sees article text instead of raw HTML with nav, ads and inline script. Deps `@mozilla/readability@0.6.0` + `linkedom@0.18.12`, both clean in OSV, both pure JS.
- **`document-extract`** parses untrusted PDFs in-process via `clawpdf@0.3.0` (clean in OSV, but a 0.x PDF parser). Acceptable only because WhatsApp DMs are pairing-gated to `OWNER_WHATSAPP_NUMBER` and `groupPolicy` is `allowlist`, so the sender set is effectively just the operator. **Revisit if `channels.whatsapp.allowFrom` widens.**

## Operational note

The Secret is read only at container start, and `openclaw-config` is generated with `disableNameSuffixHash` — so neither a new secret key nor a config edit rolls the pod on its own. Restart the deployment after either.

## Testing

- `pre-commit` on all changed files: passing, including the k8s manifest validator.
- Config parses; `plugins.allow` cross-checked against `plugins.entries` — no orphaned entry, nothing that would silently never load.
- `kustomize build clusters/homelab/services/ai` exits 0; the new ExternalSecret and `${BRAVE_API_KEY}` reference render correctly.
- `envFrom` patch dry-run against the apps-ai module's real Deployment: applies as intended.

**The BWS remote key `openclaw_brave_api_key` is a guess**, following the `openclaw_hooks_token` / `openclaw_owner_whatsapp_number` convention. Correct it if the real key name differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

