### PR TITLE
feat(cluster-homelab): add KubeVirt sandbox namespace isolation (Phase 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - [DESIGN.md](./DESIGN.md) — directory anatomy, how a module gets wired into a cluster (sources/kustomizations/dependsOn/components/postBuild/patches), the `services/` pattern, secrets/RBAC/storage model, CI, versioning
 - [clusters/homelab/README.md](./clusters/homelab/README.md) / [clusters/nas/README.md](./clusters/nas/README.md) — what's actually deployed on each cluster, with links to each module's own README in the apps repo
 - [policies/README.md](./policies/README.md) — Kyverno policy groups and what's enforced where
-- [OPERATIONS.md](./OPERATIONS.md) — manual, host-level runbooks (node prep, image builds) for procedures that happen outside Flux
+- [OPERATIONS.md](./OPERATIONS.md) — manual, occasional runbooks for procedures that happen outside Flux (node prep, image builds, sandbox policy verification/access)
 
 This is a GitOps repo (FluxCD) of Kustomize manifests — there is no application
 code to build. "Development" here means authoring/editing YAML and validating

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1,15 +1,17 @@
 # Operations
 
-This document holds manual, host-level runbooks: procedures that happen
-*outside* Flux, against a physical node or an external registry, because they
-can't be expressed as a reconciled manifest. Everything else in this repo is
-declarative and covered by [DESIGN.md](./DESIGN.md) instead — start here only
-for the operations listed below.
+This document holds manual, occasional runbooks: procedures that happen
+*outside* Flux — against a physical node, an external registry, or as an
+on-demand check of a reconciled resource's actual runtime behavior — because
+they can't be expressed as, or fully verified by, a reconciled manifest
+alone. Everything else in this repo is declarative and covered by
+[DESIGN.md](./DESIGN.md) instead — start here only for the operations listed
+below.
 
-These runbooks used to be automated by a Packer/Ansible pipeline that is now
-unmaintained and being archived; until the planned k3s → Talos migration
-removes the need for host-level node prep entirely, they're accepted as
-manual, occasional, human-run procedures instead.
+The host-level runbooks below used to be automated by a Packer/Ansible
+pipeline that is now unmaintained and being archived; until the planned k3s →
+Talos migration removes the need for host-level node prep entirely, they're
+accepted as manual, occasional, human-run procedures instead.
 
 ## Runbook: prepare a node for KubeVirt
 
@@ -599,3 +601,99 @@ nothing actually builds or pushes the image automatically, and setting up
 that watch is a separate follow-up, not done as part of this runbook. Accept
 this as a standing, real cost of building from the official artifact instead
 of relying on someone else's automated image.
+
+## Runbook: verify the sandbox NetworkPolicy falsifiability probes before/after rollout
+
+**Why:** `clusters/homelab/services/sandbox-docker/` and
+`clusters/homelab/services/sandbox-talos/` each ship a
+`netpol-falsifiability-probe` CronJob (see each namespace's
+`cronjob-netpol-falsifiability-probe.yaml`) that asserts the namespace's
+NetworkPolicies are actually being enforced, not just present — it probes
+targets that should now be unreachable (the prod kube-apiserver, Longhorn's
+manager API, kubelet, etcd, the UniFi gateway, the in-cluster `kubernetes`
+Service, and, from `sandbox-talos`, the `sandbox-docker` namespace's SSH
+Service) alongside two that must stay reachable (`api.github.com` and DNS
+resolution via CoreDNS), and fails the Job if any denial stops holding.
+
+A probe that only ever runs *after* the policy exists proves nothing by
+itself: if every target were unreachable for some unrelated reason (a
+misconfigured CNI, a routing problem, the probe pod itself broken), the
+CronJob would report success against a namespace with no working isolation
+at all. The run documented here is the other half — a baseline taken
+*before* the NetworkPolicies exist, where every probe (including the ones
+later expected to fail) must succeed. Only a probe that flips from "succeeds
+before" to "denied after" is evidence the policy — not something else — is
+what changed the outcome.
+
+### 1. Baseline: before the NetworkPolicy exists
+
+Apply the namespace and CronJob, but not `network-policy.yaml`, e.g. by
+temporarily commenting the `network-policy.yaml` entry out of that
+namespace's `kustomization.yaml` `resources:` list before this reconciles,
+or by deleting the live `NetworkPolicy` objects in the namespace after a
+normal reconcile (Flux will reassert them on its next reconcile, so this
+window is short — have the second command below ready before deleting
+them).
+
+Trigger a one-shot run of the CronJob's own template rather than waiting for
+its schedule:
+
+```bash
+kubectl create job --from=cronjob/netpol-falsifiability-probe \
+  -n sandbox-docker netpol-baseline-preflight
+kubectl logs -f job/netpol-baseline-preflight -n sandbox-docker
+```
+
+(swap `sandbox-docker` for `sandbox-talos` to baseline the other namespace).
+
+**Expected result: every probe reports `PASS`**, including the ones the
+script itself labels as testing for denial — with no NetworkPolicy in
+place, nothing is blocked yet, so a target the design expects to be denied
+later should still be reachable now. A `FAIL` at this stage means the probe
+itself is wrong (bad IP, bad port, a target that was never reachable in the
+first place) — fix the probe, not the policy, and re-run this step before
+moving on. `DOCKER_SSH_SERVICE` in the `sandbox-talos` CronJob is expected
+to report `SKIP` here (and at every step, until Phase 4 creates that
+Service) rather than `PASS`/`FAIL` — that's the intended pre-VM behavior,
+see the CronJob's own comments.
+
+### 2. Apply the NetworkPolicy
+
+Restore `network-policy.yaml` to the namespace's `kustomization.yaml` (or
+let Flux's next reconcile reassert the deleted objects — `config-services-
+sandbox-docker`/`config-services-sandbox-talos` run on a 1-minute interval
+specifically so this doesn't require a manual nudge).
+
+### 3. Confirm the flip
+
+```bash
+kubectl create job --from=cronjob/netpol-falsifiability-probe \
+  -n sandbox-docker netpol-postpolicy-check
+kubectl logs -f job/netpol-postpolicy-check -n sandbox-docker
+```
+
+**Expected result:** every probe that was `PASS` in step 1 for a target the
+script labels as a denial check now reports `PASS: ... denied as expected`
+(connection now refused/times out), while `GitHub API` and `DNS resolution`
+still report `PASS`. Any probe that stays reachable here that the design
+says should be denied means the NetworkPolicy isn't doing what it looks
+like it does — a label selector matching zero pods, a typo'd namespace
+selector, or the CNI's policy controller not enforcing at all are the usual
+causes; this is exactly the "policy that silently stopped enforcing"
+failure mode the recurring CronJob exists to keep catching automatically
+after this one-time baseline.
+
+### 4. Clean up the one-shot Jobs
+
+```bash
+kubectl delete job netpol-baseline-preflight -n sandbox-docker
+kubectl delete job netpol-postpolicy-check -n sandbox-docker
+```
+
+The recurring `netpol-falsifiability-probe` CronJob keeps running afterward
+on its own 15-minute schedule; its result is queryable via
+`kube_job_failed{namespace=~"sandbox-docker|sandbox-talos"}` in Prometheus.
+No AlertManager route is wired to it, deliberately: this is a homelab with
+no triage layer for alerts yet, so a failure is meant to be found by
+querying, not by paging — wiring an alert route is a follow-up for once
+that layer exists, not part of this change.

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -697,3 +697,51 @@ No AlertManager route is wired to it, deliberately: this is a homelab with
 no triage layer for alerts yet, so a failure is meant to be found by
 querying, not by paging — wiring an alert route is a follow-up for once
 that layer exists, not part of this change.
+
+## Runbook: reach the sandbox VMs
+
+**Why:** `virtctl ssh`/`virtctl port-forward` do not work against either sandbox VM,
+deliberately — see the comment above `allow-coder-ingress` in
+`sandbox-docker/network-policy.yaml` and above `allow-coder-and-mcp-ingress` in
+`sandbox-talos/network-policy.yaml`. Both commands have `virt-api` (in the `kubevirt`
+namespace) dial the VM's masquerade pod IP directly, which crosses into the sandbox
+namespace — an ingress path that stays blocked on purpose, since nothing about running or
+managing either VM depends on it, and admitting it would also admit `virt-api`/
+`virt-operator`/`virt-controller`, not just the already-privileged `virt-handler`. This is
+pre-explained here so it reads as expected behavior, not a bug to debug.
+
+`kubectl port-forward` is the supported substitute — a completely different mechanism, not
+subject to that NetworkPolicy: containerd's CRI implementation enters the *pod's own*
+network namespace and dials `localhost`, so it never reaches the veth where policy is
+enforced. Target the VM's `virt-launcher` pod directly by its standard KubeVirt label
+(`kubevirt.io/domain=<vm-name>`) — substitute the actual VM name once the VM workload
+manifests (a separate, not-yet-merged phase) exist:
+
+```bash
+# Talos API (talosctl, :50000) -- sandbox-talos namespace
+kubectl port-forward -n sandbox-talos \
+  "$(kubectl get pod -n sandbox-talos -l kubevirt.io/domain=<talos-vm-name> -o name)" \
+  50000:50000
+# then point talosctl at the forwarded port:
+talosctl --talosconfig <path> config endpoint 127.0.0.1
+talosctl --talosconfig <path> config node 127.0.0.1
+
+# Sandbox Kubernetes API (:6443) -- sandbox-talos namespace
+kubectl port-forward -n sandbox-talos \
+  "$(kubectl get pod -n sandbox-talos -l kubevirt.io/domain=<talos-vm-name> -o name)" \
+  6443:6443
+# then point kubectl at it -- set `server: https://127.0.0.1:6443` in that sandbox
+# cluster's own kubeconfig, not this cluster's.
+
+# SSH to the Docker VM (:22) -- sandbox-docker namespace. cronjob-netpol-falsifiability-
+# probe.yaml's DOCKER_SSH_SERVICE already anticipates this landing as a Service named
+# docker-vm -- once Phase 4 creates it, `svc/docker-vm` replaces the pod lookup below.
+kubectl port-forward -n sandbox-docker \
+  "$(kubectl get pod -n sandbox-docker -l kubevirt.io/domain=<docker-vm-name> -o name)" \
+  2222:22
+ssh -p 2222 <user>@127.0.0.1
+```
+
+**Talos ships no SSH daemon at all** — it's API-only via `talosctl` on :50000 with mTLS —
+so for that VM the SSH question doesn't arise regardless of NetworkPolicy; only the Docker
+VM (a full Ubuntu install) has a real `sshd` to reach.

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ flowchart LR
 | See what cluster-wide Kyverno policy is enforced | [policies/README.md](./policies/README.md) |
 | Run lint/validation locally | [DESIGN.md#ci-and-validation](./DESIGN.md#ci-and-validation) |
 | Understand release/versioning conventions | [DESIGN.md#versioning-and-updates](./DESIGN.md#versioning-and-updates) |
-| Run a manual, host-level procedure (node prep, image builds) | [OPERATIONS.md](./OPERATIONS.md) |
+| Run a manual, occasional procedure outside Flux (node prep, image builds, sandbox policy verification/access) | [OPERATIONS.md](./OPERATIONS.md) |

--- a/clusters/homelab/kustomizations/config-services-sandbox-docker.yaml
+++ b/clusters/homelab/kustomizations/config-services-sandbox-docker.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: config-services-sandbox-docker
+  namespace: flux-system
+spec:
+  dependsOn:
+  - name: infra-security-core
+    namespace: flux-system
+  - name: infra-networking-core
+    namespace: flux-system
+  # Short interval, split out of config-services.yaml's 15m0s on purpose: this is the
+  # isolation boundary around a namespace with a root-equivalent dockerd behind it, so
+  # drift correction (a patch reverted, a policy hand-edited away) needs to converge fast.
+  interval: 1m0s
+  path: ./clusters/homelab/services/sandbox-docker
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: root
+    namespace: flux-system
+  timeout: 2m0s
+  wait: true

--- a/clusters/homelab/kustomizations/config-services-sandbox-talos.yaml
+++ b/clusters/homelab/kustomizations/config-services-sandbox-talos.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: config-services-sandbox-talos
+  namespace: flux-system
+spec:
+  dependsOn:
+  - name: infra-security-core
+    namespace: flux-system
+  - name: infra-networking-core
+    namespace: flux-system
+  # Short interval, split out of config-services.yaml's 15m0s on purpose: this namespace
+  # is the one AI agents get full write access to, so drift correction on its isolation
+  # boundary needs to converge fast.
+  interval: 1m0s
+  path: ./clusters/homelab/services/sandbox-talos
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: root
+    namespace: flux-system
+  timeout: 2m0s
+  wait: true

--- a/clusters/homelab/kustomizations/kustomization.yaml
+++ b/clusters/homelab/kustomizations/kustomization.yaml
@@ -23,5 +23,7 @@ resources:
 - apps-misc.yaml
 - config-storage.yaml
 - config-services.yaml
+- config-services-sandbox-docker.yaml
+- config-services-sandbox-talos.yaml
 - policy-pod-security-standards.yaml
 - policy-best-practices.yaml

--- a/clusters/homelab/services/sandbox-docker/cronjob-netpol-falsifiability-probe.yaml
+++ b/clusters/homelab/services/sandbox-docker/cronjob-netpol-falsifiability-probe.yaml
@@ -1,0 +1,129 @@
+---
+# A NetworkPolicy that has never been tested in the failing direction proves nothing --
+# it could select zero pods (label typo), or the CNI's policy controller could have
+# stopped enforcing (upgrade, restart, config drift) while the object itself still reads
+# as correct. This CronJob is that test: it runs from inside the namespace the policy in
+# network-policy.yaml protects, using the exact same pod network the protected workload
+# will use, and asserts every denial *and* the two paths that must stay open. A probe that
+# only checked denials would pass against a totally broken network (e.g. no policy
+# enforcement at all) just as easily as against a correctly locked-down one.
+#
+# AlertManager is deliberately not wired up yet (no triage layer exists for a one-person
+# homelab), so this leans entirely on the Job failing and being queryable via
+# `kube_job_failed{namespace="sandbox-docker"}` in Prometheus -- see OPERATIONS.md for the
+# "run before the policy exists, expect success" half of this test, which is the other
+# half of what makes this falsifiable rather than decorative.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: netpol-falsifiability-probe
+  namespace: sandbox-docker
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  # Kept longer than successful runs so a regression is still queryable well after it
+  # first fires, not just until the next history-limit eviction.
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      # One attempt per scheduled run -- a retry can't fix a policy that stopped
+      # enforcing, and backoffLimit: 0 means the Job (and kube_job_failed) reflects a
+      # single probe run's outcome rather than blurring several attempts together.
+      backoffLimit: 0
+      activeDeadlineSeconds: 120
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: netpol-falsifiability-probe
+        spec:
+          # No selector needed to be caught by the sandbox's default-deny/allow policies:
+          # they use podSelector: {}, which matches every pod in the namespace, including
+          # this one -- that's what makes this pod a faithful stand-in for the VM's own
+          # virt-launcher pod rather than a special-cased exception to it.
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          containers:
+          - name: probe
+            # Digest-only pin, no floating tag -- matches the busybox reference already in
+            # use (and Renovate-tracked) elsewhere in this repo, e.g. traefik's log-rotate
+            # init-container.
+            image: busybox@sha256:dc2d74b28e4cf8984fa52af1f39bc7c3d9c73760b41a74d629f5d11b1ab28616
+            env:
+            - name: NODE_IPS
+              value: "192.168.8.65 192.168.8.67 192.168.8.68 192.168.8.69"
+            - name: IN_CLUSTER_KUBERNETES_SERVICE
+              # The well-known first usable address in the service CIDR
+              # (10.43.0.0/16, inferred from observed ClusterIPs -- there is no
+              # in-cluster way to read the CIDR itself at runtime).
+              value: "10.43.0.1"
+            - name: UNIFI_GATEWAY
+              value: "192.168.8.1"
+            - name: TIMEOUT_SECONDS
+              value: "3"
+            command:
+            - /bin/sh
+            - -c
+            # yamllint disable rule:line-length
+            # yamllint disable-line rule:indentation
+            - |
+              set -u
+              fail=0
+
+              # Expect the connection to be refused or time out. A successful connect
+              # here means the egress `except` list (or the policy controller enforcing
+              # it) has stopped doing its job.
+              probe_deny() {
+                desc="$1"; host="$2"; port="$3"
+                if nc -z -w "$TIMEOUT_SECONDS" "$host" "$port" 2>/dev/null; then
+                  echo "FAIL: $desc ($host:$port) -- connected, expected denial"
+                  fail=1
+                else
+                  echo "PASS: $desc ($host:$port) -- denied as expected"
+                fi
+              }
+
+              # Expect the connection to succeed. Exists so this probe can't pass against
+              # a network that's simply broken end-to-end rather than correctly scoped.
+              probe_allow() {
+                desc="$1"; host="$2"; port="$3"
+                if nc -z -w "$TIMEOUT_SECONDS" "$host" "$port" 2>/dev/null; then
+                  echo "PASS: $desc ($host:$port) -- reached as expected"
+                else
+                  echo "FAIL: $desc ($host:$port) -- blocked, expected success"
+                  fail=1
+                fi
+              }
+
+              for node in $NODE_IPS; do
+                probe_deny "prod kube-apiserver" "$node" 6443
+                probe_deny "Longhorn manager" "$node" 9500
+                probe_deny "kubelet" "$node" 10250
+                probe_deny "etcd" "$node" 2379
+              done
+
+              probe_deny "UniFi gateway" "$UNIFI_GATEWAY" 443
+              probe_deny "in-cluster kubernetes Service" "$IN_CLUSTER_KUBERNETES_SERVICE" 443
+
+              probe_allow "GitHub API (internet egress)" "api.github.com" 443
+
+              if nslookup api.github.com >/dev/null 2>&1; then
+                echo "PASS: DNS resolution via CoreDNS -- succeeded as expected"
+              else
+                echo "FAIL: DNS resolution via CoreDNS -- failed, expected success"
+                fail=1
+              fi
+
+              exit "$fail"
+            # yamllint enable rule:line-length
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              runAsUser: 65534
+              runAsGroup: 65534
+              capabilities:
+                drop:
+                - ALL
+              seccompProfile:
+                type: RuntimeDefault

--- a/clusters/homelab/services/sandbox-docker/kustomization.yaml
+++ b/clusters/homelab/services/sandbox-docker/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+- network-policy.yaml
+- cronjob-netpol-falsifiability-probe.yaml
+
+commonAnnotations:
+  # This namespace's own isolation is the point of the module -- prevent pruning
+  # unintentionally, same convention as clusters/nas/outpost.
+  kustomize.toolkit.fluxcd.io/prune: disabled

--- a/clusters/homelab/services/sandbox-docker/namespace.yaml
+++ b/clusters/homelab/services/sandbox-docker/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sandbox-docker
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    kustomize.toolkit.fluxcd.io/ssa: merge
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/homelab/services/sandbox-docker/network-policy.yaml
+++ b/clusters/homelab/services/sandbox-docker/network-policy.yaml
@@ -1,0 +1,129 @@
+---
+# Default-deny both directions. Every NetworkPolicy in the apps repo up to now is
+# ingress-only (egress stays open by omission) -- that pattern doesn't hold here: this
+# namespace fronts a real dockerd, and a reachable Docker socket/daemon is root-equivalent
+# on the VM behind it, so an unconstrained egress path out of this namespace is as
+# dangerous as an unconstrained ingress path into it. An empty podSelector with both
+# policyTypes and no ingress/egress rules denies everything in both directions;
+# everything admitted below is a separate policy object whose rules union with this one
+# for whichever pod/direction they also select -- see the other files in this directory
+# for the same pattern.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: sandbox-docker
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+# DNS is the only path out that isn't the big allow-list below. CoreDNS lives in
+# kube-system, which carries no NetworkPolicies of its own, so this is the only place the
+# boundary is enforced. Scoped by podSelector, not by the kube-dns ClusterIP: matching on
+# IP would put this rule inside the 10.0.0.0/8 `except` carved out in
+# allow-egress-internet.yaml below, which would close it right back off.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: sandbox-docker
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+---
+# Same-namespace traffic, so the dockerd VM's own virt-launcher pod can reach any Service
+# fronting it that also lives in this namespace. podSelector with no namespaceSelector is
+# implicitly scoped to this namespace only -- it does not reach into sandbox-talos or
+# anywhere else.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace-egress
+  namespace: sandbox-docker
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - podSelector: {}
+---
+# Open internet egress (dockerd needs to pull images from arbitrary registries), with an
+# `except` list that is most of this namespace's security value in one object: it closes
+# the prod kube-apiserver, Longhorn's manager API, kubelet's :10250, etcd, the UniFi
+# gateway, and the NAS, because every one of those targets sits inside one of these five
+# blocks. Do not narrow this to a smaller CIDR or drop a block to "simplify" it -- that
+# reopens a specific internal target, not just tidies the object. RFC1918 (10/8, 172.16/12,
+# 192.168/16) plus link-local (169.254/16) and loopback (127/8) covers every private range
+# in use on this network, including all pod/Service traffic (both CIDRs nest inside 10/8),
+# which is why the two policies above exist as separate carve-outs instead of just being
+# narrower `except` entries here.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-internet
+  namespace: sandbox-docker
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+        - 169.254.0.0/16
+        - 127.0.0.0/8
+---
+# Only the `coder` namespace may reach the dockerd VM -- that's the Coder workspace pods
+# that point DOCKER_HOST at it. Nothing in `sandbox-talos` (or anywhere else) is admitted
+# here: a write-capable Talos sandbox that could also reach this namespace would own the
+# Docker VM through it, since a reachable dockerd is root-equivalent on that host. That's
+# the reason these two sandboxes are separate namespaces rather than one.
+#
+# Port 22 is SSH (DOCKER_HOST=ssh://...). The range below is the kind API-server port
+# range: kind is deliberately retained against the remote daemon, and each consumer
+# (each Coder workspace's `kind create cluster`) needs its own unique
+# `networking.apiServerPort` on this shared dockerd, since kind exposes that port on the
+# Docker host's own network namespace, not container-scoped. 6550-6560 is arbitrary but
+# fixed -- allocate one port per consumer by hand from this range and record the
+# assignment where that consumer's kind config lives; nothing here tracks allocation.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-coder-ingress
+  namespace: sandbox-docker
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: coder
+    ports:
+    - protocol: TCP
+      port: 22
+    - protocol: TCP
+      port: 6550
+      endPort: 6560

--- a/clusters/homelab/services/sandbox-docker/network-policy.yaml
+++ b/clusters/homelab/services/sandbox-docker/network-policy.yaml
@@ -107,6 +107,21 @@ spec:
 # Docker host's own network namespace, not container-scoped. 6550-6560 is arbitrary but
 # fixed -- allocate one port per consumer by hand from this range and record the
 # assignment where that consumer's kind config lives; nothing here tracks allocation.
+#
+# No rule here admits the `kubevirt` namespace, and that's deliberate. Every operational
+# KubeVirt path is node-local and never crosses into this namespace: lifecycle
+# (start/stop/pause/exec, domain stats) is virt-handler -> virt-launcher over a unix
+# socket on a shared hostPath; console/VNC/serial dial virt-handler's own pod IP (inside
+# `kubevirt`, not here) and virt-handler reaches the guest via
+# /proc/<launcher-pid>/root using hostPID; metrics are scraped off virt-handler the same
+# way. The one exception is `virtctl ssh`/`virtctl port-forward` -- virt-api dials the
+# VM's masquerade pod IP directly for those, which *does* cross into this namespace, and
+# it stays blocked. Use `kubectl port-forward` instead: containerd's CRI implementation
+# enters the pod's own network namespace and dials localhost, so it never reaches the
+# veth NetworkPolicy enforces on and needs no rule -- a fully equivalent, unaffected
+# substitute. Admitting `kubevirt` would also be namespace-scoped, so it would admit
+# virt-api/virt-operator/virt-controller alongside virt-handler, not just the one already
+# privileged component -- not a cost worth paying for a path with a working substitute.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/clusters/homelab/services/sandbox-talos/cronjob-netpol-falsifiability-probe.yaml
+++ b/clusters/homelab/services/sandbox-talos/cronjob-netpol-falsifiability-probe.yaml
@@ -1,0 +1,124 @@
+---
+# See sandbox-docker/cronjob-netpol-falsifiability-probe.yaml for the full rationale --
+# same design, same reasoning about why a policy that's never been tested in the failing
+# direction proves nothing. Queryable via
+# `kube_job_failed{namespace="sandbox-talos"}`; no AlertManager wiring by design (see
+# OPERATIONS.md).
+#
+# One probe here has no sandbox-docker equivalent: reachability of the Docker namespace's
+# SSH Service from this namespace, which is the one that must NEVER pass -- see
+# network-policy.yaml for why. That Service doesn't exist until Phase 4 creates the
+# dockerd VM, so the probe below treats "name doesn't resolve yet" as SKIP rather than
+# FAIL: this CronJob has to make sense with no VM ever built (an unresolvable name isn't
+# evidence the policy works, it's evidence there's nothing there yet), and it starts
+# actually asserting the moment Phase 4 creates a Service at DOCKER_SSH_SERVICE below with
+# no change needed here. Update the env var if Phase 4 names it differently.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: netpol-falsifiability-probe
+  namespace: sandbox-talos
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 120
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: netpol-falsifiability-probe
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          containers:
+          - name: probe
+            image: busybox@sha256:dc2d74b28e4cf8984fa52af1f39bc7c3d9c73760b41a74d629f5d11b1ab28616
+            env:
+            - name: NODE_IPS
+              value: "192.168.8.65 192.168.8.67 192.168.8.68 192.168.8.69"
+            - name: IN_CLUSTER_KUBERNETES_SERVICE
+              value: "10.43.0.1"
+            - name: UNIFI_GATEWAY
+              value: "192.168.8.1"
+            - name: DOCKER_SSH_SERVICE
+              # Anticipated name/port of the Service Phase 4 fronts dockerd's SSH with,
+              # in the sandbox-docker namespace. Doesn't exist yet -- see the file-level
+              # comment above.
+              value: "docker-vm.sandbox-docker.svc.cluster.local"
+            - name: DOCKER_SSH_PORT
+              value: "22"
+            - name: TIMEOUT_SECONDS
+              value: "3"
+            command:
+            - /bin/sh
+            - -c
+            # yamllint disable rule:line-length
+            # yamllint disable-line rule:indentation
+            - |
+              set -u
+              fail=0
+
+              probe_deny() {
+                desc="$1"; host="$2"; port="$3"
+                if nc -z -w "$TIMEOUT_SECONDS" "$host" "$port" 2>/dev/null; then
+                  echo "FAIL: $desc ($host:$port) -- connected, expected denial"
+                  fail=1
+                else
+                  echo "PASS: $desc ($host:$port) -- denied as expected"
+                fi
+              }
+
+              probe_allow() {
+                desc="$1"; host="$2"; port="$3"
+                if nc -z -w "$TIMEOUT_SECONDS" "$host" "$port" 2>/dev/null; then
+                  echo "PASS: $desc ($host:$port) -- reached as expected"
+                else
+                  echo "FAIL: $desc ($host:$port) -- blocked, expected success"
+                  fail=1
+                fi
+              }
+
+              for node in $NODE_IPS; do
+                probe_deny "prod kube-apiserver" "$node" 6443
+                probe_deny "Longhorn manager" "$node" 9500
+                probe_deny "kubelet" "$node" 10250
+                probe_deny "etcd" "$node" 2379
+              done
+
+              probe_deny "UniFi gateway" "$UNIFI_GATEWAY" 443
+              probe_deny "in-cluster kubernetes Service" "$IN_CLUSTER_KUBERNETES_SERVICE" 443
+
+              # Cross-sandbox denial: the load-bearing check for why these are two
+              # namespaces rather than one. See network-policy.yaml.
+              if nslookup "$DOCKER_SSH_SERVICE" >/dev/null 2>&1; then
+                probe_deny "Docker namespace SSH Service" "$DOCKER_SSH_SERVICE" "$DOCKER_SSH_PORT"
+              else
+                echo "SKIP: Docker namespace SSH Service ($DOCKER_SSH_SERVICE:$DOCKER_SSH_PORT) -- not deployed yet"
+              fi
+
+              probe_allow "GitHub API (internet egress)" "api.github.com" 443
+
+              if nslookup api.github.com >/dev/null 2>&1; then
+                echo "PASS: DNS resolution via CoreDNS -- succeeded as expected"
+              else
+                echo "FAIL: DNS resolution via CoreDNS -- failed, expected success"
+                fail=1
+              fi
+
+              exit "$fail"
+            # yamllint enable rule:line-length
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              runAsUser: 65534
+              runAsGroup: 65534
+              capabilities:
+                drop:
+                - ALL
+              seccompProfile:
+                type: RuntimeDefault

--- a/clusters/homelab/services/sandbox-talos/kustomization.yaml
+++ b/clusters/homelab/services/sandbox-talos/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+- network-policy.yaml
+- cronjob-netpol-falsifiability-probe.yaml
+
+commonAnnotations:
+  # This namespace's own isolation is the point of the module -- prevent pruning
+  # unintentionally, same convention as clusters/nas/outpost.
+  kustomize.toolkit.fluxcd.io/prune: disabled

--- a/clusters/homelab/services/sandbox-talos/namespace.yaml
+++ b/clusters/homelab/services/sandbox-talos/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sandbox-talos
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    kustomize.toolkit.fluxcd.io/ssa: merge
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/homelab/services/sandbox-talos/network-policy.yaml
+++ b/clusters/homelab/services/sandbox-talos/network-policy.yaml
@@ -97,6 +97,20 @@ spec:
 # Port 6443 is the sandbox's own Kubernetes API; 50000 is the Talos API (talosctl).
 # Neither the coder namespace nor the ai mcp-server pods can reach sandbox-docker from
 # here -- that omission is load-bearing, see sandbox-docker/network-policy.yaml.
+#
+# No rule here admits the `kubevirt` namespace either -- same reasoning as
+# sandbox-docker/network-policy.yaml: every operational KubeVirt path (lifecycle over a
+# node-local unix socket, console/VNC/serial and metrics via virt-handler's own pod IP
+# inside `kubevirt`) never crosses into this namespace, so nothing about running or
+# managing the VM depends on one existing. `virtctl ssh`/`virtctl port-forward` are the
+# one exception (virt-api dials the VM's masquerade pod IP directly) and stay blocked;
+# `kubectl port-forward` is the supported substitute (a different mechanism -- containerd's
+# CRI dials localhost inside the pod's own netns, never reaches the veth this policy
+# enforces on). For this VM specifically, `virtctl ssh` was never going to work anyway:
+# Talos ships no SSH daemon at all, API-only via talosctl on :50000 with mTLS. Admitting
+# `kubevirt` would also be namespace-scoped, pulling in virt-api/virt-operator/
+# virt-controller alongside virt-handler -- not worth it for a path with no daemon behind
+# it here and a working substitute for the Kubernetes-API case.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/clusters/homelab/services/sandbox-talos/network-policy.yaml
+++ b/clusters/homelab/services/sandbox-talos/network-policy.yaml
@@ -1,0 +1,124 @@
+---
+# Default-deny both directions -- see sandbox-docker/network-policy.yaml for why this
+# namespace also locks down egress, not just ingress like every other NetworkPolicy in the
+# apps repo. Here the reasoning is symmetric rather than about the workload itself: this
+# namespace is the one AI agents get full write access to (today they only have read-only
+# cluster access, via mcp-kubernetes-readonly), so egress from it has to be closed by
+# default on the same footing as ingress into it.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: sandbox-talos
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+# See sandbox-docker/network-policy.yaml -- identical rule, same reasoning: CoreDNS has no
+# NetworkPolicies of its own, so this podSelector-based rule is the only place DNS egress
+# is enforced, and it has to be podSelector-based (not the kube-dns ClusterIP) to avoid
+# landing inside the 10.0.0.0/8 `except` in allow-egress-internet.yaml below.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: sandbox-talos
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+---
+# Same-namespace traffic, so the Talos VM's virt-launcher pod can reach any Service
+# fronting the sandbox cluster that also lives here (e.g. its own API server Service, if
+# one gets fronted that way). Scoped to this namespace only, same as sandbox-docker.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace-egress
+  namespace: sandbox-talos
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - podSelector: {}
+---
+# See sandbox-docker/network-policy.yaml for why this exact `except` list is most of this
+# namespace's security value: it closes the prod kube-apiserver, Longhorn's manager API,
+# kubelet, etcd, the UniFi gateway, and the NAS in one object, and it is the control this
+# whole design leans on hardest, because this namespace is the one agents can write to.
+# Internet egress stays open on purpose (package/image pulls for the sandbox cluster
+# itself); nothing about that weakens the boundary against the LAN and prod cluster, which
+# is the boundary that actually matters here.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-internet
+  namespace: sandbox-talos
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+        - 169.254.0.0/16
+        - 127.0.0.0/8
+---
+# Two admitted sources, deliberately not sandbox-docker: the operator's own `coder`
+# workspace pods, and whichever MCP server pod in `ai` is the write-capable Kubernetes
+# access path for this sandbox. Selector shape mirrors apps/subsystems/ai/network-policy.yaml
+# (mcp-servers-ingress) exactly -- app.kubernetes.io/component: mcp-server, not a name
+# list, so a server added to `ai` later (e.g. the write-capable Talos MCP this sandbox is
+# built for) is admitted automatically instead of silently falling outside every policy
+# that lists servers by name.
+#
+# Port 6443 is the sandbox's own Kubernetes API; 50000 is the Talos API (talosctl).
+# Neither the coder namespace nor the ai mcp-server pods can reach sandbox-docker from
+# here -- that omission is load-bearing, see sandbox-docker/network-policy.yaml.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-coder-and-mcp-ingress
+  namespace: sandbox-talos
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: coder
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ai
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/component: mcp-server
+    ports:
+    - protocol: TCP
+      port: 6443
+    - protocol: TCP
+      port: 50000

--- a/policies/pod-security-standard/baseline/disallow-capabilities.yaml
+++ b/policies/pod-security-standard/baseline/disallow-capabilities.yaml
@@ -62,16 +62,15 @@ spec:
           - metallb-system
           - system-upgrade
           - tailscale
-      # virt-handler and virt-launcher add capabilities beyond this policy's default-safe
-      # set (e.g. NET_ADMIN, SYS_ADMIN, SYS_NICE, SYS_PTRACE, SYS_RESOURCE) to manage VM
-      # networking and CPU/scheduling. See disallow-host-path.yaml for why this is
-      # name-scoped rather than namespace-scoped.
+      # virt-handler sets no explicit capabilities.add list at all -- Privileged: true (see
+      # disallow-privileged-containers.yaml) already grants everything it needs, so this rule
+      # shouldn't trip in practice. Kept as a low-cost safety margin on the one component in
+      # this repo that runs privileged, rather than removed on that analysis alone.
+      # virt-launcher's default (non-root) capabilities are NET_BIND_SERVICE only, already
+      # inside this policy's allowed set, so it isn't excluded here or anywhere else in this
+      # file.
       - resources:
           names:
           - 'virt-handler*'
-          - 'virt-launcher*'
-          - 'virt-operator*'
           namespaces:
           - kubevirt
-          - sandbox-docker
-          - sandbox-talos

--- a/policies/pod-security-standard/baseline/disallow-capabilities.yaml
+++ b/policies/pod-security-standard/baseline/disallow-capabilities.yaml
@@ -62,3 +62,16 @@ spec:
           - metallb-system
           - system-upgrade
           - tailscale
+      # virt-handler and virt-launcher add capabilities beyond this policy's default-safe
+      # set (e.g. NET_ADMIN, SYS_ADMIN, SYS_NICE, SYS_PTRACE, SYS_RESOURCE) to manage VM
+      # networking and CPU/scheduling. See disallow-host-path.yaml for why this is
+      # name-scoped rather than namespace-scoped.
+      - resources:
+          names:
+          - 'virt-handler*'
+          - 'virt-launcher*'
+          - 'virt-operator*'
+          namespaces:
+          - kubevirt
+          - sandbox-docker
+          - sandbox-talos

--- a/policies/pod-security-standard/baseline/disallow-host-namespaces.yaml
+++ b/policies/pod-security-standard/baseline/disallow-host-namespaces.yaml
@@ -43,18 +43,6 @@ spec:
           - 'kube-prometheus-stack-prometheus-node-exporter*'
           namespaces:
           - monitoring
-      # virt-handler manages VM network binding (bridge/masquerade) from the node's own
-      # network namespace. See disallow-host-path.yaml for why this is name-scoped rather
-      # than namespace-scoped.
-      - resources:
-          names:
-          - 'virt-handler*'
-          - 'virt-launcher*'
-          - 'virt-operator*'
-          namespaces:
-          - kubevirt
-          - sandbox-docker
-          - sandbox-talos
   - name: host-pid-namespaces
     match:
       any:
@@ -75,18 +63,18 @@ spec:
           - 'kube-prometheus-stack-prometheus-node-exporter*'
           namespaces:
           - monitoring
-      # virt-handler shares the host PID namespace to supervise qemu processes running
-      # directly on the node. See disallow-host-path.yaml for why this is name-scoped
-      # rather than namespace-scoped.
+      # virt-handler sets hostPID: true to see and supervise the qemu process libvirt starts
+      # on the node -- it has no other way to monitor a process that isn't a child of its own
+      # container. See disallow-privileged-containers.yaml for what bounds virt-handler's
+      # access generally. Verified against upstream KubeVirt's generated manifests: virt-handler
+      # doesn't set hostNetwork or hostIPC, so neither the rule above nor the one below carries
+      # a KubeVirt exclusion, and virt-operator/virt-api/virt-controller/virt-launcher don't
+      # need this rule's exclusion either.
       - resources:
           names:
           - 'virt-handler*'
-          - 'virt-launcher*'
-          - 'virt-operator*'
           namespaces:
           - kubevirt
-          - sandbox-docker
-          - sandbox-talos
   - name: host-ipc-namespaces
     match:
       any:
@@ -100,16 +88,3 @@ spec:
       pattern:
         spec:
           =(hostIPC): "false"
-    exclude:
-      any:
-      # No prior exclusions on this rule. See disallow-host-path.yaml for why this is
-      # name-scoped rather than namespace-scoped.
-      - resources:
-          names:
-          - 'virt-handler*'
-          - 'virt-launcher*'
-          - 'virt-operator*'
-          namespaces:
-          - kubevirt
-          - sandbox-docker
-          - sandbox-talos

--- a/policies/pod-security-standard/baseline/disallow-host-namespaces.yaml
+++ b/policies/pod-security-standard/baseline/disallow-host-namespaces.yaml
@@ -43,6 +43,18 @@ spec:
           - 'kube-prometheus-stack-prometheus-node-exporter*'
           namespaces:
           - monitoring
+      # virt-handler manages VM network binding (bridge/masquerade) from the node's own
+      # network namespace. See disallow-host-path.yaml for why this is name-scoped rather
+      # than namespace-scoped.
+      - resources:
+          names:
+          - 'virt-handler*'
+          - 'virt-launcher*'
+          - 'virt-operator*'
+          namespaces:
+          - kubevirt
+          - sandbox-docker
+          - sandbox-talos
   - name: host-pid-namespaces
     match:
       any:
@@ -63,6 +75,18 @@ spec:
           - 'kube-prometheus-stack-prometheus-node-exporter*'
           namespaces:
           - monitoring
+      # virt-handler shares the host PID namespace to supervise qemu processes running
+      # directly on the node. See disallow-host-path.yaml for why this is name-scoped
+      # rather than namespace-scoped.
+      - resources:
+          names:
+          - 'virt-handler*'
+          - 'virt-launcher*'
+          - 'virt-operator*'
+          namespaces:
+          - kubevirt
+          - sandbox-docker
+          - sandbox-talos
   - name: host-ipc-namespaces
     match:
       any:
@@ -76,3 +100,16 @@ spec:
       pattern:
         spec:
           =(hostIPC): "false"
+    exclude:
+      any:
+      # No prior exclusions on this rule. See disallow-host-path.yaml for why this is
+      # name-scoped rather than namespace-scoped.
+      - resources:
+          names:
+          - 'virt-handler*'
+          - 'virt-launcher*'
+          - 'virt-operator*'
+          namespaces:
+          - kubevirt
+          - sandbox-docker
+          - sandbox-talos

--- a/policies/pod-security-standard/baseline/disallow-host-path.yaml
+++ b/policies/pod-security-standard/baseline/disallow-host-path.yaml
@@ -55,3 +55,19 @@ spec:
           - 'intel-gpu-plugin-gpu-device*'
           namespaces:
           - intel-device-plugins
+      # KubeVirt needs hostPath for virt-handler's access to /dev, libvirt/qemu sockets,
+      # and cgroup paths on the node; virt-launcher mounts a handful of host device nodes
+      # (e.g. /dev/kvm) the same way. Name-scoped, not namespace-scoped, on purpose: a
+      # namespace-wide exclusion would silently admit hostPath for anything else later
+      # deployed into these namespaces, not just KubeVirt's own components. `kubevirt` is
+      # the conventional install namespace for virt-operator/virt-handler; KubeVirt is not
+      # installed yet, so this exclusion grants nothing until it is.
+      - resources:
+          names:
+          - 'virt-handler*'
+          - 'virt-launcher*'
+          - 'virt-operator*'
+          namespaces:
+          - kubevirt
+          - sandbox-docker
+          - sandbox-talos

--- a/policies/pod-security-standard/baseline/disallow-host-path.yaml
+++ b/policies/pod-security-standard/baseline/disallow-host-path.yaml
@@ -55,19 +55,19 @@ spec:
           - 'intel-gpu-plugin-gpu-device*'
           namespaces:
           - intel-device-plugins
-      # KubeVirt needs hostPath for virt-handler's access to /dev, libvirt/qemu sockets,
-      # and cgroup paths on the node; virt-launcher mounts a handful of host device nodes
-      # (e.g. /dev/kvm) the same way. Name-scoped, not namespace-scoped, on purpose: a
+      # virt-handler hostPath-mounts libvirt/qemu runtime dirs, kubelet's pod and device
+      # dirs, and node-labeller state (see disallow-privileged-containers.yaml for what
+      # bounds it). Verified against upstream KubeVirt's generated manifests: virt-launcher
+      # gets /dev/kvm and friends through Kubernetes device-plugin resource requests, not a
+      # hostPath volume, and virt-operator/virt-api/virt-controller mount none at all --
+      # neither is excluded here. Name-scoped, not namespace-scoped, on purpose: a
       # namespace-wide exclusion would silently admit hostPath for anything else later
-      # deployed into these namespaces, not just KubeVirt's own components. `kubevirt` is
-      # the conventional install namespace for virt-operator/virt-handler; KubeVirt is not
-      # installed yet, so this exclusion grants nothing until it is.
+      # deployed into `kubevirt`, not just this one DaemonSet. `kubevirt` is the conventional
+      # install namespace for virt-handler; KubeVirt is not installed yet, so this exclusion
+      # grants nothing until it is, and no other namespace is listed since virt-handler never
+      # runs outside it.
       - resources:
           names:
           - 'virt-handler*'
-          - 'virt-launcher*'
-          - 'virt-operator*'
           namespaces:
           - kubevirt
-          - sandbox-docker
-          - sandbox-talos

--- a/policies/pod-security-standard/baseline/disallow-privileged-containers.yaml
+++ b/policies/pod-security-standard/baseline/disallow-privileged-containers.yaml
@@ -55,17 +55,24 @@ spec:
           - 'node-problem-detector*'
           namespaces:
           - monitoring
-      # virt-handler runs privileged to manage VM lifecycle (libvirt/qemu process
-      # supervision, cgroup/device management) on the node it's scheduled to; some
-      # virt-launcher configurations also require it. See disallow-host-path.yaml for why
-      # this is name-scoped rather than namespace-scoped, and why `kubevirt` is listed
-      # even though nothing runs there yet.
+      # Grants virt-handler root plus every Linux capability on whichever node it lands on --
+      # it's the node agent that opens /dev/kvm and other host devices, drives libvirt/qemu
+      # process lifecycle, and edits cgroups directly, none of which an unprivileged container
+      # can do. Bounded by: once KubeVirt is installed, its CR's
+      # `spec.workloads.nodePlacement.nodeSelector` restricts virt-handler to the two nodes
+      # OPERATIONS.md's KubeVirt runbook prepares, not all four; and virt-launcher, where a VM's
+      # guest actually runs, is deliberately NOT privileged (its one, much narrower, exclusion
+      # is in restrict-seccomp-strict.yaml). Not bounded by anything here: a QEMU/KVM guest
+      # escape into virt-launcher is one more bug away from the host, at exactly the
+      # virt-handler<->virt-launcher boundary -- a boundary with a live CVE lineage
+      # (CVE-2025-64437, CVE-2025-64433; both fixed in 1.5.3/1.6.1). Keep KubeVirt patched;
+      # this exclusion doesn't defend against that class of bug, only the DaemonSet's own
+      # shape. `virt-operator`/`virt-api`/`virt-controller` aren't excluded anywhere in this
+      # repo: verified against upstream KubeVirt's generated manifests, none of them run
+      # privileged. See disallow-host-path.yaml for why every virt-handler exclusion here is
+      # name-scoped, not namespace-scoped, and why only the `kubevirt` namespace is listed.
       - resources:
           names:
           - 'virt-handler*'
-          - 'virt-launcher*'
-          - 'virt-operator*'
           namespaces:
           - kubevirt
-          - sandbox-docker
-          - sandbox-talos

--- a/policies/pod-security-standard/baseline/disallow-privileged-containers.yaml
+++ b/policies/pod-security-standard/baseline/disallow-privileged-containers.yaml
@@ -55,3 +55,17 @@ spec:
           - 'node-problem-detector*'
           namespaces:
           - monitoring
+      # virt-handler runs privileged to manage VM lifecycle (libvirt/qemu process
+      # supervision, cgroup/device management) on the node it's scheduled to; some
+      # virt-launcher configurations also require it. See disallow-host-path.yaml for why
+      # this is name-scoped rather than namespace-scoped, and why `kubevirt` is listed
+      # even though nothing runs there yet.
+      - resources:
+          names:
+          - 'virt-handler*'
+          - 'virt-launcher*'
+          - 'virt-operator*'
+          namespaces:
+          - kubevirt
+          - sandbox-docker
+          - sandbox-talos

--- a/policies/pod-security-standard/restricted/disallow-capabilities-strict.yaml
+++ b/policies/pod-security-standard/restricted/disallow-capabilities-strict.yaml
@@ -40,6 +40,18 @@ spec:
             - key: ALL
               operator: AnyNotIn
               value: "{{ element.securityContext.capabilities.drop[] || `[]` }}"
+    exclude:
+      any:
+      # virt-handler's containers don't set capabilities.drop: [ALL] -- Privileged: true (see
+      # ../baseline/disallow-privileged-containers.yaml) already grants everything the
+      # drop-list would otherwise strip, so declaring it would be cosmetic. The sibling rule
+      # below (adding-capabilities-strict) isn't excluded: virt-handler's manifest never adds
+      # a named capability either, so that check already passes on its own.
+      - resources:
+          names:
+          - 'virt-handler*'
+          namespaces:
+          - kubevirt
   - name: adding-capabilities-strict
     match:
       any:

--- a/policies/pod-security-standard/restricted/disallow-privilege-escalation.yaml
+++ b/policies/pod-security-standard/restricted/disallow-privilege-escalation.yaml
@@ -41,3 +41,14 @@ spec:
           containers:
           - securityContext:
               allowPrivilegeEscalation: "false"
+    exclude:
+      any:
+      # Kubernetes rejects allowPrivilegeEscalation: false together with privileged: true, so
+      # a privileged container can never satisfy this field -- virt-handler's privilege (see
+      # ../baseline/disallow-privileged-containers.yaml) makes this exclusion unavoidable, not
+      # optional.
+      - resources:
+          names:
+          - 'virt-handler*'
+          namespaces:
+          - kubevirt

--- a/policies/pod-security-standard/restricted/require-run-as-non-root-user.yaml
+++ b/policies/pod-security-standard/restricted/require-run-as-non-root-user.yaml
@@ -42,3 +42,15 @@ spec:
           containers:
           - =(securityContext):
               =(runAsUser): ">0"
+    exclude:
+      any:
+      # virt-handler's node-labeller init container explicitly sets runAsUser: 0 (it needs
+      # root to read/write host device and label state before the main container starts); the
+      # main container leaves runAsUser unset, which this policy already treats as compliant
+      # on its own. See ../baseline/disallow-privileged-containers.yaml for what bounds
+      # virt-handler generally.
+      - resources:
+          names:
+          - 'virt-handler*'
+          namespaces:
+          - kubevirt

--- a/policies/pod-security-standard/restricted/require-run-as-nonroot.yaml
+++ b/policies/pod-security-standard/restricted/require-run-as-nonroot.yaml
@@ -54,3 +54,14 @@ spec:
           containers:
           - securityContext:
               runAsNonRoot: "true"
+    exclude:
+      any:
+      # Neither virt-handler's pod nor any of its containers set runAsNonRoot: true anywhere
+      # -- it runs as root by design (see
+      # ../baseline/disallow-privileged-containers.yaml), so there's no partial-compliance
+      # path here to preserve.
+      - resources:
+          names:
+          - 'virt-handler*'
+          namespaces:
+          - kubevirt

--- a/policies/pod-security-standard/restricted/restrict-seccomp-strict.yaml
+++ b/policies/pod-security-standard/restricted/restrict-seccomp-strict.yaml
@@ -64,3 +64,25 @@ spec:
           - securityContext:
               seccompProfile:
                 type: "RuntimeDefault | Localhost"
+    exclude:
+      any:
+      # virt-handler sets no seccompProfile at pod or container level -- a privileged
+      # DaemonSet gets no practical extra containment from a seccomp filter anyway. See
+      # ../baseline/disallow-privileged-containers.yaml for what bounds it instead.
+      - resources:
+          names:
+          - 'virt-handler*'
+          namespaces:
+          - kubevirt
+      # virt-launcher (unprivileged -- see ../baseline/disallow-privileged-containers.yaml)
+      # only gets a declared seccompProfile when the KubeVirt CR's
+      # spec.configuration.seccompConfiguration is set, which this repo doesn't do yet; the
+      # container runtime still applies RuntimeDefault regardless, so this is a
+      # manifest-declaration gap, not an actually-unconfined process. Closing it for real
+      # means setting that CR field once KubeVirt is installed, not widening this exclusion.
+      - resources:
+          names:
+          - 'virt-launcher*'
+          namespaces:
+          - sandbox-docker
+          - sandbox-talos

--- a/policies/pod-security-standard/restricted/restrict-volume-types.yaml
+++ b/policies/pod-security-standard/restricted/restrict-volume-types.yaml
@@ -50,3 +50,15 @@ spec:
             - projected
             - secret
             - ''
+    exclude:
+      any:
+      # virt-handler mounts hostPath volumes for libvirt/qemu runtime state, kubelet's
+      # pod/device dirs, and node-labeller data (see ../baseline/disallow-host-path.yaml) --
+      # hostPath isn't in this policy's allow-list at all, so anything using it needs this
+      # exclusion. virt-launcher gets its device access (kvm/tun/vhost-net) through Kubernetes
+      # device-plugin resource requests instead, not a volume, so it isn't excluded here.
+      - resources:
+          names:
+          - 'virt-handler*'
+          namespaces:
+          - kubevirt


### PR DESCRIPTION
## Summary

Phase 3 of the KubeVirt onboarding plan: builds the isolation "cages" for
two planned VMs — a dockerd VM and a single-node Talos sandbox AI agents
get full write access to — before either VM exists.

- Two new namespaces under `clusters/homelab/services/`: `sandbox-docker`,
  `sandbox-talos`.
- Default-deny **ingress and egress** NetworkPolicies in both (the first
  egress-enforcing policies authored directly in this repo — every existing
  NetworkPolicy in the apps repo is ingress-only).
- Egress: DNS to CoreDNS only, same-namespace, and `0.0.0.0/0` except
  `10.0.0.0/8` / `172.16.0.0/12` / `192.168.0.0/16` / `169.254.0.0/16` /
  `127.0.0.0/8` — that `except` list is what closes the prod
  kube-apiserver, Longhorn's manager API, kubelet, etcd, the UniFi gateway,
  and the NAS.
- Ingress differs by design: `sandbox-docker` admits only the `coder`
  namespace (SSH + a documented `kind` `apiServerPort` range);
  `sandbox-talos` admits `coder` and the `ai` namespace's `mcp-server` pods
  (mirrors `apps-ai`'s existing `mcp-servers-ingress` selector shape), never
  `sandbox-docker` — a reachable dockerd is root-equivalent on that VM, so
  the two sandboxes must not reach each other.
- Name-scoped (never namespace-wide) Kyverno exclusions for the Baseline and
  Restricted policies KubeVirt's components will actually trip — see
  "Review follow-ups" below for what changed here.
- A `netpol-falsifiability-probe` CronJob per namespace that asserts every
  denial still holds *and* that internet egress + CoreDNS resolution still
  work, failing the Job if a denial silently stops enforcing (queryable via
  `kube_job_failed`; no AlertManager route by design). `OPERATIONS.md`
  documents the before/after baseline run that makes this probe falsifiable
  rather than decorative.

No VM exists yet — Phase 4/5 drop the two VMs into these namespaces on top
of this.

## Review follow-ups (this update)

The review correctly flagged that this repo's `homelab` cluster runs
Kyverno's **Restricted** PSS tier (adds `disallow-capabilities-strict`,
`disallow-privilege-escalation`, `require-run-as-non-root-user`,
`require-run-as-nonroot`, `restrict-seccomp-strict`, `restrict-volume-types`
on top of Baseline), and the original exclusions here only covered the 4
Baseline policies the brief named literally, declining to guess at the
Restricted gap without direction.

Verified per-component against upstream KubeVirt's actual generated
manifests (Deployment/DaemonSet Go source, not assumptions or OpenShift SCC
docs describing a different ceiling):

- **`virt-handler`** (DaemonSet) is genuinely privileged, `hostPID`, runs
  root, declares no seccomp profile, and hostPath-mounts libvirt/kubelet/
  node-labeller state. It trips all 6 Restricted policies, plus (as
  originally scoped) 3 of the 4 Baseline ones — see below on the 4th.
- **`virt-launcher`** (the per-VM pod) is *not* privileged: KubeVirt's
  default non-root mode drops all capabilities except `NET_BIND_SERVICE`,
  sets `runAsNonRoot`/`runAsUser=107`, `allowPrivilegeEscalation=false`,
  gets `/dev/kvm`/`tun`/`vhost-net` via device-plugin resource requests
  rather than a hostPath volume, and uses only allow-listed volume types.
  The one real gap: it never declares a `seccompProfile` (the KubeVirt CR's
  `seccompConfiguration` isn't set in this repo), so it trips exactly one
  Restricted policy — `restrict-seccomp-strict` — and nothing else.
- **`virt-operator`/`virt-api`/`virt-controller`** are ordinary Deployments:
  non-root, drop-all capabilities, no hostPath, no host namespaces. They
  trip nothing in either tier and get no exclusions anywhere.

That same verification also caught that the already-merged Baseline
exclusions were over-scoped: `virt-launcher*`/`virt-operator*` were excluded
from `disallow-capabilities`/`disallow-host-path`/`disallow-privileged-containers`
even though neither ever trips them, and `disallow-host-namespaces` excluded
all three components from its `hostNetwork` and `hostIPC` rules when
`virt-handler` only ever sets `hostPID`. Narrowed all four Baseline files to
`virt-handler*` only, on exactly the rules it actually trips — excluding a
component from a policy it never violates is a standing false grant the
moment that component's manifest changes, not merely redundant today. Also
narrowed every namespace list from `[kubevirt, sandbox-docker, sandbox-talos]`
to only where each component can actually be named (`virt-handler` only ever
runs in `kubevirt`; `virt-launcher` only in the two sandbox namespaces).

Every exclusion is name-scoped, never namespace-wide (the existing
`intel-gpu-plugin-gpu-device*` precedent), and its comment now states three
things: what's tolerated in plain terms (not "excludes X from Y" — the diff
already says that), why KubeVirt genuinely needs it tied to the actual
mechanism, and what bounds the risk. For `virt-handler`'s privilege
specifically: once KubeVirt is installed its CR's
`spec.workloads.nodePlacement.nodeSelector` restricts it to the two nodes
`OPERATIONS.md`'s KubeVirt runbook prepares (#814), not all four, and
`virt-launcher` — where a VM's guest actually executes — is unprivileged.
The residual this doesn't close is recorded rather than left implicit: a
guest escape reaching the host needs a second bug at exactly the
`virt-handler`↔`virt-launcher` boundary, which has a live CVE lineage
(CVE-2025-64437, CVE-2025-64433, both fixed in 1.5.3/1.6.1) — pin to a
patched KubeVirt version.

All policies stay `validationFailureAction: Audit`; nothing is blocked
today. These exclusions are written to the shape Enforce would need so that
moving to Enforce later doesn't require re-deriving any of this.

## Documented: why kubevirt-namespace ingress stays blocked (this update)

A source-level verification of KubeVirt v1.9 established that every
operational path — VM lifecycle (start/stop/pause/exec, domain stats) over a
node-local unix socket on a shared hostPath, console/VNC/serial and metrics
via `virt-handler`'s own pod IP inside the `kubevirt` namespace — is
node-local or stays within `virt-handler`, and never needs a route into
`sandbox-docker`/`sandbox-talos`. The one exception is `virtctl ssh`/
`virtctl port-forward`: `pkg/virt-api/rest/portforward.go` uses `netDial`
rather than `virtHandlerDialer`, so `virt-api` dials the VM's masquerade pod
IP directly — that *does* cross into the sandbox namespace.

**Decision: leave it blocked, don't add a `kubevirt`-namespace ingress
rule.** Nothing operational depends on it; `kubectl port-forward` is a fully
equivalent, unaffected substitute (containerd's CRI dials `localhost` inside
the pod's own network namespace, never reaching the veth NetworkPolicy
enforces on); and a namespace-scoped admit would also let in `virt-api`/
`virt-operator`/`virt-controller` alongside the already-privileged
`virt-handler` — not a cost worth paying for a path with a working
substitute.

That decision is otherwise invisible (it manifests as nothing being there),
so it's recorded in both places a future reader would look:

- A comment next to each namespace's ingress `NetworkPolicy`
  (`allow-coder-ingress` in `sandbox-docker`, `allow-coder-and-mcp-ingress`
  in `sandbox-talos`) stating the absence is deliberate, why it's safe, the
  supported alternative, and what admitting `kubevirt` would cost.
- A new `OPERATIONS.md` runbook, **"reach the sandbox VMs"**, with the
  actual `kubectl port-forward` commands for the Talos API (`:50000`), the
  sandbox Kubernetes API (`:6443`), and the Docker VM's SSH (`:22`), each
  pointing the client at `127.0.0.1` — so `virtctl ssh`'s failure is
  pre-explained, not debugged. Also notes Talos ships no SSH daemon at all
  (API-only via `talosctl` on `:50000` with mTLS), so the SSH question
  doesn't arise for that VM regardless of NetworkPolicy.

## Merge order

This PR, #814 (`docs/kubevirt-talos-node-runbooks`), and #817
(`feat/wire-infra-virtualization-core`) all independently added
`OPERATIONS.md`, which didn't exist on `main` when any of the three were
opened. **#814 has since merged** (`OPERATIONS.md` now carries its
node-prep and Talos containerDisk runbooks on `main`), so this branch has
been rebased onto current `main` and its `OPERATIONS.md` conflict resolved
here: the "verify the sandbox NetworkPolicy falsifiability probes" and
"reach the sandbox VMs" runbooks now sit after #814's two runbooks in one
file, and the `CLAUDE.md`/`README.md` one-line pointers to it are merged
rather than duplicated. #817 still creates `OPERATIONS.md` independently
and will need the same rebase-and-fold treatment on its own branch before
it can merge.

## Test plan

- [x] `pre-commit run --all-files` passes (yamllint, markdownlint,
      shellcheck, kubeconform-based manifest validation).
- [x] `kustomize build clusters/homelab` and each new
      `services/sandbox-{docker,talos}/` directory build cleanly.
- [x] `kustomize build` on `policies/pod-security-standard/baseline` and
      `.../restricted` build cleanly with the new exclusions.
- [x] Embedded probe shell script extracted and run through `shellcheck -s
      sh` clean.
- [ ] Not applied to any live cluster (no write access; CI/operator only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


