### PR TITLE
fix(cluster-homelab): admit same-namespace ingress to the Talos sandbox VM

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -935,9 +935,13 @@ of relying on someone else's automated image.
 NetworkPolicies are actually being enforced, not just present — it probes
 targets that should now be unreachable (the prod kube-apiserver, kubelet,
 etcd, the UniFi gateway, the in-cluster `kubernetes` Service, and, from
-`sandbox-talos`, the `sandbox-docker` namespace's SSH Service) alongside two
-that must stay reachable (`api.github.com` and DNS resolution via CoreDNS),
-on a recurring loop (`PROBE_INTERVAL_SECONDS`, 300s by default).
+`sandbox-talos`, the `sandbox-docker` namespace's SSH Service) alongside
+targets that must stay reachable (`api.github.com`, DNS resolution via
+CoreDNS, and, from `sandbox-talos`, its own Talos VM's Service on both
+ports it serves — the same-namespace ingress path that went silently
+missing until it denied `bootstrap-job.yaml`'s `talosctl bootstrap` call;
+see `sandbox-talos/network-policy.yaml`'s `allow-same-namespace-ingress-
+to-vm`), on a recurring loop (`PROBE_INTERVAL_SECONDS`, 300s by default).
 
 A probe that only ever runs *after* the policy exists proves nothing by
 itself: if every target were unreachable for some unrelated reason (a

--- a/clusters/homelab/services/sandbox-talos/deployment-netpol-falsifiability-probe.yaml
+++ b/clusters/homelab/services/sandbox-talos/deployment-netpol-falsifiability-probe.yaml
@@ -16,6 +16,32 @@
 # name isn't evidence the policy works, it's evidence there's nothing there yet), and it
 # starts actually asserting the moment Phase 4 creates a Service at DOCKER_SSH_SERVICE
 # below with no change needed here. Update the env var if Phase 4 names it differently.
+#
+# A second probe here also has no sandbox-docker equivalent, and for a sharper reason than
+# "no such need there": same-namespace reachability of this VM's own Service, on both
+# ports it serves. This is a positive control (must stay reachable, like the
+# api.github.com/DNS checks below), added because the deny-only suite above would not have
+# caught the exact bug it exists to catch -- allow-same-namespace-ingress-to-vm in
+# network-policy.yaml admits this traffic today, but nothing before that fix ever asserted
+# it was reachable, so the policy silently regressing to "same-namespace ingress denied
+# again" would pass every deny probe here without comment. See network-policy.yaml for the
+# full incident (bootstrap-job.yaml's `talosctl bootstrap` call denied with `connection
+# refused`) and the general lesson (an egress allow doesn't imply the matching ingress
+# allow; same-namespace traffic is never exempt once an ingress policy selects the pod).
+#
+# Same "not deployed yet" problem as DOCKER_SSH_SERVICE above, handled the same way: the
+# VM and its Service are provisioned from a separate repo/process
+# (homelab-ops-kubernetes-experiments), not by this Flux module, so this probe has to make
+# sense running before that's ever applied to a given cluster, or after `talosctl reset`
+# wipes the VM's own state and before it's re-bootstrapped. TALOS_VM_SERVICE unresolvable
+# is SKIP, not a violation, for the same reason as DOCKER_SSH_SERVICE. Once it resolves,
+# though, this check is meaningful only once the VM is actually up and listening -- and
+# because this stack REJECTs a denied packet instead of dropping it (see network-policy.yaml
+# CAVEAT), a genuine policy regression is indistinguishable at the TCP level from the VM
+# still booting. That ambiguity is inherent to any positive-reachability probe against a
+# real workload, not something to paper over: this deliberately fails loud
+# (REACHABLE/BLOCKED (violation), never a silent pass) on either cause once the Service
+# exists, rather than guessing which one it is.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -63,6 +89,15 @@ spec:
           value: "docker-vm.sandbox-docker.svc.cluster.local"
         - name: DOCKER_SSH_PORT
           value: "22"
+        - name: TALOS_VM_SERVICE
+          # Same DNS name bootstrap-job.yaml/provision-agent-admin-cronjob.yaml target
+          # (ENDPOINT there) -- see the file-level comment above for why this is a
+          # positive control, not a deny target.
+          value: "talos-vm.sandbox-talos.svc.cluster.local"
+        - name: TALOS_VM_TALOS_PORT
+          value: "50000"
+        - name: TALOS_VM_K8S_PORT
+          value: "6443"
         - name: TIMEOUT_SECONDS
           value: "3"
         - name: WARMUP_TIMEOUT_SECONDS
@@ -186,6 +221,22 @@ spec:
               fi
             else
               echo "SKIP: Docker namespace SSH Service ($DOCKER_SSH_SERVICE:$DOCKER_SSH_PORT) -- not deployed yet"
+            fi
+
+            # Same-namespace positive control: the Talos VM's own Service, both ports it
+            # serves. See the file-level comment above for why this exists and why it's
+            # SKIP (not a violation) when the Service doesn't resolve yet. Two ports, so
+            # (unlike the single-target DOCKER_SSH_SERVICE check above) the SKIP branch
+            # bumps `probes` by 2 itself rather than sharing one outer increment --
+            # probe_allow already does its own increment for each port on the resolvable
+            # path, so this keeps the SKIP and checked paths counting the same total either
+            # way.
+            if nslookup "$TALOS_VM_SERVICE" >/dev/null 2>&1; then
+              probe_allow "Talos VM Talos API (same-namespace ingress)" "$TALOS_VM_SERVICE" "$TALOS_VM_TALOS_PORT"
+              probe_allow "Talos VM Kubernetes API (same-namespace ingress)" "$TALOS_VM_SERVICE" "$TALOS_VM_K8S_PORT"
+            else
+              probes=$((probes + 2))
+              echo "SKIP: Talos VM Service ($TALOS_VM_SERVICE) -- not deployed yet (both ports)"
             fi
 
             # LB_INGRESS_VIP_HOMELAB is a deny-assertion (DNAT to a Traefik pod IP before

--- a/clusters/homelab/services/sandbox-talos/network-policy.yaml
+++ b/clusters/homelab/services/sandbox-talos/network-policy.yaml
@@ -226,3 +226,54 @@ spec:
       port: 6443
     - protocol: TCP
       port: 50000
+---
+# Admits same-namespace ingress to the Talos VM's own ports -- the gap that left this VM
+# unreachable from its own namespace. allow-same-namespace-egress (above) only ever
+# admitted this namespace's own EGRESS; the sole ingress-admitting policy
+# (allow-coder-and-mcp-ingress, immediately above) lists `coder` and the `ai` mcp-server
+# pod, never pods in `sandbox-talos` itself. That's the general trap, not just a one-off
+# gap: an egress allow does not imply a matching ingress allow, and same-namespace traffic
+# is not exempt from an ingress policy once default-deny plus any ingress-admitting rule
+# selects a pod -- every client has to be listed explicitly, including ones that live right
+# next to the target. Concretely, that gap denied
+# homelab-ops-kubernetes-experiments/experiments/apps/sandbox-talos/bootstrap-job.yaml's
+# `talosctl bootstrap` call (port 50000, surfaced as `connection refused` -- this stack's
+# kube-router REJECTs a denied packet rather than dropping it, indistinguishable at the
+# TCP level from a closed port) and would equally have denied
+# provision-agent-admin-cronjob.yaml's kubectl calls against the sandbox cluster's own API
+# server (port 6443) the first time it ran after a bootstrap. Both Jobs/CronJobs run as
+# pods in this same namespace and have no other path to the VM.
+#
+# Scoped to the VM's pod specifically (app.kubernetes.io/name: talos-vm -- the exact label
+# service.yaml's Service selects on; see that module's virtual-machine.yaml for why this
+# label exists at all: KubeVirt passes VirtualMachineInstance labels through to the
+# virt-launcher pod but adds no label of its own meant for Service/NetworkPolicy selection)
+# rather than a blanket same-namespace ingress allow across every pod here, deliberately
+# asymmetric with allow-same-namespace-egress's blanket podSelector: {}: nothing else in
+# this namespace (the bootstrap Job, the two CronJobs, the falsifiability probe) listens on
+# anything another pod would ever need to reach, so admitting ingress to them too would
+# only widen the surface with no matching need. What this doesn't touch: the containment
+# that actually matters for this namespace -- default-deny Ingress for every other selector
+# (coder/ai-only, per allow-coder-and-mcp-ingress) and default-deny Egress entirely -- both
+# stay exactly as scoped as before. Ports match allow-coder-and-mcp-ingress's own pair for
+# the same reason they're needed there: 6443 is the sandbox cluster's own Kubernetes API,
+# 50000 is the Talos API (talosctl, mTLS).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace-ingress-to-vm
+  namespace: sandbox-talos
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: talos-vm
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+    ports:
+    - protocol: TCP
+      port: 6443
+    - protocol: TCP
+      port: 50000


### PR DESCRIPTION
## Summary

- The Talos sandbox VM's Talos API (:50000) and Kubernetes API (:6443) were unreachable from *other pods in the same namespace* -- `allow-same-namespace-egress` only ever admitted this namespace's own egress; the sole ingress-admitting policy (`allow-coder-and-mcp-ingress`) lists `coder` and the `ai` mcp-server pod, never pods in `sandbox-talos` itself. Diagnosed live: the in-namespace bootstrap Job's `talosctl bootstrap` call was failing with `connection refused` (this stack's kube-router REJECTs a denied packet rather than dropping it), even though the Service/endpoints/VM were all healthy.
- Adds a new NetworkPolicy, `allow-same-namespace-ingress-to-vm`, scoped to the VM's own pod (`app.kubernetes.io/name: talos-vm`, the label its Service already selects on) admitting same-namespace ingress on 6443/50000 -- not a blanket same-namespace ingress allow, since nothing else in this namespace (bootstrap Job, the two CronJobs, the falsifiability probe) listens on anything another pod needs to reach.
- Adds a positive control to the falsifiability probe asserting the VM's own Service stays reachable from within the namespace on both ports. The existing probe suite is deny-only and would not have caught this regressing -- "nothing reaches the VM" looks identical to "the deny targets are correctly denied" from that probe's point of view. SKIPs (not a violation) when the Service doesn't resolve yet, mirroring the existing `DOCKER_SSH_SERVICE` pattern, since the VM/Service are provisioned from a separate repo/process (`homelab-ops-kubernetes-experiments`), not by this Flux module.
- `OPERATIONS.md`'s probe-runbook section updated to describe the new positive control.

Confirmed both ports are actually needed by reading `homelab-ops-kubernetes-experiments/experiments/apps/sandbox-talos/`: `bootstrap-job.yaml` targets :50000 only, `provision-agent-admin-cronjob.yaml` targets both (`talosctl kubeconfig` over :50000, then `kubectl` against the sandbox cluster's own API over :6443), `reset-cronjob.yaml` targets :50000 only.

**Checked whether `sandbox-docker` needs the same fix -- it does not.** `homelab-ops-kubernetes-experiments/experiments/apps/docker-host/` ships no Job/CronJob equivalent to `bootstrap-job.yaml`/`provision-agent-admin-cronjob.yaml`; nothing in that namespace talks to the Docker VM from inside it. SSH to it arrives only from `coder`, which `allow-coder-ingress` already admits.

## What I could not verify without this being applied

- I have no cluster access from this session (worktree-only), so I could not confirm live that the bootstrap Job now succeeds against the running VM, or watch the falsifiability probe flip its new check from SKIP/violation to `REACHABLE (ok)`. `pre-commit run --all-files` (yamllint, markdownlint, shellcheck, kubeconform via `validate-k8s`) is green, and `commitlint` ran and passed on the commit-msg hook, but neither exercises live cluster behavior.
- The probe's new positive control is a same-namespace TCP reachability check only -- it can't distinguish "policy regressed" from "VM still booting" (this stack REJECTs either way), by design; see the comment in `deployment-netpol-falsifiability-probe.yaml`.

## Test plan

- [ ] After merge and reconcile, confirm the still-running bootstrap Job (or a fresh `bootstrap-talos-vm-genN`) succeeds against the sandbox VM.
- [ ] `kubectl logs -f -n sandbox-talos deploy/netpol-falsifiability-probe` shows the two new `REACHABLE (ok): Talos VM ...` lines and `verdict=CLEAN`.
- [ ] Trigger `provision-agent-admin` once by hand and confirm it can reach the sandbox cluster's own API on :6443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)