### PR TITLE
fix(cluster-homelab): allow sandbox egress to MetalLB standard-pool VIPs

### DIFF
--- a/clusters/homelab/services/sandbox-docker/deployment-netpol-falsifiability-probe.yaml
+++ b/clusters/homelab/services/sandbox-docker/deployment-netpol-falsifiability-probe.yaml
@@ -80,6 +80,18 @@ spec:
           value: "10.43.0.1"
         - name: UNIFI_GATEWAY
           value: "192.168.8.1"
+        - name: LB_INGRESS_VIP_HOMELAB
+          # Positive control for allow-egress-lb-ingress-vips in network-policy.yaml: the
+          # homelab cluster's MetalLB `standard-pool` VIP, which is also the live Traefik
+          # ingress VIP (confirmed live: `metallb.io/ip-allocated-from-pool: standard-pool`
+          # on the `traefik` Service). Must stay in lockstep with that NetworkPolicy's
+          # ipBlock -- see it for how this range was derived and why it's the only pool
+          # opened.
+          value: "192.168.8.80"
+        - name: LB_INGRESS_VIP_NAS
+          # Same as above, for the nas cluster's `standard-pool` -- also Harbor's VIP,
+          # since Harbor is ingress-fronted rather than a dedicated LoadBalancer Service.
+          value: "192.168.8.192"
         - name: TIMEOUT_SECONDS
           value: "3"
         - name: WARMUP_TIMEOUT_SECONDS
@@ -256,6 +268,19 @@ spec:
 
             probe_deny "UniFi gateway" "$UNIFI_GATEWAY" 443
             probe_deny "in-cluster kubernetes Service" "$IN_CLUSTER_KUBERNETES_SERVICE" 443
+
+            # Positive controls for allow-egress-lb-ingress-vips in network-policy.yaml.
+            # This stack REJECTs rather than DROPs, so every BLOCKED (ok) verdict above is
+            # "connection refused", indistinguishable via nc -z from "nothing is listening
+            # there" -- these two checks are the other half of that: proof the allow rule
+            # actually opens something live, not just that it doesn't error. Both VIPs are
+            # Traefik's own Service IP on their cluster (see network-policy.yaml for why),
+            # so TCP:443 accepting is expected regardless of which hostname would have
+            # routed there -- this only proves L3 reachability, not that any particular
+            # hostname (Harbor, the API server) is behind it, which is the whole point of
+            # the CAVEAT in that policy file: this layer can't tell those apart.
+            probe_allow "homelab standard-pool ingress VIP (LoadBalancer allow)" "$LB_INGRESS_VIP_HOMELAB" 443
+            probe_allow "nas standard-pool ingress VIP (LoadBalancer allow, fronts Harbor)" "$LB_INGRESS_VIP_NAS" 443
 
             probe_allow "GitHub API (internet egress)" "api.github.com" 443
 

--- a/clusters/homelab/services/sandbox-docker/network-policy.yaml
+++ b/clusters/homelab/services/sandbox-docker/network-policy.yaml
@@ -130,6 +130,92 @@ spec:
         - 169.254.0.0/16
         - 127.0.0.0/8
 ---
