### PR TITLE
fix(cluster-homelab): patch the git committer onto obsidian-tools 0.3.1

### DIFF
--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -64,6 +64,34 @@ spec:
     - kind: Secret
       name: cluster-secrets
   patches:
+  # TEMPORARY, and the port-back is tracked -- this is a prototype, not a destination.
+  #
+  # apps-ai v0.6.20 pins obsidian-tools 0.3.0, whose image cannot start: its virtualenv console
+  # script carried a shebang naming the builder's interpreter path, so the container died with
+  # `exec .../obsidian-tools failed: No such file or directory` and crashlooped every 15 minutes.
+  # Fixed in ppat/obsidian-tools#33 and released as 0.3.1, which also adds a CI job that pulls the
+  # published image and runs its entrypoint -- the check whose absence let 0.3.0 build, publish,
+  # pass everything and deploy while being unable to exec.
+  #
+  # Patching here rather than waiting on an apps-ai release: the module change is one digest, and
+  # the round trip is commit -> release -> tag -> bump before a broken CronJob stops failing.
+  #
+  # Retirement is TWO commits, not one. This patch *substitutes* a fix rather than neutralising
+  # something, so bumping ref.tag and deleting the patch together leaves a window where the new
+  # revision has not been fetched yet but the override is already gone -- straight back to the
+  # unstartable image. Bump the tag first (this patch then sets the digest the module already
+  # names, and is inert), then remove it once that revision has actually landed.
+  # yamllint disable-line rule:indentation
+  - patch: |
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/containers/0/image
+        value: docker.io/ppatlabs/obsidian-tools:0.3.1@sha256:5f0b80fe3b447363004b2a03f6910f1cd8ff34e220c73ac0a07d9b717949bcf3
+    target:
+      group: batch
+      version: v1
+      kind: CronJob
+      name: git-committer
+      namespace: obsidian-vault
   # yamllint disable-line rule:indentation
   - patch: |
       - op: add


### PR DESCRIPTION
Patches the CronJob's image onto `obsidian-tools` **0.3.1** (`sha256:5f0b80fe...`), replacing the unstartable 0.3.0 that `apps-ai` v0.6.20 pins.

## What was broken

The container died at startup on every run, and has been crashlooping every 15 minutes since the CronJob was created:

```
[FATAL tini (7)] exec /opt/obsidian-tools/.venv/bin/obsidian-tools failed: No such file or directory
```

The script was present. A virtualenv's console scripts carry an **absolute** shebang naming their interpreter, and the image built its venv at `/build/.venv` before copying it to `/opt/obsidian-tools/.venv` — leaving `#!/build/.venv/bin/python` pointing at an interpreter absent from the final image. `exec` reports `ENOENT` against the *script* — the file that does exist — which is why the message reads as though the entrypoint were never installed.

Fixed in `ppat/obsidian-tools#33` (build the venv at its destination path so the shebangs are correct by construction) and released as **0.3.1**.

## Why patch here rather than release the module

The module change is a single digest. The alternative is commit → `apps-ai` release → tag → `ref.tag` bump before a crashlooping workload stops failing. This is the established prototype-cluster-side pattern.

**It is a prototype, not a destination.** The module still ships the unstartable digest, so this fixes *this cluster only* and any other consumer remains broken. The port-back needs to happen promptly.

## Retiring it — two commits, deliberately

This patch **substitutes** a fix rather than neutralising something, so bumping `ref.tag` and deleting the patch in one commit leaves a window where the new revision has not been fetched yet but the override is already gone — straight back to the unstartable image.

1. Bump `ref.tag` to the `apps-ai` release carrying 0.3.1. This patch stays, now naming the same digest the module does, and is inert.
2. Remove the patch once that revision has actually landed.

## What 0.3.1 also brings

A CI job that pulls the published image and runs its entrypoint — as a separate job against the artifact, not a `RUN` inside the Dockerfile, which would bake a dead layer into what ships and test the build context rather than the thing a cluster pulls.

Its absence is why 0.3.0 built, published, passed every check and deployed while being unable to start: unit tests import the package in the runner's own environment, the image build proves the image *builds*, and the chainsaw suite asserts the CronJob object's shape without ever scheduling a pod. Three green signals, none of which answered "does it start".
