### PR TITLE
fix(cluster-homelab): drop dead homelab standard-pool allow, fix probe false positive

### DIFF
--- a/clusters/homelab/services/sandbox-docker/deployment-netpol-falsifiability-probe.yaml
+++ b/clusters/homelab/services/sandbox-docker/deployment-netpol-falsifiability-probe.yaml
@@ -81,16 +81,25 @@ spec:
         - name: UNIFI_GATEWAY
           value: "192.168.8.1"
         - name: LB_INGRESS_VIP_HOMELAB
-          # Positive control for allow-egress-lb-ingress-vips in network-policy.yaml: the
-          # homelab cluster's MetalLB `standard-pool` VIP, which is also the live Traefik
-          # ingress VIP (confirmed live: `metallb.io/ip-allocated-from-pool: standard-pool`
-          # on the `traefik` Service). Must stay in lockstep with that NetworkPolicy's
-          # ipBlock -- see it for how this range was derived and why it's the only pool
-          # opened.
+          # DENY target, not an allow -- despite being the same kind of object as
+          # LB_INGRESS_VIP_NAS below. This is *this cluster's own* MetalLB `standard-pool`
+          # VIP (Traefik's), so a pod's packet to it gets DNAT'd by k3s's embedded
+          # kube-proxy to a Traefik pod IP (10.42.x.x) before kube-router's NetworkPolicy
+          # controller ever evaluates it -- NetworkPolicy sees the post-DNAT destination,
+          # inside the 10.0.0.0/8 `except`, not the VIP this dials. allow-egress-lb-ingress-
+          # vips in network-policy.yaml deliberately does NOT include this range as a
+          # result (it would be dead config -- it can never match); this probe asserting
+          # BLOCKED is expected and correct, not a gap. See that NetworkPolicy for the full
+          # mechanism -- this is the same DNAT effect the in-cluster kubernetes Service
+          # check below already exercises.
           value: "192.168.8.80"
         - name: LB_INGRESS_VIP_NAS
-          # Same as above, for the nas cluster's `standard-pool` -- also Harbor's VIP,
-          # since Harbor is ingress-fronted rather than a dedicated LoadBalancer Service.
+          # Positive control for allow-egress-lb-ingress-vips in network-policy.yaml: nas's
+          # MetalLB `standard-pool` VIP -- also Harbor's VIP, since Harbor is
+          # ingress-fronted rather than a dedicated LoadBalancer Service. Unlike
+          # LB_INGRESS_VIP_HOMELAB above, this has no Service on *this* cluster, so no DNAT
+          # intercepts it and the ipBlock allow actually applies. Must stay in lockstep with
+          # that NetworkPolicy's ipBlock.
           value: "192.168.8.192"
         - name: TIMEOUT_SECONDS
           value: "3"
@@ -269,17 +278,23 @@ spec:
             probe_deny "UniFi gateway" "$UNIFI_GATEWAY" 443
             probe_deny "in-cluster kubernetes Service" "$IN_CLUSTER_KUBERNETES_SERVICE" 443
 