+# Punch-through for the ingress/LoadBalancer path, added after pushing the Talos
+# containerDisk to Harbor failed with `dial tcp 192.168.8.192:443: connect: connection
+# refused` -- Harbor's ingress VIP sits inside the 192.168.0.0/16 `except` in
+# allow-egress-internet.yaml above. Reaching LAN services *through* the ingress/
+# LoadBalancer path is a controllable boundary (Traefik host-based routing today, Gateway
+# API later -- "who can hit what" is governable there); reaching cluster-internal services
+# directly is not, and stays closed.
+#
+# What's allowed: each cluster's MetalLB `standard-pool` -- the one pool with no
+# `serviceAllocation` restriction, which is what Traefik's own LoadBalancer Service draws
+# its VIP from on both clusters (confirmed live: `metallb.io/ip-allocated-from-pool:
+# standard-pool` on both `traefik` Services). Every other MetalLB pool on either cluster
+# (e.g. the ones backing Pi-hole, the UniFi controller, syslog-ng, Plex, Jellyfin,
+# FreeRADIUS) is deliberately NOT opened: those are `serviceAllocation`-scoped to one
+# specific Service each and hand out a VIP that talks directly to that backend, bypassing
+# Traefik entirely -- exactly the "reach cluster-internal services directly" pattern this
+# design closes, not the ingress path it opens. Ports 80/443 only, matching what Traefik's
+# Service actually listens on (`web`/`websecure`) -- nothing else binds on these pools.
+#
+# Ranges, read live from each cluster's IPAddressPool object (the value is Bitwarden
+# secret-sourced via `metallb_standard_ip_pool`/`cluster_{homelab,nas}_metallb_ip_pool`,
+# never plaintext in git, so this was verified against the deployed objects, not inferred):
+#   - homelab `standard-pool`: 192.168.8.80/28  (192.168.8.80-192.168.8.95)
+#   - nas     `standard-pool`: 192.168.8.192/28 (192.168.8.192-192.168.8.207; this is
+#     Harbor's VIP range -- Harbor is `expose.type: ingress`, fronted by nas's Traefik,
+#     not a dedicated LoadBalancer Service of its own)
+# Neither range overlaps a node IP (192.168.8.65/.67/.68/.69) or the UniFi gateway (.1) --
+# checked by hand against both ranges before this was written; no `ipBlock.except` carve-out
+# is needed here as a result. If a future pool resize ever brought one of those addresses
+# into range, that check must be redone -- this comment recording today's ranges is exactly
+# so a future reader can tell without going back to MetalLB to look it up.
+#
+# What this tolerates, plainly: both sandbox namespaces can now reach every service exposed
+# via either cluster's `standard-pool` VIP -- which includes the prod Kubernetes API server,
+# because Traefik hostname-routes behind one shared Service and there is no IP-level way to
+# separate it from Harbor. `kubernetes-api` Ingress in `default`, on both clusters, routes
+# straight to the real `kubernetes` Service on :443 off this same VIP (on nas, the identical
+# address as Harbor's). This is a DIFFERENT path from the raw `node-IP:6443` kube-apiserver
+# access probed and blocked below, which this change does not touch and stays fully closed.
+#
+# Why it's acceptable: reachability is not access. Agents reach Kubernetes only through the
+# MCP server (get/list/watch, no Secrets, no `pods/exec`, audited, zero RBAC write). The
+# workspace kubeconfig is OIDC-backed and has never been authenticated inside a workspace,
+# so there is no ambient credential to replay. And critically, OIDC is enforced by
+# kube-apiserver itself, not by Traefik -- verified: the Authentik forward-auth outpost's
+# Ingress lists 11 hostnames and `kubernetes-api` is not among them, so the bearer token is
+# passed straight through and validated by the API server regardless of route. The
+# authentication boundary is real and independent of the ingress path.
+#
+# What bounds it: node IPs, the gateway, and the rest of RFC1918 remain denied (see the
+# `except` list above) -- only these two `standard-pool` ranges are permitted.
+#
+# What would make this wrong, and why not fixed now: see
+# https://github.com/ppat/homelab-ops-kubernetes-clusters/issues/828, which records the
+# full deferral reasoning (moving the API server to its own VIP on k3s is a TLS
+# trust-anchor migration, not a config tweak -- deferred to the Talos migration, where a
+# native control-plane VIP and Cilium L2 announcements make the separation structural and
+# the trust-anchor change costs nothing because certs/kubeconfigs are being regenerated
+# anyway) and the full list of conditions that would invalidate this acceptance. Sharpest
+# one, stated here because it's the realistic failure: any non-interactive auth path added
+# to that API ingress -- a static token, a service-account token accepted at the edge, an
+# automation bypass -- converts this reachability directly into usable access from the
+# sandboxes. Also note the allow is pool-scoped, not service-scoped: any future
+# LoadBalancer service placed in either cluster's `standard-pool` becomes reachable from
+# both sandbox namespaces automatically, with no change needed here.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-lb-ingress-vips
+  namespace: sandbox-docker
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 192.168.8.80/28
+    - ipBlock:
+        cidr: 192.168.8.192/28
+    ports:
+    - protocol: TCP
+      port: 80
+    - protocol: TCP
+      port: 443
+---
 # Only the `coder` namespace may reach the dockerd VM -- that's the Coder workspace pods
 # that point DOCKER_HOST at it. Nothing in `sandbox-talos` (or anywhere else) is admitted
 # here: a write-capable Talos sandbox that could also reach this namespace would own the

