### PR TITLE
feat(cluster-homelab): wire infra-virtualization-core (KubeVirt) v0.1.0

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -384,6 +384,19 @@ sudo rm -f /etc/rancher/k3s/config.yaml.d/90-kubevirt.yaml
 kubectl label node beelink-ser8-1 homelab-ops.internal/virtualization-
 ```
 
+### 6. Sequencing hazard: label before `infra-virtualization-core` reconciles
+
+**As of this writing, no node carries `homelab-ops.internal/virtualization=enabled`
+yet** — step 2 above is written but not yet applied. If the
+`infra-virtualization-core` `Kustomization` reconciles first, `virt-handler` has
+nowhere to schedule and the `KubeVirt` custom resource sits un-`Deployed`
+indefinitely. From the outside that looks identical to a real failure
+(virt-operator crash-looping, a wrong monitor `ServiceAccount`, a bad
+`GitRepository` tag) but is just this precondition — check
+`kubectl get nodes -l homelab-ops.internal/virtualization=enabled` before
+assuming anything else is wrong. Run [Path A](#path-a--these-two-nodes-today)
+first, then let `infra-virtualization-core` reconcile.
+
 ## Runbook: build and publish the Talos containerDisk
 
 **Why:** the single-node Talos sandbox VM boots from a KubeVirt

--- a/clusters/homelab/kustomizations/infra-virtualization-core.yaml
+++ b/clusters/homelab/kustomizations/infra-virtualization-core.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-virtualization-core
+  namespace: flux-system
+spec:
+  # No dependsOn: infra-virtualization-core is self-contained (its own CRD,
+  # operator, RBAC) and its nodeSelector targets a manually-applied label,
+  # not a node-feature-discovery one -- see the module's own README
+  # (Dependencies: Depends On: None) in the apps repo.
+  interval: 15m0s
+  path: ./infrastructure/subsystems/virtualization-core
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: infra-virtualization-core
+    namespace: flux-system
+  # The KubeVirt operator installs the KubeVirt CRD in the same reconcile as
+  # the KubeVirt CR that depends on it, so the first attempt(s) may hit "no
+  # matches for kind KubeVirt" before the CRD is established. A short
+  # retryInterval keeps that window seconds, not the default (== interval)
+  # 15m0s; timeout is generous enough for virt-operator plus per-node
+  # virt-handlers to come up.
+  retryInterval: 1m0s
+  timeout: 5m0s
+  wait: true
+  postBuild:
+    substitute:
+      kubevirt_use_emulation: "false"
+      kubevirt_monitor_namespace: monitoring
+      # The real kube-prometheus-stack Prometheus ServiceAccount (read from
+      # the live monitoring.coreos.com/v1 Prometheus's spec.serviceAccountName),
+      # not upstream's OpenShift-oriented "prometheus-k8s" default -- virt-operator
+      # silently skips creating its ServiceMonitor (no error, just a log line) if
+      # it can't find a ServiceAccount by this name in this namespace.
+      kubevirt_monitor_account: kube-prometheus-stack-prometheus

--- a/clusters/homelab/kustomizations/kustomization.yaml
+++ b/clusters/homelab/kustomizations/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
 - infra-security-core.yaml
 - infra-security-extra.yaml
 - infra-storage-core.yaml
+- infra-virtualization-core.yaml
 - apps-ai.yaml
 - apps-coder.yaml
 - apps-downloaders.yaml

--- a/clusters/homelab/sources/infra-virtualization-core.yaml
+++ b/clusters/homelab/sources/infra-virtualization-core.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: infra-virtualization-core
+  namespace: flux-system
+spec:
+  ignore: |
+    # exclude all
+    /*
+    # include the corresponding infrastructure subsystems directory
+    !/infrastructure/subsystems/virtualization-core
+  interval: 1m0s
+  ref:
+    tag: infra-virtualization-core-v0.1.0
+  url: https://github.com/ppat/homelab-ops-kubernetes-apps.git

--- a/clusters/homelab/sources/kustomization.yaml
+++ b/clusters/homelab/sources/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
 - infra-security-core.yaml
 - infra-security-extra.yaml
 - infra-storage-core.yaml
+- infra-virtualization-core.yaml
 - apps-ai.yaml
 - apps-coder.yaml
 - apps-downloaders.yaml


### PR DESCRIPTION
## Summary

Wires the `infra-virtualization-core` module (KubeVirt operator + CR) into the `homelab` cluster, pinned to `infra-virtualization-core-v0.1.0`. This is the platform-capability step that a later, separate phase (VM workloads: an Ubuntu `dockerd` VM for unprivileged Coder workspaces, a single-node Talos sandbox for AI agents) depends on. That later phase is **not** part of this PR, and neither are the sandbox namespaces/NetworkPolicies in #815 — this PR only makes KubeVirt itself deployable.

- `clusters/homelab/sources/infra-virtualization-core.yaml` — `GitRepository`, `ignore` scoped to the module's own directory, matching every other source in this cluster.
- `clusters/homelab/kustomizations/infra-virtualization-core.yaml` — no `dependsOn` (see below), `wait: true`, a short `retryInterval` (1m) and a generous `timeout` (5m), and the module's `postBuild.substitute` variables.
- `OPERATIONS.md` — a short "Sequencing hazard" subsection on the node-labelling precondition (see below), slotted into the existing "Runbook: prepare a node for KubeVirt" that `main` already carries as of #814 (see **Rebased onto current `main`** below) rather than added as a separate block.

## `ref.tag` — pinned to `v0.1.0`, not `v0.0.1`

This branch originally targeted `infra-virtualization-core-v0.0.1`, whose `KubeVirt` CR still exposed the node-placement label as two Flux `postBuild` variables (`vm_node_label_key`/`vm_node_label_value`). This `Kustomization` doesn't supply either — apps repo PR [ppat/homelab-ops-kubernetes-apps#3506](https://github.com/ppat/homelab-ops-kubernetes-apps/pull/3506) removed both and replaced them with a hardcoded module constant (`homelab-ops.internal/virtualization: "enabled"`), since the label key is the module's own scheduling contract, not cluster config. Merging against `v0.0.1` would have left `${vm_node_label_key}`/`${vm_node_label_value}` unresolved in the rendered `KubeVirt` CR, which Flux would refuse to apply.

#3506 merged and release-please cut `infra-virtualization-core-v0.1.0` off its `BREAKING CHANGE:` marker (minor rather than major — the module is pre-1.0, `bump-minor-pre-major: true`). `ref.tag` here is pinned to that tag, verified against the actual `refs/tags/infra-virtualization-core-v0.1.0` in the apps repo rather than assumed. `v0.1.0`'s `kubevirt-cr.yaml` references exactly three `${...}` substitution variables — `kubevirt_use_emulation`, `kubevirt_monitor_namespace`, `kubevirt_monitor_account` — all three of which this `Kustomization` supplies (see table below); no variable is missing and none supplied here goes unread.

## Node-label precondition

`kustomizations/infra-virtualization-core.yaml` schedules KubeVirt's privileged `virt-handler`/`virt-api`/`virt-controller` onto nodes carrying `homelab-ops.internal/virtualization=enabled` — the module's own hardcoded scheduling contract as of `v0.1.0`, not a per-cluster configurable value. **No node currently carries that label** — applying it is a manual, out-of-band step this repo's Flux reconciliation cannot perform on its own:

```bash
kubectl label node beelink-ser8-1 homelab-ops.internal/virtualization=enabled
kubectl label node minisforum-nab9-1 homelab-ops.internal/virtualization=enabled
```

(The full node-prep runbook — pre-flight checks, the git-visible `config.yaml.d` drop-in, and rollback — is in `OPERATIONS.md`'s "Runbook: prepare a node for KubeVirt", merged by #814; the commands above are its "Path A" shortcut for these two already-qualified nodes.)

If this `Kustomization` reconciles before the target nodes carry the label, `virt-handler` has nowhere to schedule and the `KubeVirt` CR sits un-`Deployed` indefinitely. `OPERATIONS.md` already documents everything else about this precondition (the label constant, why it's a module contract not cluster config, "Path A" for these two nodes) — this PR's only addition is a short "### 6. Sequencing hazard" subsection at the end of that same runbook stating the un-`Deployed` symptom and pointing back at "Path A", rather than repeating anything. **Label the target nodes first, then merge/let this reconcile.**

### Three failure modes that all look identical from the outside (Kustomization stuck, not Ready) — how to tell them apart

1. **Unlabelled nodes** (the expected state right now): `kubectl get nodes -l homelab-ops.internal/virtualization=enabled` returns nothing. Fix: label the nodes (above), then let Flux reconcile.
2. **Wrong/dangling `ref.tag`**: `flux get sources git infra-virtualization-core -n flux-system` reports it can't resolve the tag, or the rendered CR has a literal, unresolved `${...}` in it.
3. **Wrong monitor `ServiceAccount`**: doesn't block `Deployed` at all (virt-operator only skips creating the `ServiceMonitor`, no error) — check `kubectl get servicemonitor -n kubevirt` exists and `kubectl logs -n kubevirt deploy/virt-operator | grep -i monitor` for a silent skip message.

Also expect the *first* reconcile attempt(s) to legitimately show `no matches for kind "KubeVirt"` — the CRD ships in the same module as the CR that needs it. That should clear within the 1m `retryInterval`, not require manual intervention.

## The substitution values, and where each came from

| Variable | Value | Source |
| --- | --- | --- |
| `kubevirt_use_emulation` | `"false"` | Given directly — both target nodes have `/dev/kvm` and an all-PASS `virt-host-validate qemu` per #814's pre-flight, so hardware virtualization is available. |
| `kubevirt_monitor_namespace` | `monitoring` | Given directly. |
| `kubevirt_monitor_account` | `kube-prometheus-stack-prometheus` | Read live from the `homelab` cluster via the `kubernetes_homelab` MCP tool: `monitoring.coreos.com/v1 Prometheus/kube-prometheus-stack -n monitoring`, field `spec.serviceAccountName`. **Not** upstream's `prometheus-k8s` default (an OpenShift convention that doesn't exist under kube-prometheus-stack) and not guessed. |

`vm_node_label_key`/`vm_node_label_value` are **not** supplied — `v0.1.0` no longer reads either (see the `ref.tag` section above).

## Where this PR now differs from its original version

- **Removed `dependsOn: infra-kubernetes-core`.** The original version of this PR added it on the reasoning that node-feature-discovery lives in `infra-kubernetes-core`. That reasoning doesn't hold up: this module's own README (`infrastructure/subsystems/virtualization-core/README.md`, `## Dependencies` → `### Depends On`) states plainly **"None. This module ships its own CRD, operator, and RBAC, and requires no secret store, storage class, or other module's resources."** — and the `nodeSelector` targets a manually-applied label (`kubectl label node`), not anything NFD generates. A `dependsOn` asserting a relationship that doesn't exist is dead config that misleads whoever reads it next, so it's gone. `wait: true` plus the short `retryInterval` already handle the one real ordering wrinkle (CRD not yet established on first reconcile) without needing a cross-module dependency.
- **`retryInterval`/generous `timeout` unchanged from the original PR**: no other Kustomization in this repo sets `retryInterval` explicitly (all inherit the Flux default, which equals `interval` — 15m here, far too slow for the expected CRD-not-yet-present window). Kept the explicit `1m0s`. `timeout` here is `5m0s` vs. this repo's usual `2m0s` (only the two `policy-*` Kustomizations currently use `5m`) — the extra headroom is for virt-operator + per-node virt-handlers, not observed empirically since nothing is applied to the live cluster.