-            # Positive controls for allow-egress-lb-ingress-vips in network-policy.yaml.
-            # This stack REJECTs rather than DROPs, so every BLOCKED (ok) verdict above is
-            # "connection refused", indistinguishable via nc -z from "nothing is listening
-            # there" -- these two checks are the other half of that: proof the allow rule
-            # actually opens something live, not just that it doesn't error. Both VIPs are
-            # Traefik's own Service IP on their cluster (see network-policy.yaml for why),
-            # so TCP:443 accepting is expected regardless of which hostname would have
-            # routed there -- this only proves L3 reachability, not that any particular
-            # hostname (Harbor, the API server) is behind it, which is the whole point of
-            # the CAVEAT in that policy file: this layer can't tell those apart.
-            probe_allow "homelab standard-pool ingress VIP (LoadBalancer allow)" "$LB_INGRESS_VIP_HOMELAB" 443
+            # LB_INGRESS_VIP_HOMELAB is a deny-assertion, not a positive control -- see its
+            # env var comment above and network-policy.yaml for the full DNAT-vs-NetworkPolicy
+            # mechanism (this is what caught the original version of this policy allowing a
+            # range that could never actually match). This stack REJECTs rather than DROPs,
+            # so BLOCKED alone can't distinguish a policy denial from a dead port -- proof
+            # something is actually listening here comes from outside this probe: every one
+            # of this cluster's ingress-fronted apps resolves to this exact VIP, so it is
+            # definitely live. What's asserted is that DNAT-then-netpol denies pod-originated
+            # traffic to it, not that nothing answers.
+            probe_deny "homelab standard-pool ingress VIP (DNAT to pod IP, expected denied)" "$LB_INGRESS_VIP_HOMELAB" 443
+
+            # Positive control for allow-egress-lb-ingress-vips in network-policy.yaml: nas's
+            # standard-pool VIP has no Service on this cluster, so no DNAT intercepts it and
+            # the ipBlock allow actually applies. TCP:443 accepting only proves L3
+            # reachability, not that any particular hostname (Harbor, nas's API server) is
+            # behind it -- this layer can't tell those apart, which is exactly the CAVEAT in
+            # that policy file.
             probe_allow "nas standard-pool ingress VIP (LoadBalancer allow, fronts Harbor)" "$LB_INGRESS_VIP_NAS" 443
 
             probe_allow "GitHub API (internet egress)" "api.github.com" 443

--- a/clusters/homelab/services/sandbox-docker/network-policy.yaml
+++ b/clusters/homelab/services/sandbox-docker/network-policy.yaml
@@ -138,63 +138,79 @@ spec:
 # API later -- "who can hit what" is governable there); reaching cluster-internal services
 # directly is not, and stays closed.
 #
-# What's allowed: each cluster's MetalLB `standard-pool` -- the one pool with no
-# `serviceAllocation` restriction, which is what Traefik's own LoadBalancer Service draws
-# its VIP from on both clusters (confirmed live: `metallb.io/ip-allocated-from-pool:
-# standard-pool` on both `traefik` Services). Every other MetalLB pool on either cluster
-# (e.g. the ones backing Pi-hole, the UniFi controller, syslog-ng, Plex, Jellyfin,
-# FreeRADIUS) is deliberately NOT opened: those are `serviceAllocation`-scoped to one
-# specific Service each and hand out a VIP that talks directly to that backend, bypassing
-# Traefik entirely -- exactly the "reach cluster-internal services directly" pattern this
-# design closes, not the ingress path it opens. Ports 80/443 only, matching what Traefik's
-# Service actually listens on (`web`/`websecure`) -- nothing else binds on these pools.
+# Only nas's MetalLB `standard-pool` is allowed below -- NOT homelab's, despite both pools
+# being the same kind of object. That asymmetry is deliberate, not an oversight: see "Why
+# only nas" below, which is the load-bearing part of this comment.
 #
