### PR TITLE
chore(cluster-homelab): deploy apps-ai (v0.6.16 -> v0.6.17)

### DIFF
--- a/clusters/homelab/sources/apps-ai.yaml
+++ b/clusters/homelab/sources/apps-ai.yaml
@@ -14,5 +14,5 @@ spec:
     !/apps/subsystems/ai
   interval: 1m0s
   ref:
-    tag: apps-ai-v0.6.16
+    tag: apps-ai-v0.6.17
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git


### PR DESCRIPTION
Carries [ppat/homelab-ops-kubernetes-apps#3476](https://github.com/ppat/homelab-ops-kubernetes-apps/pull/3476)
— the obsidian pod hardening:

- **The vault moves off the volume mount root** to `/vault/brain`. The mount root carries the
  NFS-exported ext4 filesystem's `lost+found`, root-owned and mode `0700`, which Obsidian's file
  watcher hits with `EACCES` — it could not open the vault at all. Only the GUI surfaced this: the
  pod stayed `1/1 Ready` with zero restarts and the REST API kept serving, because the readiness
  probe hits the REST API rather than the renderer's vault load.
- **The pod gains `descheduler.alpha.kubernetes.io/prefer-no-eviction`.** It was evicted three times
  in about an hour for `LowNodeUtilization`, once relocating to another node. This is the single
  writer of the authoritative vault and its writes are not transactional, so eviction mid-write is a
  corruption window.

## This is the release that lets the `apps-ai` suspension be lifted

`apps-ai` is currently **suspended** on the homelab cluster, holding two imperative overrides —
`OBSIDIAN_VAULT_DIR=/vault/brain` and the eviction annotation — that survive only because Flux is not
reconciling. Both are in `v0.6.17`.

**Order matters, and it is checkable rather than a matter of timing.** The `GitRepository/apps-ai` is
owned by the `root` Kustomization, which is *not* suspended, so it picks up the new tag independently
of `apps-ai`. After merging, poll:

```sh
kubectl get gitrepository apps-ai -n flux-system -o jsonpath='{.status.artifact.revision}{"\n"}'
```

Once that reads `apps-ai-v0.6.17@sha1:...`, `flux resume kustomization apps-ai`. At that point there
is no `v0.6.16` left for the Kustomization to apply. Flux reconciliation is level-triggered, so there
is no deferred reconcile replaying the previously-applied revision.

Resuming while still pinned at `v0.6.16` would revert `OBSIDIAN_VAULT_DIR` to `/vault` and Obsidian
would again fail to open the vault. Recoverable, not destructive — the next reconcile after the source
updates fixes it — but it may leave a stray `/vault/.obsidian` at the volume root.

After resuming, confirm the reconciled Deployment still carries `/vault/brain`, the pod is `1/1` with
no `EACCES`, and that the agent MCP now advertises **eleven** tools rather than twelve — the
`obsidian_delete_note` withholding pinned in
[#804](https://github.com/ppat/homelab-ops-kubernetes-clusters/pull/804) has not actually taken effect
yet, because nothing has reconciled since.

## No cluster-side patch

Neither change is something this cluster overrides — both are module values. The three existing
`apps-ai` patches (CNPG anti-affinity, n8n `Cluster` de-injection, Grafana generator stopgap) are
unaffected.

## Provenance

This commit was originally force-pushed onto #804's branch after that PR had already merged, and
#804's description was briefly rewritten to describe it. #804 has been restored to describe what it
actually merged; this PR carries the `v0.6.17` bump on its own branch.