## Rebased onto current `main` (twice — after #814, then again after #815)

`main` moved twice while this PR was open, both times bringing `OPERATIONS.md` along:

- **#814** (`docs/kubevirt-talos-node-runbooks`) merged first, landing `OPERATIONS.md` with the KubeVirt node-prep and Talos containerDisk runbooks. This branch originally created `OPERATIONS.md` from scratch too, so the first rebase folded this PR's note into #814's already-merged "Runbook: prepare a node for KubeVirt" as a new closing subsection (`### 6. Sequencing hazard`) rather than a standalone block, cross-referencing "Path A" instead of repeating its `kubectl label` steps.
- **#815** (`feat/kubevirt-sandbox-cages`) merged next, adding two more runbooks to the same file ("verify the sandbox NetworkPolicy falsifiability probes" and "reach the sandbox VMs") — unrelated in topic to this PR's node-labelling concern, so the second rebase needed no further change to this PR's own content, just replaying it onto the now-larger file.

`OPERATIONS.md` now carries four runbooks total (#814's two, #815's two, plus this PR's one subsection folded into #814's first one) with nothing duplicated between them. The `CLAUDE.md`/`README.md` one-line pointers to `OPERATIONS.md` are #814's and #815's, unchanged by this PR.

## Verification

- `kustomize build clusters/homelab` — clean, both new resources render correctly (`postBuild.substitute` values and the cluster-wide `prune: false` patch apply as expected). This validates the `Kustomization`/`GitRepository` CRs' own schema and substitution wiring, not KubeVirt's actual runtime behavior — that only happens on reconcile, which nothing here triggers (no cluster write access).
- `pre-commit run --all-files` — all hooks pass (yamllint, markdownlint, shellcheck, commitlint, kubeconform via `validate-kubernetes-manifests`).
- **Not applied to the live cluster** — no cluster write access, per instructions.

## Test plan

- [x] `ref.tag` bumped to `infra-virtualization-core-v0.1.0`, verified against the apps repo's actual tag and the module's `${...}` references at that tag.
- [ ] Label `beelink-ser8-1` and `minisforum-nab9-1` with `homelab-ops.internal/virtualization=enabled` **before** merging/reconciling this PR.
- [ ] After merge, confirm `flux get sources git infra-virtualization-core -n flux-system` resolves the tag and `flux get kustomizations infra-virtualization-core -n flux-system` reaches `Deployed`/Ready.
- [ ] Confirm `kubectl get servicemonitor -n kubevirt` exists (validates the monitor ServiceAccount was accepted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