-# Ranges, read live from each cluster's IPAddressPool object (the value is Bitwarden
-# secret-sourced via `metallb_standard_ip_pool`/`cluster_{homelab,nas}_metallb_ip_pool`,
-# never plaintext in git, so this was verified against the deployed objects, not inferred):
-#   - homelab `standard-pool`: 192.168.8.80/28  (192.168.8.80-192.168.8.95)
-#   - nas     `standard-pool`: 192.168.8.192/28 (192.168.8.192-192.168.8.207; this is
-#     Harbor's VIP range -- Harbor is `expose.type: ingress`, fronted by nas's Traefik,
-#     not a dedicated LoadBalancer Service of its own)
-# Neither range overlaps a node IP (192.168.8.65/.67/.68/.69) or the UniFi gateway (.1) --
-# checked by hand against both ranges before this was written; no `ipBlock.except` carve-out
-# is needed here as a result. If a future pool resize ever brought one of those addresses
-# into range, that check must be redone -- this comment recording today's ranges is exactly
-# so a future reader can tell without going back to MetalLB to look it up.
+# What's allowed: nas's `standard-pool`, 192.168.8.192/28 (192.168.8.192-192.168.8.207) --
+# the one pool with no `serviceAllocation` restriction, which is what Traefik's own
+# LoadBalancer Service draws its VIP from (confirmed live: `metallb.io/ip-allocated-from-pool:
+# standard-pool` on nas's `traefik` Service). This is also Harbor's VIP range -- Harbor is
+# `expose.type: ingress`, fronted by nas's Traefik, not a dedicated LoadBalancer Service of
+# its own. Every other MetalLB pool on either cluster (e.g. the ones backing Pi-hole, the
+# UniFi controller, syslog-ng, Plex, Jellyfin, FreeRADIUS) is deliberately NOT opened: those
+# are `serviceAllocation`-scoped to one specific Service each and hand out a VIP that talks
+# directly to that backend, bypassing Traefik entirely -- exactly the "reach cluster-internal
+# services directly" pattern this design closes, not the ingress path it opens. Ports 80/443
+# only, matching what Traefik's Service actually listens on (`web`/`websecure`).
 #
-# What this tolerates, plainly: both sandbox namespaces can now reach every service exposed
-# via either cluster's `standard-pool` VIP -- which includes the prod Kubernetes API server,
-# because Traefik hostname-routes behind one shared Service and there is no IP-level way to
-# separate it from Harbor. `kubernetes-api` Ingress in `default`, on both clusters, routes
-# straight to the real `kubernetes` Service on :443 off this same VIP (on nas, the identical
-# address as Harbor's). This is a DIFFERENT path from the raw `node-IP:6443` kube-apiserver
-# access probed and blocked below, which this change does not touch and stays fully closed.
+# Why only nas, not homelab too -- NetworkPolicy vs kube-proxy DNAT, verified against this
+# stack rather than assumed: homelab's `standard-pool` (192.168.8.80/28) was allowed here
+# too when this policy first shipped, and it does not work. Confirmed on the live
+# `netpol-falsifiability-probe`: 192.168.8.80:443 reported BLOCKED (a false negative --
+# nothing was denying it on purpose) while 192.168.8.192:443 reported REACHABLE, from the
+# identical ipBlock/port shape. The reason: 192.168.8.80 is *this cluster's own* LoadBalancer
+# VIP. A pod's packet to it never leaves the node as dialed -- k3s's embedded kube-proxy (no
+# separate kube-proxy DaemonSet exists on this cluster; confirmed live) programs Service DNAT,
+# including for LoadBalancer VIPs, in the nat table's PREROUTING/OUTPUT chains, which the
+# kernel always processes before any routing decision. kube-router's NetworkPolicy controller
+# enforces on the FORWARD chain (`KUBE-ROUTER-FORWARD`, see the default-deny CAVEAT above),
+# which is only reached *after* PREROUTING -- so by the time NetworkPolicy evaluates the
+# packet, its destination has already been rewritten to a Traefik pod IP (10.42.x.x). That
+# address falls inside the `10.0.0.0/8` `except` in allow-egress-internet.yaml above -- the
+# same catch-all that already denies the in-cluster kubernetes Service probed below (10.43.0.1,
+# also pod/Service-CIDR space) -- so it's denied, and the 192.168.8.80/28 ipBlock never gets
+# evaluated at all: NetworkPolicy sees the post-DNAT destination, not the one the pod dialed.
+# nas's VIP has no Service on *this* cluster, so no DNAT happens, the packet leaves as-is, and
+# the ipBlock matches normally.
 #
-# Why it's acceptable: reachability is not access. Agents reach Kubernetes only through the
-# MCP server (get/list/watch, no Secrets, no `pods/exec`, audited, zero RBAC write). The
-# workspace kubeconfig is OIDC-backed and has never been authenticated inside a workspace,
-# so there is no ambient credential to replay. And critically, OIDC is enforced by
-# kube-apiserver itself, not by Traefik -- verified: the Authentik forward-auth outpost's
-# Ingress lists 11 hostnames and `kubernetes-api` is not among them, so the bearer token is
-# passed straight through and validated by the API server regardless of route. The
-# authentication boundary is real and independent of the ingress path.
+# 192.168.8.80/28 is deliberately NOT in the ipBlock list below as a result -- it was dead
+# config that could never match, and removing it is a net improvement, not a loss: it keeps
+# homelab's own API server unreachable from these sandboxes, a better posture than what was
+# originally documented here.
 #
