### PR TITLE
fix(cluster-homelab): close three loose ends in the sandbox netpol probe

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -758,20 +758,55 @@ logs carry `namespace`/`pod`/`node_name`/`container` labels via promtail):
 # Any violation, ever, in the lookback window:
 {namespace=~"sandbox-docker|sandbox-talos"} |= "(violation)"
 
-# The pod itself failing to become policed (crash-loop signature):
+# The pod itself failing to become policed at startup (crash-loop signature):
 {namespace=~"sandbox-docker|sandbox-talos"} |= "WARMUP-TIMEOUT"
+
+# The pod losing enforcement mid-life, after having passed the warm-up gate
+# (see "Mid-life re-verification" below) -- distinct from WARMUP-TIMEOUT
+# because it's a materially more alarming event:
+{namespace=~"sandbox-docker|sandbox-talos"} |= "MIDLIFE-ENFORCEMENT-LAPSE"
 ```
 
 An absent recent `SUMMARY` line is itself a signal worth treating as
 suspect — it means the probe stopped producing cycles, not that it found
-nothing wrong; a crash-looping pod (`WARMUP-TIMEOUT`, or a killed container)
-also shows up as `kube_pod_container_status_restarts_total{namespace=~
+nothing wrong; a crash-looping pod (`WARMUP-TIMEOUT`, `MIDLIFE-ENFORCEMENT-
+LAPSE`, or a killed container) also shows up as
+`kube_pod_container_status_restarts_total{namespace=~
 "sandbox-docker|sandbox-talos"}` climbing in Prometheus, which is a
 reasonable proxy for what `kube_job_failed` used to surface directly. No
 AlertManager route is wired to any of this, deliberately: this is a homelab
 with no triage layer for alerts yet, so a failure is meant to be found by
 querying, not by paging — wiring an alert route is a follow-up for once
 that layer exists, not part of this change.
+
+The container also carries a `livenessProbe` that restarts it if its internal
+heartbeat file goes stale (`HEARTBEAT_MAX_AGE_SECONDS`, 420s by default) —
+this catches the loop hanging mid-cycle on something with no timeout of its
+own (concretely, the plain `nslookup` calls in the script). That probe's
+result is **not** in this Loki stream: exec probe output goes to kubelet's
+probe result, not the container's stdout, so a heartbeat-triggered restart is
+visible via `kubectl describe pod` (`Warning  Unhealthy`) and the same
+`kube_pod_container_status_restarts_total` climb, not by grepping logs.
+
+### Mid-life re-verification
+
+The warm-up gate (above) only proves a pod was policed **at container
+start**. Every `MIDLIFE_REVERIFY_EVERY_N_CYCLES` cycles (12 by default, ~1
+hour at `PROBE_INTERVAL_SECONDS=300s`), the probe loop re-runs that same
+deny-check against `UNIFI_GATEWAY:443` on its own, outside the ordinary
+per-cycle target list, specifically so a mid-life enforcement lapse (a
+kube-router restart racing this pod, a full iptables resync gone wrong) is
+distinguishable from an ordinary probe violation rather than just adding one
+more line to that cycle's `violations` count. If that re-check finds the
+target reachable, the container logs `MIDLIFE-ENFORCEMENT-LAPSE` and exits
+non-zero rather than logging and continuing — restarting re-runs the warm-up
+gate on the replacement pod, re-proving enforcement before the loop is
+trusted again, at the cost of losing that pod's running history. The
+alternative (log loudly, keep running) was rejected: continuing would mean
+the probe keeps emitting `BLOCKED (ok)` results for every other target built
+on a premise — "this pod is policed" — that this very check just disproved,
+which is the same class of check-that-can't-fail bug the whole
+CronJob→Deployment redesign exists to close.
 
 ## Known limitation: the per-pod NetworkPolicy enforcement window
 

--- a/clusters/homelab/services/sandbox-docker/deployment-netpol-falsifiability-probe.yaml
+++ b/clusters/homelab/services/sandbox-docker/deployment-netpol-falsifiability-probe.yaml
@@ -101,6 +101,33 @@ spec:
           # polite to the prod targets being probed (kube-apiserver, etcd): one denied
           # connection attempt per target per cycle, not a tight port-scan loop.
           value: "300"
+        - name: HEARTBEAT_FILE
+          # Written once warm-up succeeds and again after every full cycle -- see the
+          # livenessProbe below for what reads it. Must be writable; the container's root
+          # filesystem is read-only, so this lives on the `heartbeat` emptyDir volume, not
+          # the image itself.
+          value: "/var/run/probe/heartbeat"
+        - name: HEARTBEAT_MAX_AGE_SECONDS
+          # How stale HEARTBEAT_FILE can get before the liveness probe below decides the
+          # loop is wedged. PROBE_INTERVAL_SECONDS (one full cycle between writes) plus
+          # headroom for a cycle's own bounded probe time (worst case, every deny target
+          # times out instead of refusing instantly: ~17 checks x TIMEOUT_SECONDS(3s) =
+          # ~51s) plus a safety margin, rounded up. Not derived from PROBE_INTERVAL_SECONDS
+          # automatically -- an exec probe command can't reach into another env var's
+          # arithmetic cleanly -- so keep this above PROBE_INTERVAL_SECONDS + ~120s if that
+          # value changes.
+          value: "420"
+        - name: MIDLIFE_REVERIFY_EVERY_N_CYCLES
+          # How often (in cycles, not seconds) to re-run the warm-up gate's own
+          # enforcement check instead of only trusting the one done at container start.
+          # At the default PROBE_INTERVAL_SECONDS=300s, 12 cycles is ~1 hour: tight enough
+          # to bound how long an undetected mid-life enforcement lapse (a kube-router
+          # restart racing this pod, a full iptables resync gone wrong) could persist
+          # unnoticed in a homelab with no alerting, and deliberately slower than the
+          # ordinary per-cycle "UniFi gateway" deny probe already below -- see the
+          # MIDLIFE-* block in the loop for why this is a separate, rarer check rather
+          # than reusing that one.
+          value: "12"
         command:
         - /bin/sh
         - -c
@@ -139,6 +166,17 @@ spec:
             exit 1
           fi
 
+          # --- Heartbeat: evidence for the liveness probe that the loop is still alive ---
+          # Touched here and again after every full cycle below. The liveness probe fails
+          # this container if HEARTBEAT_FILE's mtime is older than HEARTBEAT_MAX_AGE_SECONDS
+          # -- the one failure mode this specifically catches: the loop hangs mid-cycle on
+          # something with no bound of its own, e.g. the plain `nslookup api.github.com`
+          # call below has no explicit timeout and can wedge forever against a
+          # broken/unreachable DNS server. A liveness probe that just execs `true` would
+          # satisfy Kyverno's require-pod-probes policy too, without detecting anything --
+          # this is deliberately not that.
+          date +%s > "$HEARTBEAT_FILE"
+
           # --- Main probe suite: runs on a loop once warm-up has succeeded ---
           # Observation-first wording (REACHABLE / BLOCKED) rather than PASS/FAIL: a line
           # like "FAIL: ... -- connected, expected denial" reads, at a skim, like the
@@ -175,6 +213,32 @@ spec:
             probes=0
             violations=0
 
+            # --- Mid-life re-verification (Fix 3) ---
+            # The warm-up gate above only proves this pod was policed at container start --
+            # a CLEAN verdict on cycle 50 otherwise rests on that one assumption from cycle
+            # 0. Re-run the same check on a slower, distinguishable cadence
+            # (MIDLIFE_REVERIFY_EVERY_N_CYCLES) so a mid-life lapse gets its own token
+            # instead of blending into the ordinary per-cycle "UniFi gateway" deny probe
+            # below as just one more line in a violations count.
+            if [ $((cycle % MIDLIFE_REVERIFY_EVERY_N_CYCLES)) -eq 0 ]; then
+              if nc -z -w "$TIMEOUT_SECONDS" "$UNIFI_GATEWAY" 443 2>/dev/null; then
+                # Deliberately a distinct token from WARMUP-TIMEOUT: this is a materially
+                # more alarming event -- the pod passed the warm-up gate at start and isn't
+                # policed anymore, so every verdict from here on is untrustworthy, not just
+                # this one target. Exit non-zero rather than log-and-continue: restarting
+                # re-runs the warm-up gate on the new pod, re-proving enforcement before the
+                # loop is trusted again, the same reasoning the warm-up gate itself uses.
+                # The cost is losing this pod's running history (cycle count, any violation
+                # trend) -- accepted, because continuing would mean this probe keeps
+                # reporting BLOCKED (ok) results built on a premise that's already false,
+                # which is exactly the "check that can't fail" class of bug this whole
+                # redesign exists to close.
+                echo "MIDLIFE-ENFORCEMENT-LAPSE: ${UNIFI_GATEWAY}:443 reachable at cycle ${cycle} -- this pod was policed at start (WARMUP-OK) but is not policed now. Exiting non-zero to force a restart and re-prove enforcement from a clean pod."
+                exit 1
+              fi
+              echo "MIDLIFE-CHECK-OK: enforcement re-confirmed at cycle ${cycle} (next re-check in ${MIDLIFE_REVERIFY_EVERY_N_CYCLES} cycles)"
+            fi
+
             for node in $NODE_IPS; do
               probe_deny "prod kube-apiserver" "$node" 6443
               # Longhorn manager (:9500) used to be probed here too, and always reported
@@ -209,9 +273,58 @@ spec:
               echo "SUMMARY namespace=$NAMESPACE cycle=$cycle probes=$probes violations=$violations verdict=VIOLATIONS-DETECTED"
             fi
 
+            date +%s > "$HEARTBEAT_FILE"
             sleep "$PROBE_INTERVAL_SECONDS"
           done
         # yamllint enable rule:line-length
+        livenessProbe:
+          # Catches exactly one failure mode: the probe loop hung mid-cycle on something
+          # with no timeout of its own -- concretely, the plain `nslookup api.github.com`
+          # call above has no explicit bound and can wedge forever against a
+          # broken/unreachable DNS server (the other named failure mode, a hung `nc`,
+          # can't happen: every `nc` call in this script is already `-w`-bounded). It does
+          # NOT check whether the probe suite's findings are correct -- that's what
+          # SUMMARY/violations in this container's own logs are for -- only whether the
+          # loop producing them is still moving. `exec: ["true"]` would satisfy Kyverno's
+          # require-pod-probes policy too, and would detect nothing; this is deliberately
+          # not that.
+          #
+          # A restart here is desirable, not just tolerated: it re-runs the warm-up gate
+          # on the new pod, re-proving enforcement before the loop resumes -- same
+          # reasoning as MIDLIFE_REVERIFY_EVERY_N_CYCLES choosing restart over
+          # log-and-continue above.
+          #
+          # This exec probe's own stdout goes to kubelet's probe result, not this
+          # container's log stream -- a failure here shows up via `kubectl describe pod`
+          # (`Warning  Unhealthy`) and the same `kube_pod_container_status_restarts_total`
+          # climb already used as a proxy for WARMUP-TIMEOUT restarts (see OPERATIONS.md),
+          # not by grepping Loki for a token.
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - |
+                now=$(date +%s)
+                hb=$(stat -c %Y "$HEARTBEAT_FILE" 2>/dev/null) || exit 1
+                [ $((now - hb)) -le "$HEARTBEAT_MAX_AGE_SECONDS" ]
+          # Covers the warm-up gate's own worst case (WARMUP_TIMEOUT_SECONDS=30s) plus
+          # slack to reach the first heartbeat write, which happens the moment warm-up
+          # succeeds -- not only after the first full cycle -- so this doesn't also need
+          # to cover a full PROBE_INTERVAL_SECONDS.
+          initialDelaySeconds: 45
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+        # No readinessProbe: this pod fronts no Service and receives no traffic, so there
+        # is nothing for "ready to receive traffic" to mean here. Adding one anyway would
+        # only be to placate Kyverno's require-pod-probes policy, which livenessProbe
+        # above already satisfies -- the same always-passing-probe trap this fix exists to
+        # avoid. No startupProbe either: the warm-up gate already self-bounds startup and
+        # exits non-zero on its own timeout, and initialDelaySeconds above already covers
+        # that window for the liveness probe.
+        volumeMounts:
+        - name: heartbeat
+          mountPath: /var/run/probe
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -223,3 +336,9 @@ spec:
             - ALL
           seccompProfile:
             type: RuntimeDefault
+      volumes:
+      - name: heartbeat
+        # Backs HEARTBEAT_FILE -- readOnlyRootFilesystem: true above means the image
+        # itself isn't writable, so the liveness heartbeat needs its own writable spot.
+        emptyDir:
+          sizeLimit: 1Mi

--- a/clusters/homelab/services/sandbox-docker/network-policy.yaml
+++ b/clusters/homelab/services/sandbox-docker/network-policy.yaml
@@ -31,6 +31,24 @@ kind: NetworkPolicy
 metadata:
   name: default-deny
   namespace: sandbox-docker
+  # Kubernetes strips YAML comments before persisting to etcd, so the CAVEAT comment
+  # above is invisible to `kubectl get netpol -o yaml` or any MCP/API client -- only
+  # someone reading git or OPERATIONS.md ever sees it. This annotation survives onto the
+  # live object as the discoverable half of that same warning; the comment stays too, for
+  # the git/PR reader who wants the full mechanism. `homelab-ops.internal/*` is this
+  # platform's established self-defined-key prefix (see the `homelab-ops.internal/
+  # virtualization` node label in OPERATIONS.md) -- `.internal` is the RFC 9476 reserved,
+  # non-delegatable TLD, so it can never collide with or be mistaken for a domain anyone
+  # actually owns, unlike `.example`, which is a fill-in-the-value placeholder (e.g.
+  # harbor.example.com elsewhere in OPERATIONS.md) and would read as "someone forgot to
+  # set this" on a key meant to ship permanently.
+  annotations:
+    homelab-ops.internal/netpol-caveat: >-
+      CAVEAT: pods here are unpoliced for a short window right after creation (k3s's
+      kube-router netpol controller programs firewall rules reactively); a short-lived
+      pod can complete its entire life inside that window with zero enforcement. Full
+      explanation and how to verify a given pod is actually policed: OPERATIONS.md,
+      "Known limitation: the per-pod NetworkPolicy enforcement window".
 spec:
   podSelector: {}
   policyTypes:

--- a/clusters/homelab/services/sandbox-talos/deployment-netpol-falsifiability-probe.yaml
+++ b/clusters/homelab/services/sandbox-talos/deployment-netpol-falsifiability-probe.yaml
@@ -58,6 +58,21 @@ spec:
           value: "2"
         - name: PROBE_INTERVAL_SECONDS
           value: "300"
+        - name: HEARTBEAT_FILE
+          # See sandbox-docker's copy of this Deployment for the full rationale (Fix 2:
+          # liveness heartbeat). Backed by the `heartbeat` emptyDir volume below, since the
+          # root filesystem is read-only.
+          value: "/var/run/probe/heartbeat"
+        - name: HEARTBEAT_MAX_AGE_SECONDS
+          # See sandbox-docker's copy for the derivation (PROBE_INTERVAL_SECONDS plus
+          # headroom for a cycle's own bounded probe time plus a safety margin). This
+          # namespace probes one extra target per cycle (the cross-sandbox SSH check
+          # below), which is still well within the same ~120s of headroom.
+          value: "420"
+        - name: MIDLIFE_REVERIFY_EVERY_N_CYCLES
+          # See sandbox-docker's copy for the derivation (Fix 3: ~1 hour at the default
+          # PROBE_INTERVAL_SECONDS).
+          value: "12"
         command:
         - /bin/sh
         - -c
@@ -85,6 +100,10 @@ spec:
             echo "WARMUP-TIMEOUT: ${UNIFI_GATEWAY}:443 was still reachable after ${WARMUP_TIMEOUT_SECONDS}s -- this pod's egress was never policed within the warm-up window. This is NOT evidence the NetworkPolicy is broken: it means enforcement could not be established for THIS pod before the deadline, so nothing below can be trusted yet. See the kube-router per-pod dispatch-rule race documented in network-policy.yaml / OPERATIONS.md. Exiting non-zero so this is loud (pod restart, CrashLoopBackOff) rather than a silent false pass."
             exit 1
           fi
+
+          # --- Heartbeat: evidence for the liveness probe that the loop is still alive ---
+          # See sandbox-docker's copy of this Deployment for the full rationale (Fix 2).
+          date +%s > "$HEARTBEAT_FILE"
 
           # --- Main probe suite: runs on a loop once warm-up has succeeded ---
           probe_deny() {
@@ -114,6 +133,19 @@ spec:
             cycle=$((cycle + 1))
             probes=0
             violations=0
+
+            # --- Mid-life re-verification (Fix 3) ---
+            # See sandbox-docker's copy of this Deployment for the full rationale: why this
+            # is a separate, rarer check rather than reusing the ordinary per-cycle "UniFi
+            # gateway" deny probe below, and why a lapse restarts the pod instead of
+            # logging and continuing.
+            if [ $((cycle % MIDLIFE_REVERIFY_EVERY_N_CYCLES)) -eq 0 ]; then
+              if nc -z -w "$TIMEOUT_SECONDS" "$UNIFI_GATEWAY" 443 2>/dev/null; then
+                echo "MIDLIFE-ENFORCEMENT-LAPSE: ${UNIFI_GATEWAY}:443 reachable at cycle ${cycle} -- this pod was policed at start (WARMUP-OK) but is not policed now. Exiting non-zero to force a restart and re-prove enforcement from a clean pod."
+                exit 1
+              fi
+              echo "MIDLIFE-CHECK-OK: enforcement re-confirmed at cycle ${cycle} (next re-check in ${MIDLIFE_REVERIFY_EVERY_N_CYCLES} cycles)"
+            fi
 
             for node in $NODE_IPS; do
               probe_deny "prod kube-apiserver" "$node" 6443
@@ -159,9 +191,42 @@ spec:
               echo "SUMMARY namespace=$NAMESPACE cycle=$cycle probes=$probes violations=$violations verdict=VIOLATIONS-DETECTED"
             fi
 
+            date +%s > "$HEARTBEAT_FILE"
             sleep "$PROBE_INTERVAL_SECONDS"
           done
         # yamllint enable rule:line-length
+        livenessProbe:
+          # See sandbox-docker's copy of this Deployment for the full rationale (Fix 2):
+          # catches the probe loop hanging mid-cycle on something with no timeout of its
+          # own (the plain `nslookup api.github.com` call above, or -- unique to this
+          # namespace -- a DNS lookup on DOCKER_SSH_SERVICE before Phase 4 creates that
+          # Service, though `nslookup` failing fast on NXDOMAIN is the expected case there,
+          # not a hang). Every `nc` call in this script is `-w`-bounded, so a hung `nc`
+          # can't happen here either. `exec: ["true"]` would satisfy Kyverno's
+          # require-pod-probes policy too, and would detect nothing; this is deliberately
+          # not that.
+          #
+          # This exec probe's own stdout goes to kubelet's probe result, not this
+          # container's log stream -- see sandbox-docker's copy for how a failure here is
+          # actually surfaced.
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - |
+                now=$(date +%s)
+                hb=$(stat -c %Y "$HEARTBEAT_FILE" 2>/dev/null) || exit 1
+                [ $((now - hb)) -le "$HEARTBEAT_MAX_AGE_SECONDS" ]
+          initialDelaySeconds: 45
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+        # No readinessProbe/startupProbe -- see sandbox-docker's copy of this Deployment
+        # for why (no traffic to gate readiness on; the warm-up gate already self-bounds
+        # startup).
+        volumeMounts:
+        - name: heartbeat
+          mountPath: /var/run/probe
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -173,3 +238,9 @@ spec:
             - ALL
           seccompProfile:
             type: RuntimeDefault
+      volumes:
+      - name: heartbeat
+        # Backs HEARTBEAT_FILE -- readOnlyRootFilesystem: true above means the image
+        # itself isn't writable, so the liveness heartbeat needs its own writable spot.
+        emptyDir:
+          sizeLimit: 1Mi

--- a/clusters/homelab/services/sandbox-talos/network-policy.yaml
+++ b/clusters/homelab/services/sandbox-talos/network-policy.yaml
@@ -26,6 +26,25 @@ kind: NetworkPolicy
 metadata:
   name: default-deny
   namespace: sandbox-talos
+  # Kubernetes strips YAML comments before persisting to etcd, so the CAVEAT comment
+  # above is invisible to `kubectl get netpol -o yaml` or any MCP/API client -- only
+  # someone reading git or OPERATIONS.md ever sees it. This annotation survives onto the
+  # live object as the discoverable half of that same warning; the comment stays too, for
+  # the git/PR reader who wants the full mechanism. Wording deliberately differs from
+  # sandbox-docker's copy of this annotation: this is the namespace AI agents get full
+  # write access to, so the hazard is framed around what an agent can do inside the
+  # window, not just that the window exists. `homelab-ops.internal/*` is this platform's
+  # established self-defined-key prefix (see the `homelab-ops.internal/virtualization`
+  # node label in OPERATIONS.md) -- `.internal` is the RFC 9476 reserved, non-delegatable
+  # TLD, so it can never collide with or be mistaken for a domain anyone actually owns.
+  annotations:
+    homelab-ops.internal/netpol-caveat: >-
+      CAVEAT: AI agents have full pod-create rights in this namespace, and a freshly
+      created pod is unpoliced for a short window (k3s's kube-router netpol controller
+      programs firewall rules reactively) -- an agent-run Job could exfiltrate toward
+      prod or the LAN in that window before enforcement ever begins. Full explanation and
+      how to verify a given pod is actually policed: OPERATIONS.md, "Known limitation:
+      the per-pod NetworkPolicy enforcement window".
 spec:
   podSelector: {}
   policyTypes:


### PR DESCRIPTION
## Summary

A verification sweep of the sandbox NetworkPolicy falsifiability probe's CronJob->Deployment redesign (#818, already merged) found three follow-on gaps, all instances of the same theme: **a check that cannot fail is worse than no check**.

- **Discoverable CAVEAT**: the per-pod enforcement-window warning lived only as a YAML comment on each namespace's `default-deny` NetworkPolicy, invisible on the live object once Kubernetes strips comments on persist. Added as a `homelab-ops.internal/netpol-caveat` annotation so it survives into `kubectl get netpol -o yaml`/MCP tooling; the comment stays for git readers. `homelab-ops.internal/*` is this platform's established self-defined-key prefix -- it's already in use for the `virtualization` node label (see `OPERATIONS.md`) -- and `.internal` is the RFC 9476 reserved, non-delegatable TLD, chosen so a self-defined key can never collide with or be mistaken for a domain anyone actually owns. Wording differs deliberately between namespaces -- `sandbox-talos`'s copy calls out that AI agents have pod-create rights there.
- **Probes that can actually fail**: Kyverno's `require-pod-probes` policy (audit-mode) now flags both probe Deployments -- a `Job` was never subject to it, a `Deployment` is. Added a `livenessProbe` backed by a heartbeat file the loop touches after warm-up and after every cycle; the probe fails if that file goes stale (`HEARTBEAT_MAX_AGE_SECONDS`, 420s default). Catches the loop hanging mid-cycle on something with no timeout of its own (the plain `nslookup` calls, which can wedge forever against a broken DNS server). Deliberately not an always-succeeding `exec: ["true"]` probe. No `readinessProbe` (the pod serves no traffic) or `startupProbe` (the warm-up gate already self-bounds startup).
- **Mid-life re-verification**: the warm-up gate only proves a pod was policed at container start; a `CLEAN` verdict on cycle 50 rested on that one assumption. Every `MIDLIFE_REVERIFY_EVERY_N_CYCLES` cycles (12, ~1h at the default `PROBE_INTERVAL_SECONDS`), the loop re-runs the warm-up gate's own deny-check. A lapse logs a distinct `MIDLIFE-ENFORCEMENT-LAPSE` token (not `WARMUP-TIMEOUT`) and exits non-zero rather than logging and continuing -- a restart re-proves enforcement via the warm-up gate before the loop is trusted again, at the cost of that pod's running history.

`OPERATIONS.md` documents the new log tokens, the mid-life re-verification design and tradeoff, and where a liveness-triggered restart is actually visible (`kubectl describe pod` / restart-count metric, not container logs -- exec probe stdout never reaches promtail).

**On first rollout:** two assumptions behind the liveness probe aren't verified against a live cluster -- busybox's `stat -c %Y` support, and the `heartbeat` emptyDir being writable by `runAsUser: 65534` with no `fsGroup` set. Both are believed to hold, but if either doesn't, it fails loudly (liveness fails immediately -> `CrashLoopBackOff`) rather than silently passing -- the safe failure direction. A crash loop on either probe Deployment after this rollout is the signal to check these two assumptions, not evidence the NetworkPolicy itself broke.

**Worth internalizing either way:** a crash-looping probe means nothing is asserting the isolation anymore. The NetworkPolicy still enforces -- the probe is only the witness -- so `CrashLoopBackOff` here means "we've lost the assertion," not "we've lost the protection."

## Test plan

- [x] `pre-commit run --all-files` (yamllint, markdownlint, shellcheck, kubeconform) -- green
- [x] `kustomize build clusters/homelab` -- clean
- [x] `kustomize build clusters/homelab/services/{sandbox-docker,sandbox-talos}` -- rendered manifests inspected (annotations, env vars, livenessProbe, volumes all present as expected)
- [x] `shellcheck -s sh` against the extracted probe-loop and liveness-probe scripts for both namespaces -- clean
- [ ] Not verified against a live cluster (no cluster access in this environment) -- see the two assumptions called out above; confirm by observation on first rollout rather than by assertion. `OPERATIONS.md`'s existing before/after runbook covers how to validate the rest on a real cluster.

Not applied to any live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)