### PR TITLE
chore(cluster-homelab): deploy apps-ai (v0.6.15 -> v0.6.16)

### DIFF
--- a/clusters/homelab/sources/apps-ai.yaml
+++ b/clusters/homelab/sources/apps-ai.yaml
@@ -14,5 +14,5 @@ spec:
     !/apps/subsystems/ai
   interval: 1m0s
   ref:
-    tag: apps-ai-v0.6.15
+    tag: apps-ai-v0.6.16
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git


### PR DESCRIPTION
Carries [ppat/homelab-ops-kubernetes-apps#3469](https://github.com/ppat/homelab-ops-kubernetes-apps/pull/3469):
`disallowed_tools: ["obsidian_delete_note"]` on the `obsidian_agent_mcp` entry, withholding the
delete tool from the agent handle while the ingestor keeps it.

`OBSIDIAN_WRITE_PATHS` gates *where* a call may write, never *what kind* of write it is, so the agent
instance advertised `obsidian_delete_note` over its own scope — including `log.md`, the append-only
audit log. Nothing in the design deletes on an agent's behalf. The ingestor keeps it, because
relocating a rolled-up source into `90-archive/` is write-to-new-path plus delete-at-old-path — there
is no move or rename tool.

**No cluster-side patch accompanies this.** The change is a litellm config value inside the module,
not something this cluster overrides. The three existing `apps-ai` patches (CNPG anti-affinity, n8n
`Cluster` de-injection, Grafana generator stopgap) are unaffected.

---

**Correction to this PR's own record.** After this merged, its branch was force-pushed with a
follow-on `v0.6.16 -> v0.6.17` bump and this description was rewritten to describe that instead —
in error, on the mistaken belief that the PR was still open. This body has been restored to describe
what actually merged here. The `v0.6.17` bump is
[#805](https://github.com/ppat/homelab-ops-kubernetes-clusters/pull/805).