-# What bounds it: node IPs, the gateway, and the rest of RFC1918 remain denied (see the
-# `except` list above) -- only these two `standard-pool` ranges are permitted.
+# If a real need for homelab-ingress reachability appears later, it needs a different
+# mechanism, not a bigger ipBlock: an egress rule selecting Traefik's *pods* directly
+# (namespaceSelector matching the `traefik` namespace + a podSelector matching the Traefik
+# release) instead of an ipBlock -- pod-selector NetworkPolicy rules match the pod IP
+# directly and aren't affected by Service DNAT in front of it, so that path doesn't hit this
+# problem. Do not "fix" this by widening the ipBlock (e.g. to the whole /24 or to
+# 10.42.0.0/16 to chase the post-DNAT address) -- the destination is already rewritten before
+# any ipBlock is checked, so that doesn't restore the intended behavior, and widening it that
+# way would admit every pod in the cluster instead of just Traefik's. And doing this for real
+# would unavoidably expose homelab's own API server -- the identical shared-VIP/shared-Service
+# problem #828 documents for nas below, since selecting Traefik's pods doesn't distinguish
+# which hostname routes to them any more than the ipBlock did.
 #
-# What would make this wrong, and why not fixed now: see
-# https://github.com/ppat/homelab-ops-kubernetes-clusters/issues/828, which records the
-# full deferral reasoning (moving the API server to its own VIP on k3s is a TLS
-# trust-anchor migration, not a config tweak -- deferred to the Talos migration, where a
-# native control-plane VIP and Cilium L2 announcements make the separation structural and
-# the trust-anchor change costs nothing because certs/kubeconfigs are being regenerated
-# anyway) and the full list of conditions that would invalidate this acceptance. Sharpest
-# one, stated here because it's the realistic failure: any non-interactive auth path added
-# to that API ingress -- a static token, a service-account token accepted at the edge, an
-# automation bypass -- converts this reachability directly into usable access from the
-# sandboxes. Also note the allow is pool-scoped, not service-scoped: any future
-# LoadBalancer service placed in either cluster's `standard-pool` becomes reachable from
-# both sandbox namespaces automatically, with no change needed here.
+# What this tolerates, plainly, is narrower than a first read suggests: only nas's
+# `standard-pool` is actually reachable, which includes nas's prod Kubernetes API server
+# (`kubernetes-api` Ingress in `default`, routed by nas's Traefik straight to the real
+# `kubernetes` Service on :443, off the identical VIP as Harbor -- no IP-level way to
+# separate them). Homelab's equivalent Ingress is NOT reachable from here, for the DNAT
+# reason above -- this sandbox can pull images from the cluster it is NOT running on, but
+# cannot reach the API server of the cluster it IS running on. That asymmetry is a direct
+# side effect of the DNAT behavior, not something engineered on purpose, and it's worth
+# knowing rather than assuming both clusters are equally exposed.
+#
+# Why nas's exposure is accepted, and what would make it wrong: see
+# https://github.com/ppat/homelab-ops-kubernetes-clusters/issues/828 for the full reasoning
+# (deferred to the Talos migration -- a TLS trust-anchor migration, not a config tweak) and
+# the conditions that would invalidate the acceptance. Sharpest one, stated here because it's
+# the realistic failure: any non-interactive auth path added to that API ingress -- a static
+# token, a service-account token accepted at the edge, an automation bypass -- converts this
+# reachability directly into usable access from the sandboxes. The allow is pool-scoped, not
+# service-scoped: any future LoadBalancer service placed in nas's `standard-pool` becomes
+# reachable from both sandbox namespaces automatically, with no change needed here.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -206,8 +222,6 @@ spec:
   - Egress
   egress:
   - to:
