### PR TITLE
fix(cluster-homelab): fix Bitwarden store sandbox allowlist and drop dead pihole entry

### DIFF
--- a/clusters/homelab/cluster/secrets/bitwarden-secret-store.yaml
+++ b/clusters/homelab/cluster/secrets/bitwarden-secret-store.yaml
@@ -22,6 +22,18 @@ spec:
         key: ca.crt
       organizationID: f736b07c-b94f-42b0-a640-b204011e4200
       projectID: e9c6c45e-e8d9-480c-b2cf-b204011e80e6
+  # This allowlist is the only access boundary on the whole store: projectID above is one
+  # shared Bitwarden project, so every namespace listed here can read every secret in it,
+  # not just the ones it consumes -- Bitwarden Secrets Manager's free tier caps project
+  # count, so a second, sandbox-only project (the isolated option) isn't available.
+  # sandbox-docker/sandbox-talos are here for their ExternalSecrets (an SSH public key;
+  # the Talos machine config, which embeds the cluster CA private key) and accepted on
+  # that shared-project basis because only Flux can create ExternalSecrets in either
+  # namespace -- AI agents get cluster-admin on the Talos cluster running *inside* the
+  # sandbox-talos VM, not on this host cluster, so they can't author one to read the rest
+  # of the project. Re-open this if either changes: something other than Flux gains
+  # ExternalSecret-create rights in a sandbox namespace, or a paid tier/second project
+  # removes the reason a dedicated store isn't used instead.
   conditions:
   - namespaces:
     - ai
@@ -43,6 +55,8 @@ spec:
     - obsidian-vault
     - openclaw
     - pihole
+    - sandbox-docker
+    - sandbox-talos
     - tailscale
     - traefik
     - unifi

--- a/clusters/homelab/cluster/secrets/bitwarden-secret-store.yaml
+++ b/clusters/homelab/cluster/secrets/bitwarden-secret-store.yaml
@@ -34,6 +34,11 @@ spec:
   # of the project. Re-open this if either changes: something other than Flux gains
   # ExternalSecret-create rights in a sandbox namespace, or a paid tier/second project
   # removes the reason a dedicated store isn't used instead.
+  #
+  # Prune an entry when its consumer goes away, not just add one when a new consumer
+  # shows up: `pihole` was removed here because no ExternalSecret uses it (or `dns`,
+  # where Pi-hole actually lives) -- dead config surviving a rename. An allowlist that
+  # only ever grows erodes the same way this one did, without anything looking wrong.
   conditions:
   - namespaces:
     - ai
@@ -54,7 +59,6 @@ spec:
     - n8n
     - obsidian-vault
     - openclaw
-    - pihole
     - sandbox-docker
     - sandbox-talos
     - tailscale


### PR DESCRIPTION
## Summary

- Adds `sandbox-docker` and `sandbox-talos` to `bitwarden-secret-manager-store`'s namespace allowlist so their KubeVirt VMs can provision: `sandbox-docker` needs an SSH public key, `sandbox-talos` needs the Talos machine config (which embeds the cluster CA private key). Without this, both `ExternalSecret`s are rejected and neither VM comes up.
- Removes `pihole` from the same allowlist — no `ExternalSecret` targets that namespace (or `dns`, where Pi-hole actually runs), so it was dead config left over from a rename, not a live grant. Verified against a live listing of all 48 `ExternalSecret`s cluster-wide: none live in `pihole` or `dns`, so removal cannot break anything currently working.
- Extends the comment above the allowlist to record: what the list actually controls (the store points at one shared Bitwarden project, so membership means read access to *everything* in that project, not just what a namespace consumes); why the sandbox additions were accepted anyway (free-tier project-count limits rule out a dedicated sandbox-only store; exposure stays bounded because only Flux can create `ExternalSecret`s in these namespaces — AI agents get cluster-admin on the Talos cluster running *inside* the `sandbox-talos` VM, not on this host cluster); and what would invalidate that call (something other than Flux gaining `ExternalSecret`-create rights in a sandbox namespace, or the project-limit constraint going away). It also now notes that entries should be pruned when their consumer disappears, not just added when a new one shows up.

**Flagging, not touching:** `traefik` is also in the allowlist with no `ExternalSecret` currently using it. Unlike `pihole`, that namespace genuinely exists, so it may be intentionally pre-provisioned rather than stale — leaving it alone for the operator to decide separately.

## Test plan

- [x] `pre-commit run --all-files` (yamllint, kubeconform validation, etc.) — green
- [x] `kustomize build clusters/homelab` — clean, and confirms the rendered `ClusterSecretStore` carries the updated namespace list (`sandbox-docker`/`sandbox-talos` present, `pihole` gone)
- [x] No changes to provider config, auth, or anything else in the store — diff is scoped to the allowlist and its comment
- [ ] Not applied to any live cluster (Flux will reconcile after merge)