### PR TITLE
feat(cluster-homelab): deploy the vault git committer (PVC, v0.6.20, remote URL)

### DIFF
--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -33,6 +33,19 @@ spec:
   postBuild:
     substitute:
       db_bootstrap_database: litellm
+      # Which repository the vault's git committer pushes derived history to. Module
+      # configuration, not a cluster-wide value, so it belongs here rather than in
+      # cluster-secrets alongside dns_zone and the IP addresses. It has no default in
+      # obsidian-tools -- a missing value fails the run at startup rather than silently
+      # defaulting to something wrong.
+      #
+      # git_committer_remote_nas_url is deliberately not set. The NAS bare repository is a
+      # second push target for independence insurance, and obsidian-tools treats it as
+      # optional: with the variable absent the committer pushes to origin only and logs
+      # which remotes are configured. Enabling it later means adding one line here, plus
+      # the NAS-side setup (bare repo, authorized_keys, and its host key via
+      # GIT_SSH_KNOWN_HOSTS_EXTRA, since it is published nowhere).
+      git_committer_remote_origin_url: git@github.com:ppat/obsidian-vault.git
       db_bootstrap_owner: litellm
       db_name: litellm-db
       db_namespace: ai

--- a/clusters/homelab/sources/apps-ai.yaml
+++ b/clusters/homelab/sources/apps-ai.yaml
@@ -14,5 +14,5 @@ spec:
     !/apps/subsystems/ai
   interval: 1m0s
   ref:
-    tag: apps-ai-v0.6.18
+    tag: apps-ai-v0.6.20
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git

--- a/clusters/homelab/storage/apps/pvc/ai/kustomization.yaml
+++ b/clusters/homelab/storage/apps/pvc/ai/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - n8n-data.yaml
 - openclaw-data.yaml
 - vault-data.yaml
+- vault-git-cache.yaml
 
 patches:
 # yamllint disable-line rule:indentation
@@ -22,3 +23,21 @@ patches:
         recurring-job-group.longhorn.io/backup-ops: enabled
   target:
     kind: PersistentVolumeClaim
+    name: '^(openwebui|n8n-data|openclaw-data|vault-data)$'
+# vault-git-cache only holds the committer's clone of vault git history/state —
+# it's re-derivable with a fresh `git clone` from the remotes it pushes to, so
+# unlike the other PVCs here it skips snapshot-ops/backup-ops (nothing to
+# protect) and keeps only the default group's filesystem-trim housekeeping.
+# Same reasoning as the wyoming-* model caches in storage/apps/pvc/home-automation.
+# yamllint disable-line rule:indentation
+- patch: |-
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: irrelevant
+      labels:
+        recurring-job.longhorn.io/source: enabled
+        recurring-job-group.longhorn.io/default: enabled
+  target:
+    kind: PersistentVolumeClaim
+    name: vault-git-cache

--- a/clusters/homelab/storage/apps/pvc/ai/vault-git-cache.yaml
+++ b/clusters/homelab/storage/apps/pvc/ai/vault-git-cache.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vault-git-cache
+  namespace: obsidian-vault
+  labels:
+    app.kubernetes.io/name: obsidian-vault
+spec:
+  # RWO, not vault-data's RWX: exactly one git-committer CronJob pod ever
+  # mounts this (concurrencyPolicy: Forbid), so there's no concurrent-mount
+  # need to justify Longhorn's RWX/NFS overhead.
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: sc-longhorn-replicated
+  volumeMode: Filesystem


### PR DESCRIPTION
Lands the three pieces the git committer needs **together**, so the PVC it mounts and the module version that references it arrive in the same reconcile. Split across two PRs, the workload would briefly reference a claim that does not exist.

## What is in here

**1. `vault-git-cache` PVC** — RWO, 1Gi, on the standard replicated class.

RWO rather than the vault's RWX because exactly one CronJob pod mounts it at a time (`concurrencyPolicy: Forbid`); `vault-data` is RWX for a reason that does not apply here.

It takes Longhorn's `default` recurring-job group **only** — deliberately not `snapshot-ops` or `backup-ops`. The git directory is a **derivable cache**: the committer clones it from `origin` whenever it is missing or invalid, and nothing depends on it surviving. Backing it up protects nothing and spends offsite capacity. This mirrors the existing treatment of the re-downloadable model caches, which take `default` only while durable volumes take the full set.

Note the `ai/` PVC kustomization previously carried one selector-less patch applying the full group set to every PVC in the directory — a default nobody chose. It is now split into name-scoped patches so this one can opt out without changing the other four.

**2. `apps-ai` `ref.tag` 0.6.18 → 0.6.20.** Carries the CronJob itself (0.6.19) and the switch away from a pinned `known_hosts` secret (0.6.20).

**3. `git_committer_remote_origin_url`** — the module's one required substitution, in `substitute` rather than `cluster-secrets` because it is module configuration, not a cluster-wide value like `dns_zone` or the IP addresses.

## The NAS remote is deliberately unset

`obsidian-tools` treats it as optional: absent, the committer pushes to `origin` only and logs which remotes are configured. Enabling it later is one line here plus the NAS-side setup — bare repo, `authorized_keys`, and its host key via `GIT_SSH_KNOWN_HOSTS_EXTRA`, since it is published nowhere and so cannot be fetched the way GitHub's are.

## Operator prerequisites, both already done

- `obsidian_git_committer_ssh_private_key` in Bitwarden.
- Its public half registered as a deploy key on `ppat/obsidian-vault` **with write access** — verified via the API (`read_only=false`), since read-only is GitHub's default and would fail at first push.

## What to watch after this reconciles

This is the first time the committer executes anywhere — everything green so far has been unit tests and object-shape assertions. Worth checking the **first commit it creates** on `ppat/obsidian-vault`: that it contains the `.obsidian/` baseline with the intended allowlist and **no `plugins/*/data.json`**, and that a second run then commits nothing, which is what proves the `skip-worktree` freeze holds.