-    - ipBlock:
-        cidr: 192.168.8.80/28
     - ipBlock:
         cidr: 192.168.8.192/28
     ports:

--- a/clusters/homelab/services/sandbox-talos/deployment-netpol-falsifiability-probe.yaml
+++ b/clusters/homelab/services/sandbox-talos/deployment-netpol-falsifiability-probe.yaml
@@ -45,12 +45,17 @@ spec:
         - name: UNIFI_GATEWAY
           value: "192.168.8.1"
         - name: LB_INGRESS_VIP_HOMELAB
-          # See sandbox-docker's copy of this Deployment for the full rationale -- positive
-          # control for allow-egress-lb-ingress-vips in network-policy.yaml. Must stay in
-          # lockstep with that NetworkPolicy's ipBlock.
+          # DENY target, not an allow -- see sandbox-docker's copy of this Deployment and
+          # network-policy.yaml for the full DNAT-vs-NetworkPolicy mechanism: this is
+          # *this cluster's own* MetalLB VIP, so pod-originated traffic to it gets DNAT'd
+          # to a Traefik pod IP (inside the 10.0.0.0/8 `except`) before NetworkPolicy ever
+          # evaluates it, and the corresponding ipBlock allow deliberately excludes this
+          # range as a result.
           value: "192.168.8.80"
         - name: LB_INGRESS_VIP_NAS
-          # Also Harbor's VIP -- see sandbox-docker's copy and network-policy.yaml.
+          # Positive control -- also Harbor's VIP. See sandbox-docker's copy and
+          # network-policy.yaml: nas has no Service on this cluster, so no DNAT intercepts
+          # it and the ipBlock allow actually applies.
           value: "192.168.8.192"
         - name: DOCKER_SSH_SERVICE
           # Anticipated name/port of the Service Phase 4 fronts dockerd's SSH with, in the
@@ -183,11 +188,13 @@ spec:
               echo "SKIP: Docker namespace SSH Service ($DOCKER_SSH_SERVICE:$DOCKER_SSH_PORT) -- not deployed yet"
             fi
 
-            # Positive controls for allow-egress-lb-ingress-vips in network-policy.yaml --
-            # see sandbox-docker's copy of this Deployment for the full rationale (REJECT
-            # vs DROP, why this is the other half of the deny checks above, and why this
-            # only proves L3 reachability, not which hostname is behind the VIP).
-            probe_allow "homelab standard-pool ingress VIP (LoadBalancer allow)" "$LB_INGRESS_VIP_HOMELAB" 443
+            # LB_INGRESS_VIP_HOMELAB is a deny-assertion (DNAT to a Traefik pod IP before
+            # NetworkPolicy evaluates it), LB_INGRESS_VIP_NAS is the positive control -- see
+            # sandbox-docker's copy of this Deployment for the full rationale (REJECT vs
+            # DROP, why proof-of-liveness for the homelab target comes from outside this
+            # probe, and why the NAS check only proves L3 reachability, not which hostname
+            # is behind the VIP).
+            probe_deny "homelab standard-pool ingress VIP (DNAT to pod IP, expected denied)" "$LB_INGRESS_VIP_HOMELAB" 443
             probe_allow "nas standard-pool ingress VIP (LoadBalancer allow, fronts Harbor)" "$LB_INGRESS_VIP_NAS" 443
 
             probe_allow "GitHub API (internet egress)" "api.github.com" 443

--- a/clusters/homelab/services/sandbox-talos/network-policy.yaml
+++ b/clusters/homelab/services/sandbox-talos/network-policy.yaml
@@ -130,21 +130,33 @@ spec:
 # identical and not repeated here. Deferral reasoning and conditions that would invalidate
 # this acceptance: https://github.com/ppat/homelab-ops-kubernetes-clusters/issues/828.
 #