--- a/clusters/homelab/services/sandbox-talos/deployment-netpol-falsifiability-probe.yaml
+++ b/clusters/homelab/services/sandbox-talos/deployment-netpol-falsifiability-probe.yaml
@@ -44,6 +44,14 @@ spec:
           value: "10.43.0.1"
         - name: UNIFI_GATEWAY
           value: "192.168.8.1"
+        - name: LB_INGRESS_VIP_HOMELAB
+          # See sandbox-docker's copy of this Deployment for the full rationale -- positive
+          # control for allow-egress-lb-ingress-vips in network-policy.yaml. Must stay in
+          # lockstep with that NetworkPolicy's ipBlock.
+          value: "192.168.8.80"
+        - name: LB_INGRESS_VIP_NAS
+          # Also Harbor's VIP -- see sandbox-docker's copy and network-policy.yaml.
+          value: "192.168.8.192"
         - name: DOCKER_SSH_SERVICE
           # Anticipated name/port of the Service Phase 4 fronts dockerd's SSH with, in the
           # sandbox-docker namespace. Doesn't exist yet -- see the file-level comment above.
@@ -174,6 +182,13 @@ spec:
             else
               echo "SKIP: Docker namespace SSH Service ($DOCKER_SSH_SERVICE:$DOCKER_SSH_PORT) -- not deployed yet"
             fi
+
+            # Positive controls for allow-egress-lb-ingress-vips in network-policy.yaml --
+            # see sandbox-docker's copy of this Deployment for the full rationale (REJECT
+            # vs DROP, why this is the other half of the deny checks above, and why this
+            # only proves L3 reachability, not which hostname is behind the VIP).
+            probe_allow "homelab standard-pool ingress VIP (LoadBalancer allow)" "$LB_INGRESS_VIP_HOMELAB" 443
+            probe_allow "nas standard-pool ingress VIP (LoadBalancer allow, fronts Harbor)" "$LB_INGRESS_VIP_NAS" 443
 
             probe_allow "GitHub API (internet egress)" "api.github.com" 443
 

--- a/clusters/homelab/services/sandbox-talos/network-policy.yaml
+++ b/clusters/homelab/services/sandbox-talos/network-policy.yaml
@@ -121,6 +121,51 @@ spec:
         - 169.254.0.0/16
         - 127.0.0.0/8
 ---
+# See sandbox-docker/network-policy.yaml for the full rationale -- same punch-through,
+# same reasoning, applied here too because this namespace has the identical Harbor-pull
+# need (pulling base images for the Talos sandbox cluster) plus the containerDisk-push need
+# that surfaced this gap in the first place. Only the differences from that copy are noted
+# below; everything else (why `standard-pool` and not the other MetalLB pools, why no
+# `ipBlock.except` is needed, what this tolerates, why it's acceptable, what bounds it) is
+# identical and not repeated here. Deferral reasoning and conditions that would invalidate
+# this acceptance: https://github.com/ppat/homelab-ops-kubernetes-clusters/issues/828.
+#
+# The one thing that IS more acute here than in sandbox-docker: this is the namespace AI
+# agents get full write access to (see default-deny above), so "the prod API server's
+# ingress is now L3-reachable from this namespace" lands on the namespace with pod-create
+# rights and cluster-admin inside its own sandbox cluster, not just a single long-lived VM
+# workload. The "what bounds the risk" argument still holds -- no ambient credential exists
+# here to use against that ingress -- but it holds with less margin than in sandbox-docker,
+# precisely because this is the namespace built to run arbitrary agent-authored pods. #828
+# names this explicitly as one of the conditions worth re-checking.
+#
+# Ranges (same pools as sandbox-docker, repeated here so this file doesn't require reading
+# the other one to know what it allows):
+#   - homelab `standard-pool`: 192.168.8.80/28  (192.168.8.80-192.168.8.95)
+#   - nas     `standard-pool`: 192.168.8.192/28 (192.168.8.192-192.168.8.207; Harbor's VIP
+#     range -- Harbor is ingress-fronted, not a dedicated LoadBalancer Service)
+# Neither overlaps a node IP (192.168.8.65/.67/.68/.69) or the UniFi gateway (.1).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-lb-ingress-vips
+  namespace: sandbox-talos
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 192.168.8.80/28
+    - ipBlock:
+        cidr: 192.168.8.192/28
+    ports:
+    - protocol: TCP
+      port: 80
+    - protocol: TCP
+      port: 443
+---
 # Two admitted sources, deliberately not sandbox-docker: the operator's own `coder`
 # workspace pods, and whichever MCP server pod in `ai` is the write-capable Kubernetes
 # access path for this sandbox. Selector shape mirrors apps/subsystems/ai/network-policy.yaml


