### PR TITLE
feat(cluster-homelab): add sandbox VM egress dashboard

### DIFF
--- a/clusters/homelab/services/monitoring/dashboards/sandbox-vm-egress.json
+++ b/clusters/homelab/services/monitoring/dashboards/sandbox-vm-egress.json
@@ -1,0 +1,628 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [ ],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Network egress/ingress for the sandbox KubeVirt VMs (docker-vm, talos-vm), which have wide-open internet access by design. Metrics-only visibility, no alert rules — alerting stays deferred until an AI triage layer exists.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [ ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [ ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [ ]
+          }
+        },
+        "overrides": [ ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "code": {
+          "language": "markdown",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "Source: `kubevirt_vmi_network_{transmit,receive}_bytes_total`, exported by `virt-handler` per VMI. The two VMs are split by the `name`/`namespace` labels — **not** `pod`, which is the per-node `virt-handler` DaemonSet pod and is shared across every VMI on that node. These VMs are destroyed and rebuilt weekly, which resets the underlying counters to zero; `rate()`/`increase()` compensate for a counter reset automatically, and the rolling-24h panels below stay meaningful across a rebuild since each is a self-contained trailing window rather than an accumulation since dashboard-range start.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.2.0",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Egress: bytes/sec sent by each sandbox VM.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [ ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": [ ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (name, namespace) (rate(kubevirt_vmi_network_transmit_bytes_total{namespace=~\"sandbox-.*\"}[$__rate_interval]))",
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Egress rate (transmit)",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Ingress: bytes/sec received by each sandbox VM.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [ ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": [ ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (name, namespace) (rate(kubevirt_vmi_network_receive_bytes_total{namespace=~\"sandbox-.*\"}[$__rate_interval]))",
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Ingress rate (receive)",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rolling trailing-24h total transmitted, evaluated continuously. A slow, low-rate drip that the rate graph above averages into invisibility still shows as a rising line here, and — unlike a total pinned to the dashboard's selected range — this stays a comparable day-over-day number even right after a weekly VM rebuild, since it is always 'last 24h from now', not 'since the dashboard range started'.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [ ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [ ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (name, namespace) (increase(kubevirt_vmi_network_transmit_bytes_total{namespace=~\"sandbox-.*\"}[1d]))",
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Rolling 24h total transmitted",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rolling trailing-24h total received, evaluated continuously — same reasoning as the transmit version. A compromised VM pulling down a payload slowly enough to hide in the rate graph still shows up as a rising line here.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [ ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [ ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (name, namespace) (increase(kubevirt_vmi_network_receive_bytes_total{namespace=~\"sandbox-.*\"}[1d]))",
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Rolling 24h total received",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Total bytes transmitted by each VM over the selected dashboard time range. Note this resets to a small number right after the weekly VM rebuild (less elapsed VM lifetime, not less traffic) — use the rolling-24h panel above for a reading that stays comparable day-over-day.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [ ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [ ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (name, namespace) (increase(kubevirt_vmi_network_transmit_bytes_total{namespace=~\"sandbox-.*\"}[$__range]))",
+          "instant": true,
+          "legendFormat": "{{name}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Total transmitted (selected range)",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Total bytes received by each VM over the selected dashboard time range — a compromised VM pulling down a payload shows up here even if the transfer rate never spikes. Same reset caveat as the transmit total: prefer the rolling-24h panel for a day-over-day comparable reading.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [ ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [ ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (name, namespace) (increase(kubevirt_vmi_network_receive_bytes_total{namespace=~\"sandbox-.*\"}[$__range]))",
+          "instant": true,
+          "legendFormat": "{{name}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Total received (selected range)",
+      "transparent": true,
+      "type": "stat"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": [ ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [ ],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": { },
+  "timezone": "",
+  "title": "Sandbox VM Egress",
+  "weekStart": ""
+}

--- a/clusters/homelab/services/monitoring/kustomization.yaml
+++ b/clusters/homelab/services/monitoring/kustomization.yaml
@@ -31,6 +31,16 @@ configMapGenerator:
     labels:
       grafana_dashboard: "1"
     disableNameSuffixHash: true
+- name: dashboard-sandbox-vm-egress
+  namespace: monitoring
+  files:
+  - dashboards/sandbox-vm-egress.json
+  options:
+    annotations:
+      kustomize.toolkit.fluxcd.io/substitute: disabled
+    labels:
+      grafana_dashboard: "1"
+    disableNameSuffixHash: true
 - name: snmp-exporter-extra-config
   namespace: monitoring
   files:


### PR DESCRIPTION
## Summary

- Both `sandbox-docker` and `sandbox-talos` KubeVirt VMs have wide-open internet egress by design (RFC1918/link-local/loopback denied, everything else allowed). This dashboard was named as the mitigation for the largest unmitigated residual risk in the sandbox security model — unmonitored internet access from an agent-controlled VM is exactly the kind of thing that becomes a reputational event silently.
- Adds a locally-authored "Sandbox VM Egress" dashboard as a sidecar ConfigMap (`clusters/homelab/services/monitoring/dashboards/sandbox-vm-egress.json`), following this cluster's existing dashboard convention (see `dashboards/spegel.json`).
- Uses KubeVirt's own per-VMI metrics (`kubevirt_vmi_network_{transmit,receive}_bytes_total`), confirmed live and already scraped via the existing `prometheus-kubevirt-rules` ServiceMonitor — no new scrape config needed.
- Series are split by the `name`/`namespace` labels, **not** `pod` — `pod` is the per-node `virt-handler` DaemonSet pod shared across every VMI on that node, and using it would silently merge both VMs into one series.
- **No alert rules added**, per this project's standing policy of deferring alerting until an AI triage layer exists between AlertManager and a human.

## Panels

1. **Egress/ingress rate** (timeseries, `rate()` over `$__rate_interval`, split per VM) — for an active spike.
2. **Rolling 24h total transmitted/received** (timeseries, `increase()` over a fixed `[1d]` window, evaluated continuously) — a slow, low-rate drip that the rate graph averages into invisibility still shows as a rising line, and it stays a comparable day-over-day reading regardless of when in the weekly VM-rebuild cycle you look, since it's always "last 24h from now" rather than "since the dashboard range started".
3. **Total transmitted/received over the selected range** (stat, `increase()` over `$__range`) — a quick-glance number for whatever range is currently selected.

Both sandbox VMs are destroyed and rebuilt weekly, which resets the underlying Prometheus counters to zero. `rate()`/`increase()` compensate for a single counter reset within their own query window automatically (standard Prometheus behavior), and the rolling-24h panels are resilient to this by construction since each evaluation is a self-contained trailing window rather than an accumulation since the dashboard range's start. The range-total stat panels legitimately read low right after a rebuild (less elapsed VM lifetime, not less traffic) — their panel description calls this out and points at the rolling-24h panel instead. Dashboard default range is 7d so one full rebuild cycle is visible without touching the time picker.

## Test plan

- [x] `kustomize build clusters/homelab/services/monitoring` renders the new `dashboard-sandbox-vm-egress` ConfigMap with the `grafana_dashboard: "1"` label and valid embedded JSON (7 panels).
- [x] `pre-commit run` (check-json, yamllint, kubeconform `Validate Kubernetes manifests`) passes on the changed files.
- [x] Every PromQL expression in the dashboard verified against live Prometheus data via the Grafana MCP (`query_prometheus`), confirming two distinct, sane-valued series (docker-vm / talos-vm) for each.
- [x] CI (lint workflow) green on this PR.

Closes #833