### PR TITLE
fix(policies): exclude virt-launcher pods from emptyDir sizeLimit mutation

### DIFF
--- a/policies/best-practices/add-emptydir-sizelimit.yaml
+++ b/policies/best-practices/add-emptydir-sizelimit.yaml
@@ -50,3 +50,49 @@ spec:
           namespaces:
           - kube-system
           - longhorn-system
+      # IMPORTANT for whoever next tunes a *mutate* policy's exclusions: validationFailureAction
+      # only exists on *validate* rules. Every virt-handler/virt-launcher exclusion elsewhere in
+      # this repo was added to *validate* policies that already run in Audit mode, so "Audit"
+      # felt like a low-stakes backstop while the exclusion list was worked out. A mutate rule
+      # has no such backstop -- it always applies, unconditionally, the moment it matches. That
+      # gap is exactly what caused docker-vm to eviction-loop: this policy silently added a
+      # 256Mi sizeLimit to virt-launcher's internal "ephemeral-disks" emptyDir (the containerDisk
+      # copy-on-write overlay backing every write the guest makes to its root filesystem), and
+      # nothing surfaced it as a violation anywhere because a mutate rule doesn't report one --
+      # it just rewrites the object.
+      #
+      # virt-launcher pods run in the VM's own namespace (sandbox-docker, sandbox-talos here),
+      # not in `kubevirt` -- unlike virt-handler, which is a DaemonSet confined to that one
+      # namespace. A namespace-scoped exclusion targeting `kubevirt` would exclude nothing.
+      #
+      # Whole-pod, not per-volume: every emptyDir a virt-launcher pod carries (private, public,
+      # sockets, virt-bin-dir, libvirt-runtime, ephemeral-disks, and container-disks when image
+      # volumes aren't in use) is created internally by virt-controller for KubeVirt's own
+      # bookkeeping -- kubelet already tears the whole pod down when a VM is deleted, so none of
+      # them benefit from an externally imposed cap. Verified against KubeVirt v1.9.0 source
+      # (pkg/virt-controller/services/rendervolumes.go, the emptyDirVolume() helper all of them
+      # go through): it unconditionally emits EmptyDirVolumeSource{} with no SizeLimit, and
+      # there is no KubeVirt/VirtualMachine CR field that feeds one in -- this isn't a case of
+      # "KubeVirt could set its own limit but doesn't"; it has no such knob.
+      #
+      # Deliberately left uncapped rather than re-added at a bigger, hand-picked number: this
+      # volume backs a real VM's disk writes, so any fixed number is a guess divorced from the
+      # workload, and a long-lived VM's overlay only grows -- a bigger cap just relocates the
+      # same eviction loop further down the timeline, most convincingly right after whoever hit
+      # it has stopped watching. The actual backstop is the one Kubernetes already ships for
+      # exactly this shape of problem: kubelet's node-level ephemeral-storage eviction
+      # (nodefs.available). A VM that needs real persistent capacity belongs on a PVC-backed
+      # virtio disk (KubeVirt dataVolumeTemplates/PVC volumes), not written into this
+      # containerDisk overlay -- that's a workload-level fix, not a policy one, and is out of
+      # scope here.
+      #
+      # Name-scoped like every other virt-launcher/virt-handler exclusion in this repo, even
+      # though these pods also carry a stable `kubevirt.io: virt-launcher` label that would work
+      # equally well: kept consistent with the 8 existing name-glob exclusions elsewhere rather
+      # than introducing a second selector style for the same controller-owned pods.
+      - resources:
+          names:
+          - 'virt-launcher*'
+          namespaces:
+          - sandbox-docker
+          - sandbox-talos


### PR DESCRIPTION
## Live outage this unblocks

`docker-vm` (KubeVirt VM in `sandbox-docker`) is currently eviction-looping in production: its `virt-launcher` pod gets evicted mid `apt install docker-ce` with `Usage of EmptyDir volume "ephemeral-disks" exceeds the limit "256Mi"`, restarts, and repeats indefinitely. This PR unblocks it. **Not merged yet** — opening for review per the operator's usual process; the loop continues until this lands.

## Root cause

`ephemeral-disks` is an emptyDir KubeVirt creates itself inside every `virt-launcher` pod — it backs the copy-on-write overlay for every write the guest makes to its containerDisk root filesystem. This repo's `add-emptydir-sizelimit` Kyverno **mutate** policy adds a `sizeLimit: 256Mi` to any emptyDir that lacks one, so it silently capped that overlay. Installing Docker CE and its dependencies blows straight through 256Mi.

## Why a Kyverno exclusion, not a KubeVirt-side fix

The redirect during this investigation asked whether KubeVirt itself could be made to set a `sizeLimit` on this volume, which would let the existing 256Mi guard stay untouched. I checked against KubeVirt v1.9.0 source (`pkg/virt-controller/services/rendervolumes.go`): the `emptyDirVolume()` helper backing **all** of virt-launcher's internal volumes (`private`, `public`, `sockets`, `virt-bin-dir`, `libvirt-runtime`, `ephemeral-disks`, `container-disks`) unconditionally emits `EmptyDirVolumeSource{}` with no `SizeLimit`, and no `KubeVirt`/`VirtualMachine` CR field feeds one in. This isn't "KubeVirt could set its own limit but doesn't" — there's no such knob to configure. A Kyverno-side exclusion is the only lever available.