### PR DESCRIPTION
## Summary

- Pushing the Talos containerDisk to Harbor failed with a connection-refused: Harbor's ingress VIP falls inside the RFC1918 `except` that `sandbox-docker`/`sandbox-talos` egress otherwise denies.
- Adds a punch-through NetworkPolicy in both namespaces allowing egress to each cluster's MetalLB `standard-pool` range only (`192.168.8.80/28` on homelab, `192.168.8.192/28` on nas), TCP 80/443 only -- the one pool with no `serviceAllocation` restriction, which is what Traefik's ingress-fronting Service draws its VIP from on both clusters. Every other MetalLB pool (Pi-hole, UniFi, Plex, Jellyfin, syslog-ng, FreeRADIUS) stays closed -- those bypass ingress entirely and would reopen exactly the "reach cluster-internal services directly" pattern this design closes.
- Adds positive-control checks to both namespaces' `netpol-falsifiability-probe` Deployments, asserting the two permitted VIPs are reachable, alongside the unchanged node-IP/gateway deny assertions. This stack REJECTs rather than DROPs, so a policy denial and a dead port both read as "blocked" via `nc -z` -- the existing deny checks needed a paired liveness proof, which these provide.

## The tradeoff this accepts, and why

Because Traefik hostname-routes behind one shared `LoadBalancer` Service per cluster, there is no IP-level way to allow Harbor without also making the **prod Kubernetes API server's ingress** reachable from both sandbox namespaces, on both clusters (`kubernetes-api` Ingress in `default` routes straight to the real `kubernetes` Service on the same shared VIP; on nas it's the identical address as Harbor's).

This is accepted for now rather than fixed here. Moving the API server to its own VIP on k3s turned out to be a TLS trust-anchor migration (client-facing TLS is currently terminated by Traefik's own cert-manager certificate, not the apiserver's; a dedicated VIP means clients trust k3s's internal CA instead -- a `tls-san` change, a k3s restart, and every kubeconfig needing to trust a different CA), not a config tweak, and the shape itself (`LoadBalancer` + selectorless Service + manually-patched node-IP endpoints) has no precedent in this estate. The full reasoning -- what was accepted, why it's acceptable today, why not now, why the Talos migration (native control-plane VIP + Cilium L2 announcements, replacing MetalLB) is the right moment, and the conditions that would invalidate this acceptance -- is recorded in **ppat/homelab-ops-kubernetes-clusters#828**, referenced from the policy comments rather than restated there.

Short version of why it's acceptable: reachability is not access. Agents reach Kubernetes only through the MCP server (get/list/watch, no Secrets, no `pods/exec`, audited). The workspace kubeconfig is OIDC-backed and has never been authenticated inside a workspace, so there's no ambient credential to replay. And OIDC is enforced by kube-apiserver itself, not by Traefik -- verified live: the Authentik forward-auth outpost's Ingress lists 11 hostnames and `kubernetes-api` isn't among them, so the bearer token passes straight through and the API server validates it regardless of route. The raw node-IP:6443 kube-apiserver path, kubelet, etcd, and the rest of RFC1918 all stay fully denied -- only these two `standard-pool` ranges are permitted, and the allow is pool-scoped (any future LoadBalancer service on either cluster's `standard-pool` becomes reachable too, which #828 also flags).

## Test plan

- [x] `pre-commit run --all-files` green, including `commitlint` on the actual commit (confirmed it's wired up and gating, not silently skipped)
- [x] YAML and embedded shell script (`bash -n`) validated for all 4 changed files
- [x] Verified live against both clusters (read-only MCP): `standard-pool` CIDRs, Traefik VIP-to-pool mapping, `kubernetes-api` Ingress routing, Authentik outpost's host list, MetalLB speaker DaemonSet scheduling
- [ ] **Not verified**: the probes' actual behavior on-cluster. This PR is not applied to any cluster; the falsifiability probes' pass/fail, and the NetworkPolicy's actual enforcement, are unverified until Flux reconciles this and the probes run for real.

Not merging -- opening for review.