+# Only nas's `standard-pool` is allowed below -- NOT homelab's. homelab's was allowed here
+# too when this policy first shipped and does not work: it is *this cluster's own* MetalLB
+# VIP, so a pod's packet to it gets DNAT'd to a Traefik pod IP (10.42.x.x, inside the
+# 10.0.0.0/8 `except`) by k3s's embedded kube-proxy before kube-router's NetworkPolicy
+# controller ever evaluates it -- NetworkPolicy sees the post-DNAT destination, not the VIP
+# the pod dialed, so the ipBlock can never match. Confirmed on the live falsifiability probe
+# (BLOCKED on the homelab VIP, REACHABLE on nas's, identical ipBlock/port shape); full
+# mechanism in sandbox-docker's copy of this file, including why the fix -- if one is ever
+# needed -- is a podSelector on Traefik's pods, not a bigger ipBlock, and why that would
+# unavoidably expose homelab's own API server too.
+#
 # The one thing that IS more acute here than in sandbox-docker: this is the namespace AI
-# agents get full write access to (see default-deny above), so "the prod API server's
-# ingress is now L3-reachable from this namespace" lands on the namespace with pod-create
-# rights and cluster-admin inside its own sandbox cluster, not just a single long-lived VM
-# workload. The "what bounds the risk" argument still holds -- no ambient credential exists
-# here to use against that ingress -- but it holds with less margin than in sandbox-docker,
+# agents get full write access to (see default-deny above), so nas's API server ingress
+# being L3-reachable from this namespace lands on the namespace with pod-create rights and
+# cluster-admin inside its own sandbox cluster, not just a single long-lived VM workload.
+# The "what bounds the risk" argument still holds -- no ambient credential exists here to
+# use against that ingress -- but it holds with less margin than in sandbox-docker,
 # precisely because this is the namespace built to run arbitrary agent-authored pods. #828
 # names this explicitly as one of the conditions worth re-checking.
 #
-# Ranges (same pools as sandbox-docker, repeated here so this file doesn't require reading
-# the other one to know what it allows):
-#   - homelab `standard-pool`: 192.168.8.80/28  (192.168.8.80-192.168.8.95)
-#   - nas     `standard-pool`: 192.168.8.192/28 (192.168.8.192-192.168.8.207; Harbor's VIP
-#     range -- Harbor is ingress-fronted, not a dedicated LoadBalancer Service)
-# Neither overlaps a node IP (192.168.8.65/.67/.68/.69) or the UniFi gateway (.1).
+# Range (repeated here so this file doesn't require reading the other one to know what it
+# allows): nas `standard-pool`, 192.168.8.192/28 (192.168.8.192-192.168.8.207) -- Harbor's
+# VIP range, since Harbor is ingress-fronted rather than a dedicated LoadBalancer Service.
+# Doesn't overlap a node IP (192.168.8.65/.67/.68/.69) or the UniFi gateway (.1). Homelab's
+# API server is NOT reachable from here, for the DNAT reason above -- this sandbox can pull
+# images from the cluster it is NOT running on, but cannot reach the API server of the
+# cluster it IS running on.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -156,8 +168,6 @@ spec:
   - Egress
   egress:
   - to:
-    - ipBlock:
-        cidr: 192.168.8.80/28
     - ipBlock:
         cidr: 192.168.8.192/28
     ports:


### PR DESCRIPTION
## Summary

#829 shipped an egress allow to both clusters' MetalLB `standard-pool` ranges, believing them symmetric. They aren't, and the falsifiability probe it added caught this on the live cluster within its first real run:

```
BLOCKED (violation): homelab standard-pool ingress VIP (192.168.8.80:443)
REACHABLE (ok):      nas standard-pool ingress VIP  (192.168.8.192:443)
```

Same policy, same shape, both `/28`s allowed -- one can never work.

## Root cause (verified against this stack, not assumed)