## Why this was invisible until it caused an outage

Every existing `virt-handler`/`virt-launcher` exclusion in this repo lives on a **validate** policy, and every validate policy here runs `validationFailureAction: Audit`. That made "add a name-scoped exclusion" feel like a routine, low-stakes pattern. But `validationFailureAction` only exists on validate rules — it has no meaning on a **mutate** rule. A mutate rule always applies, unconditionally, the moment it matches, and reports no violation anywhere for Policy Reporter or a human to notice. That gap is exactly why `add-emptydir-sizelimit` mutating a KubeVirt-internal volume went unnoticed until it took a live eviction loop to surface it. Recorded as a comment in the policy itself so the next person tuning a mutate policy's exclusions doesn't repeat the assumption.

## What changed

Added an `exclude` entry to `add-emptydir-sizelimit.yaml`'s single rule, matching `virt-launcher*` pods in `sandbox-docker`/`sandbox-talos` — the VM's own namespaces, not `kubevirt` (`virt-launcher` never runs there, unlike the `virt-handler` DaemonSet). Whole-pod, not per-volume: every emptyDir a virt-launcher pod carries is KubeVirt-internal bookkeeping that kubelet tears down with the pod anyway, so none of them benefit from an externally imposed cap.

Decisions worth surfacing:

- **Name-glob over label**: these pods also carry a stable `kubevirt.io: virt-launcher` label that would work equally well as a selector, but I kept the name-glob (`virt-launcher*`) for consistency with the repo's 8 other existing `virt-launcher`/`virt-handler` exclusions, all of which use the same style.
- **Left uncapped, not re-capped at a bigger number**: I considered setting a bigger explicit `sizeLimit` (e.g. via a second rule in the same policy, where rule ordering is deterministic — unlike ordering across separate `ClusterPolicy` objects, which isn't a documented guarantee). I didn't go this way: the volume backs a real VM's disk writes, so any fixed number is a guess divorced from the actual workload, and a long-lived VM's containerDisk overlay only grows over its lifetime — a bigger cap just relocates today's eviction loop further down the timeline. The real backstop for unbounded local disk growth is the one Kubernetes already ships for this exact shape of problem: kubelet's node-level ephemeral-storage eviction (`nodefs.available`). `beelink-ser8-1` (where `docker-vm` is currently scheduled) reports ~127Gi allocatable ephemeral-storage, so there's real headroom, but it isn't infinite — a VM that needs durable, growing capacity belongs on a PVC-backed virtio disk (KubeVirt `dataVolumeTemplates`/PVC volumes), not written into this ephemeral overlay. That's a workload-level architecture fix, out of scope here, and worth remembering before this recurs at a higher plateau in a few months.

## Munger inversion: other mutate policies checked against KubeVirt

Per the operator's ask, I checked whether either of the other two mutate policies in `policies/best-practices/` could also be quietly affecting KubeVirt-generated pods:

- **`add-default-resources`** (adds default `requests.cpu`/`requests.memory` to containers missing them, via `+()` add-if-absent anchors): confirmed via KubeVirt source (`pkg/virt-controller/services/renderresources.go`) that virt-controller **always** computes explicit CPU/memory requests for the `compute` container (required for scheduling/sizing), and sidecar containers get theirs via `sidecarResources()`. So this policy is a no-op on virt-launcher pods today — nothing to fix.
- **`add-ndots`** (sets `dnsConfig.options: [{name: ndots, value: "1"}]` on pods missing it): this mutates the **pod's own** `/etc/resolv.conf`. I confirmed KubeVirt does read the pod's `/etc/resolv.conf` and forward its nameservers/search domains into the guest VM via DHCP (`pkg/network/dns/resolveconf.go`, `GetResolvConfDetailsFromPod`) — so there was a real question of whether this mutation leaks into the guest's own DNS behavior. It doesn't: that parser only reads lines prefixed `nameserver`/`search`; it has no handling for an `options` line at all, so the `ndots` mutation is invisible to the guest and only affects virt-launcher's own process-level DNS resolution. Verified, not assumed — no fix needed.

## Verification

- `yamllint --strict`, `kustomize build policies/best-practices`, and `pre-commit run --all-files` all pass.
- **Verified in both directions with `kyverno apply` (Kyverno CLI v1.18.2, via `mise exec kyverno`)**, against the modified policy standalone:
  - An ordinary pod (`default` namespace) still gets `sizeLimit: 256Mi` added — the guard is intact, not disabled.
  - A `virt-launcher`-shaped pod in `sandbox-docker` is left with `emptyDir: {}` — the fix works.
  - A `virt-launcher`-named pod in a namespace **other than** `sandbox-docker`/`sandbox-talos` still gets `sizeLimit: 256Mi` — confirms the namespace scoping isn't accidentally broader than intended (name-glob alone would have been too permissive).
- Nothing applied to a live cluster.

## Test plan

- [ ] Reviewer confirms the exclusion reasoning (unbounded vs. a fixed cap) is the right call for this cluster
- [ ] Merge, let Flux reconcile `policy-best-practices`, confirm `docker-vm`'s `virt-launcher` pod stops evicting and the Docker CE install completes