### PR TITLE
fix(cluster-homelab): retire obsidian bindingHost prototype, bump apps-ai to v0.6.14

### DIFF
--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -101,31 +101,3 @@ spec:
       kind: Grafana
       name: mcp-grafana-token
       namespace: ai
-  # Cluster-side prototype of an unverified image fix, ahead of a module release -- see
-  # homelab-ops-kubernetes-apps CLAUDE.md's "prototype cluster-side, then upstream" workflow.
-  #
-  # PROBLEM: the obsidian-local-rest-api plugin (coddingtonbear/obsidian-local-rest-api,
-  # bundled at 5.0.2) defaults its listener to 127.0.0.1 (DefaultBindingHost, applied to both
-  # the HTTPS and plaintext listeners). Loopback-only breaks two things at once: the kubelet's
-  # startup/readiness/liveness probes connect to the pod IP, not loopback, so they all fail and
-  # liveness restarts the container in a crash loop; and the two mcp-obsidian-* pods that proxy
-  # this API run on a different node, so they can never reach it either way.
-  #
-  # FIX: this digest forces `bindingHost: "0.0.0.0"` in the plugin's settings. Binding wider is
-  # not the security boundary and was never meant to be -- that boundary is the ClusterIP
-  # Service with no ingress, the NetworkPolicy admitting only the mcp-obsidian-* pods, and the
-  # plugin's own bearer token.
-  #
-  # This is a prototype: the digest has not shipped in a module release, only verified live.
-  # Retire this patch -- and carry the digest into
-  # apps/subsystems/ai/obsidian-vault/obsidian/deployment.yaml -- the next time apps-ai's tag
-  # is bumped past apps-ai-v0.6.13.
-  # yamllint disable-line rule:indentation
-  - patch: |
-      - op: replace
-        path: /spec/template/spec/containers/0/image
-        value: docker.io/ppatlabs/obsidian:1.12.7@sha256:81bbdf129b65c0787ba4b0d25b4d4e8d0688f7dfad3bd1b24bacaa73e7341266
-    target:
-      kind: Deployment
-      name: obsidian
-      namespace: obsidian-vault

--- a/clusters/homelab/sources/apps-ai.yaml
+++ b/clusters/homelab/sources/apps-ai.yaml
@@ -14,5 +14,5 @@ spec:
     !/apps/subsystems/ai
   interval: 1m0s
   ref:
-    tag: apps-ai-v0.6.13
+    tag: apps-ai-v0.6.14
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git


### PR DESCRIPTION
## Summary

- Retires the cluster-side `spec.patches` prototype in `clusters/homelab/kustomizations/apps-ai.yaml` that forced the `obsidian` Deployment's image to a digest fixing the Local REST API plugin's `127.0.0.1`-only bind (which broke kubelet probes and cross-node MCP server access).
- Bumps `clusters/homelab/sources/apps-ai.yaml` from `apps-ai-v0.6.13` to `apps-ai-v0.6.14`, which now pins that same digest natively in the module.
- Both changes land in one commit deliberately: bumping the tag alone would still carry the old digest until this commit is applied, and removing the patch first would drop the fix in the gap between the two.

The fix was originally prototyped cluster-side (per this fleet's "prototype cluster-side, then upstream" workflow) because its correctness depended on live behaviour CI could not reproduce. It has since been verified live on the cluster and is now covered by a chainsaw readiness assertion (`ci/test/apps-ai/validate-obsidian.yaml` in the apps repo) that would fail the same way the original defect did.

## Verification performed

- Confirmed `apps-ai-v0.6.14` exists as a release in `ppat/homelab-ops-kubernetes-apps`.
- Fetched `apps/subsystems/ai/obsidian-vault/obsidian/deployment.yaml` at `ref=apps-ai-v0.6.14` via `gh api` and confirmed it pins `docker.io/ppatlabs/obsidian:1.12.7@sha256:81bbdf129b65c0787ba4b0d25b4d4e8d0688f7dfad3bd1b24bacaa73e7341266` — the exact digest the prototype patch applied.
- Confirmed the other three patches in `apps-ai.yaml` (CloudNativePG anti-affinity, n8n backup/restore de-injection, Grafana generator CRD-field stopgap) are untouched.
- `pre-commit run --all-files` passes.

## Test plan

- [ ] CI green except the known/expected `diff (homelab, helmrelease)` failure (LiteLLM's digest-pinned OCI chart is not a valid semver constraint for `helm template --version`, and recurs whenever the pinned apps-ai tag changes).
- [ ] No merge — this PR is for review/CI validation only.