`192.168.8.80` is **homelab's own** LoadBalancer VIP. A pod's packet to it never leaves the node as dialed: k3s's embedded kube-proxy (confirmed live -- no separate `kube-proxy` DaemonSet exists on this cluster) programs Service DNAT, including for LoadBalancer VIPs, in the `nat` table's `PREROUTING`/`OUTPUT` chains, which the kernel always processes before any routing decision. kube-router's NetworkPolicy controller enforces on the `FORWARD` chain (`KUBE-ROUTER-FORWARD`), reached only *after* `PREROUTING` -- so NetworkPolicy evaluates the **post-DNAT** destination, a Traefik pod IP (`10.42.x.x`), not the VIP the pod dialed. That address falls inside the existing `10.0.0.0/8` `except` -- the same catch-all that already denies the in-cluster `kubernetes` Service probed alongside it (`10.43.0.1`, also pod/Service-CIDR space) -- so it's denied, and the `192.168.8.80/28` ipBlock never gets evaluated at all.

`192.168.8.192` (nas) has no Service on the homelab cluster, so no DNAT intercepts it; the packet leaves as-is and the ipBlock matches normally. This is the standard NetworkPolicy-vs-Service-VIP hairpin interaction, not something specific to this stack, but the mechanism (embedded kube-proxy, kube-router's `FORWARD`-chain enforcement) was confirmed live rather than assumed.

## What changed

- Removed `192.168.8.80/28` from the egress allow in both `sandbox-docker` and `sandbox-talos` -- it was dead config that could never match. This is a net improvement, not a loss: it keeps homelab's own API server unreachable from the sandboxes, a better posture than what #829 documented.
- Documented in the policy comment why a genuine future need for homelab-ingress reachability requires an egress rule selecting Traefik's **pods** directly (`namespaceSelector` + `podSelector`), not a bigger ipBlock -- pod-selector rules match the pod IP directly and aren't affected by the DNAT that defeats an ipBlock here. Also noted that doing so would unavoidably expose homelab's own API server, the identical shared-VIP/shared-Service problem #828 already documents for nas.
- Converted the corresponding falsifiability-probe check (both namespaces) from a positive control to a **deny-assertion with the mechanism stated**, so the probe actively encodes "this is expected to be unreachable, and here's why" instead of silently omitting a target that used to false-positive. nas's VIP remains the positive control.
- Updated the "what this tolerates" statement: it previously claimed both clusters' `standard-pool` ranges were reachable, including both API servers. That was only ever true for nas. Homelab's API server is not reachable, for the DNAT reason above -- **the sandboxes can pull images from the cluster they are NOT running on, but cannot reach the API server of the cluster they ARE running on.** That asymmetry is a direct, useful side effect of the DNAT behavior, not something engineered on purpose, and is worth knowing rather than assuming both clusters are equally exposed.
- References **ppat/homelab-ops-kubernetes-clusters#828** for the deferral reasoning (being corrected in parallel to reflect this) rather than restating it.

## Worth reflecting on

This is the **second** time a probe in this pair of namespaces proved right against reasoning that was documented and believed correct -- the first was the unpoliced-startup-window false negative (#818/#819). Both times the fix was to the belief, not the probe. That's the argument for keeping these probes noisy-when-broken and clean-when-correct rather than tolerating an occasional `VIOLATIONS-DETECTED` as background noise: a control that cries wolf gets ignored within a week, and then it can't catch the next one either.

## Test plan

- [x] `pre-commit run --all-files` green, including `commitlint` on the actual commit (confirmed running, not silently skipped -- visible as its own passing hook stage)
- [x] YAML and embedded shell script (`bash -n`) validated for all 4 changed files
- [x] Confirmed live: no separate `kube-proxy` DaemonSet on the homelab cluster (k3s embedded kube-proxy), consistent with the DNAT mechanism above
- [x] Confirmed both egress NetworkPolicies now allow only `192.168.8.192/28`
- [ ] **Not verified**: the corrected probes' actual on-cluster behavior. This PR is not applied to any cluster -- the steady-state verdict (clean, not `VIOLATIONS-DETECTED`) is unverified until Flux reconciles this and the probes run for real.

Not merging -- opening for review.