### PR TITLE
fix(cluster-homelab,policies): scope kubevirt read into mcp-kubernetes-readonly and close the controllerrevisions bypass

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -266,7 +266,18 @@ question: operators ship their own aggregating `ClusterRole`s (KubeVirt's
 `kubevirt.io:view` carries `rbac.authorization.k8s.io/aggregate-to-view`, and
 its `kubevirt.io:default` is bound to `system:authenticated`), so check what
 a subject already holds through `view` or through the operator's own bindings
-before concluding a kind is unreadable.
+before concluding a kind is unreadable. That also means an exclusion is a
+property of a *subject*, deliberately, not a cluster-wide guarantee: stock
+`system:aggregate-to-view` — which `view` consumes, and which `oidc-readers`
+binds `homelab-users` to — carries `apps/controllerrevisions` and `pods/log`
+alongside everything else it aggregates, so both channels a KubeVirt
+exclusion is built to withhold stay fully readable by any authenticated human
+through `view`. That's intentional: a dedicated read-only `ClusterRole` like
+this one gets scoped hardest around the identity reachable from an LLM — an
+agent that can be prompted, acts without a human reading every response, and
+can carry output past the cluster boundary — while an authenticated human
+holding `view` is a different threat model and is deliberately left
+unconstrained.
 
 Identities bound here must not live in `kube-system`: it's conventionally
 exempted from Pod Security Admission and from policy-engine namespace

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -250,11 +250,23 @@ another kind's content defeats a kind-level exclusion — wrapper kinds, or
 controller-written state/snapshot kinds that carry another kind's payload.
 When a group mixes credential-bearing and benign kinds, enumerate kinds
 rather than wildcarding the group, and re-check the enumeration whenever the
-operator adds a kind. `get`/`list`/`watch` is also not uniformly a read-only
-boundary: the API server maps HTTP method to RBAC verb for `*/proxy`
+operator adds a kind. Wrapper kinds do not respect API-group boundaries, so
+enumerate the wrappers before trusting an exclusion: KubeVirt records each
+`VirtualMachine`'s full spec in an `apps/controllerrevisions` object on every
+start, which puts the payload of an excluded kind in a group that looks
+entirely unrelated to it. `get`/`list`/`watch` is also not uniformly a
+read-only boundary: the API server maps HTTP method to RBAC verb for `*/proxy`
 subresources, and kubelet exposes GET routes for exec/attach/portForward, so
 `get` on `nodes/proxy` is code-execution-equivalent — treat proxy
-subresources as write access.
+subresources as write access. Aggregated APIs decide the verb the same way,
+which is why `subresources.kubevirt.io` serves a guest console at `get`.
+
+Finally, an exclusion is only meaningful for identities bound to the role in
+question: operators ship their own aggregating `ClusterRole`s (KubeVirt's
+`kubevirt.io:view` carries `rbac.authorization.k8s.io/aggregate-to-view`, and
+its `kubevirt.io:default` is bound to `system:authenticated`), so check what
+a subject already holds through `view` or through the operator's own bindings
+before concluding a kind is unreadable.
 
 Identities bound here must not live in `kube-system`: it's conventionally
 exempted from Pod Security Admission and from policy-engine namespace

--- a/ci/policy-tests/rbac-clusterrole-readonly.yaml
+++ b/ci/policy-tests/rbac-clusterrole-readonly.yaml
@@ -12,8 +12,11 @@
 # mcp-kubernetes-readonly.yaml on both clusters) before merge.
 #
 # Constrains what is INSIDE the mcp-kubernetes-readonly ClusterRole: no verb
-# outside get/list/watch, no nodes/proxy, no core Secrets, and an allow-list
-# on generators.external-secrets.io. The companion policy
+# outside get/list/watch, no nodes/proxy, no core Secrets, an allow-list on
+# generators.external-secrets.io, no "*" apiGroup, and — for KubeVirt — no
+# resource wildcard on any *.kubevirt.io group, no console/export subresource
+# groups, no kind that can embed a VM spec, and no apps/controllerrevisions
+# (which is one such kind in disguise). The companion policy
 # rbac-clusterrolebinding-roleref.yaml (test-rbac-clusterrolebinding-roleref)
 # constrains which role is actually BOUND to the mcp-kubernetes ServiceAccount
 # — this file says nothing about that. Both must pass for the read-only
@@ -147,3 +150,136 @@ spec:
             denying fakes/webhooks alone does not deny either wrapper. Use
             an explicit resource allow-list instead of "*", and keep
             fakes/webhooks/clustergenerators/generatorstates off it.
+  - name: no-apigroup-wildcard
+    match:
+      any:
+      - resources:
+          kinds:
+          - ClusterRole
+    validate:
+      cel:
+        expressions:
+        - expression: "!object.rules.exists(r, '*' in r.apiGroups)"
+          message: >-
+            A rule uses "*" in apiGroups. Every other rule in this policy
+            excludes things by naming an apiGroup — core Secrets, the
+            generators.external-secrets.io allow-list, the KubeVirt rules
+            below — so a single apiGroups: ["*"] rule silently re-admits all
+            of them at once and makes the rest of this policy decorative. It
+            also re-admits every group nobody has reviewed yet, including
+            ones installed after this file was last read. The role's own
+            group-wide grant already demonstrates the correct shape: a
+            wildcard on RESOURCES within an explicitly enumerated list of
+            apiGroups. Enumerate the apiGroups.
+  - name: kubevirt-must-enumerate-kinds
+    match:
+      any:
+      - resources:
+          kinds:
+          - ClusterRole
+    validate:
+      cel:
+        expressions:
+        - expression: >-
+            !object.rules.exists(r,
+            r.apiGroups.exists(g, g == 'kubevirt.io' || g.endsWith('.kubevirt.io')) &&
+            ('*' in r.resources))
+          message: >-
+            A rule wildcards resources on a KubeVirt apiGroup. KubeVirt
+            spreads across 11 groups that mix benign configuration
+            (KubeVirt CR, instancetypes, migrationpolicies) with kinds that
+            embed a full VM spec — and therefore any inline
+            cloudInitNoCloud.userData — plus, in subresources.kubevirt.io, a
+            guest console. Its API surface also grows across minors: v1.9.0
+            added backup.kubevirt.io, template.kubevirt.io,
+            plugin.kubevirt.io and a second aggregated subresource group, so
+            a "*" written today grants kinds nobody has read the schema of.
+            The endsWith() match is deliberate: it covers KubeVirt groups
+            that do not exist yet. Enumerate the resources by kind.
+  - name: kubevirt-excluded-groups
+    match:
+      any:
+      - resources:
+          kinds:
+          - ClusterRole
+    validate:
+      cel:
+        expressions:
+        - expression: >-
+            !object.rules.exists(r,
+            r.apiGroups.exists(g, g in ['subresources.kubevirt.io',
+            'subresources.template.kubevirt.io', 'export.kubevirt.io',
+            'cdi.kubevirt.io']))
+          message: >-
+            A rule names a KubeVirt apiGroup that must never appear in a
+            read-only role. subresources.kubevirt.io serves
+            virtualmachineinstances/console, /vnc and /portforward, and
+            KubeVirt derives the RBAC verb from the HTTP method — those
+            routes are GET, so "get" there is an interactive session inside
+            the guest, exactly like the nodes/proxy case above. The same
+            group also serves virtualmachines/expand-spec at verb "get",
+            which returns the fully expanded VM object and would hand back
+            the inline cloud-init that excluding virtualmachines exists to
+            withhold. subresources.template.kubevirt.io is a second
+            aggregated subresource group (new in v1.9.0).
+            export.kubevirt.io is the VM disk-image export control plane.
+            cdi.kubevirt.io is not installed. Remove the group.
+  - name: kubevirt-excluded-kinds
+    match:
+      any:
+      - resources:
+          kinds:
+          - ClusterRole
+    validate:
+      cel:
+        expressions:
+        - expression: >-
+            !object.rules.exists(r,
+            r.apiGroups.exists(g, g == 'kubevirt.io' || g.endsWith('.kubevirt.io')) &&
+            r.resources.exists(res, res in ['virtualmachines',
+            'virtualmachineinstances', 'virtualmachineinstancereplicasets',
+            'virtualmachinesnapshotcontents', 'virtualmachinetemplates',
+            'virtualmachinepools', 'virtualmachineclones',
+            'virtualmachinerestores', 'virtualmachineexports']))
+          message: >-
+            A rule grants a KubeVirt kind that can carry inline plaintext
+            cloud-init. VirtualMachine holds
+            spec.template.spec.volumes[].cloudInitNoCloud.userData directly;
+            the rest are wrappers for it, and RBAC allows and denies by
+            kind, never by content. VirtualMachineInstance is the rendered
+            copy of the VM template, userData included, so granting it
+            instead of VirtualMachine is not a mitigation.
+            VirtualMachineInstanceReplicaSet and VirtualMachinePool hold VM
+            templates; VirtualMachineSnapshotContent embeds a whole
+            VirtualMachine; VirtualMachineTemplate.spec.virtualMachine is
+            x-kubernetes-preserve-unknown-fields and stores one verbatim;
+            VirtualMachineClone and VirtualMachineRestore carry free-form
+            JSON patches that can set any field on the target.
+            VirtualMachineExport is the disk-export control plane. Grant the
+            KubeVirt CR, instancetypes/preferences, migrationpolicies,
+            virtualmachineinstancemigrations and
+            virtualmachineinstancepresets instead — none of those can
+            reference a volume at all.
+  - name: no-controllerrevisions
+    match:
+      any:
+      - resources:
+          kinds:
+          - ClusterRole
+    validate:
+      cel:
+        expressions:
+        - expression: "!object.rules.exists(r, ('apps' in r.apiGroups) && ('controllerrevisions' in r.resources))"
+          message: >-
+            A rule grants apps/controllerrevisions. That is a wrapper kind
+            for a workload spec, and on a cluster running KubeVirt it is a
+            complete bypass of the kubevirt-excluded-kinds rule above:
+            virt-controller writes a ControllerRevision whose .data is the
+            entire vm.spec every time a VirtualMachine starts, so a VM using
+            inline cloudInitNoCloud.userData puts that plaintext in apiGroup
+            "apps" with no kubevirt.io grant involved. Verified by reading
+            one on the homelab cluster through the mcp-kubernetes-readonly
+            identity itself. Excluding the KubeVirt kinds while granting
+            this achieves nothing. Remove controllerrevisions from
+            resources; nothing but StatefulSet/DaemonSet rollout history
+            reads them.

--- a/ci/policy-tests/rbac-clusterrole-readonly.yaml
+++ b/ci/policy-tests/rbac-clusterrole-readonly.yaml
@@ -209,7 +209,9 @@ spec:
             !object.rules.exists(r,
             r.apiGroups.exists(g, g in ['subresources.kubevirt.io',
             'subresources.template.kubevirt.io', 'export.kubevirt.io',
-            'cdi.kubevirt.io']))
+            'cdi.kubevirt.io', 'snapshot.kubevirt.io', 'template.kubevirt.io',
+            'pool.kubevirt.io', 'clone.kubevirt.io', 'backup.kubevirt.io',
+            'plugin.kubevirt.io']))
           message: >-
             A rule names a KubeVirt apiGroup that must never appear in a
             read-only role. subresources.kubevirt.io serves
@@ -223,7 +225,16 @@ spec:
             withhold. subresources.template.kubevirt.io is a second
             aggregated subresource group (new in v1.9.0).
             export.kubevirt.io is the VM disk-image export control plane.
-            cdi.kubevirt.io is not installed. Remove the group.
+            cdi.kubevirt.io is not installed. snapshot.kubevirt.io,
+            template.kubevirt.io, pool.kubevirt.io and clone.kubevirt.io each
+            embed a whole VirtualMachine or a free-form JSON patch that can
+            set any field on one, same as the kinds kubevirt-excluded-kinds
+            rejects above — see the role file's own "KubeVirt API groups
+            deliberately granted NOTHING" comment for the per-group
+            reasoning, including why virtualmachinetemplaterequests
+            (installed on homelab today) is excluded by group rather than by
+            kind. backup.kubevirt.io and plugin.kubevirt.io carry no VM spec
+            but are excluded as unused and unaudited. Remove the group.
   - name: kubevirt-excluded-kinds
     match:
       any:
@@ -236,14 +247,17 @@ spec:
         - expression: >-
             !object.rules.exists(r,
             r.apiGroups.exists(g, g == 'kubevirt.io' || g.endsWith('.kubevirt.io')) &&
-            r.resources.exists(res, res in ['virtualmachines',
+            r.resources.exists(res, ['virtualmachines',
             'virtualmachineinstances', 'virtualmachineinstancereplicasets',
             'virtualmachinesnapshotcontents', 'virtualmachinetemplates',
             'virtualmachinepools', 'virtualmachineclones',
-            'virtualmachinerestores', 'virtualmachineexports']))
+            'virtualmachinerestores', 'virtualmachineexports'].exists(k,
+            res == k || res.startsWith(k + '/'))))
           message: >-
             A rule grants a KubeVirt kind that can carry inline plaintext
-            cloud-init. VirtualMachine holds
+            cloud-init, either directly or via its */status subresource (a
+            GET on <kind>/status returns the whole object, spec included, so
+            it is not a narrower grant). VirtualMachine holds
             spec.template.spec.volumes[].cloudInitNoCloud.userData directly;
             the rest are wrappers for it, and RBAC allows and denies by
             kind, never by content. VirtualMachineInstance is the rendered
@@ -269,17 +283,23 @@ spec:
     validate:
       cel:
         expressions:
-        - expression: "!object.rules.exists(r, ('apps' in r.apiGroups) && ('controllerrevisions' in r.resources))"
+        - expression: >-
+            !object.rules.exists(r,
+            ('apps' in r.apiGroups) &&
+            r.resources.exists(res, res == 'controllerrevisions' || res.startsWith('controllerrevisions/')))
           message: >-
-            A rule grants apps/controllerrevisions. That is a wrapper kind
-            for a workload spec, and on a cluster running KubeVirt it is a
-            complete bypass of the kubevirt-excluded-kinds rule above:
-            virt-controller writes a ControllerRevision whose .data is the
-            entire vm.spec every time a VirtualMachine starts, so a VM using
-            inline cloudInitNoCloud.userData puts that plaintext in apiGroup
-            "apps" with no kubevirt.io grant involved. Verified by reading
-            one on the homelab cluster through the mcp-kubernetes-readonly
-            identity itself. Excluding the KubeVirt kinds while granting
-            this achieves nothing. Remove controllerrevisions from
-            resources; nothing but StatefulSet/DaemonSet rollout history
-            reads them.
+            A rule grants apps/controllerrevisions (or its /status
+            subresource — ControllerRevision has no status subresource today,
+            but the check is written the same way as kubevirt-excluded-kinds
+            above for consistency rather than because anything currently
+            turns on it). That is a wrapper kind for a workload spec, and on
+            a cluster running KubeVirt it is a complete bypass of the
+            kubevirt-excluded-kinds rule above: virt-controller writes a
+            ControllerRevision whose .data is the entire vm.spec every time a
+            VirtualMachine starts, so a VM using inline
+            cloudInitNoCloud.userData puts that plaintext in apiGroup "apps"
+            with no kubevirt.io grant involved. Verified by reading one on
+            the homelab cluster through the mcp-kubernetes-readonly identity
+            itself. Excluding the KubeVirt kinds while granting this achieves
+            nothing. Remove controllerrevisions from resources; nothing but
+            StatefulSet/DaemonSet rollout history reads them.

--- a/clusters/homelab/cluster/rbac/mcp-kubernetes-readonly.yaml
+++ b/clusters/homelab/cluster/rbac/mcp-kubernetes-readonly.yaml
@@ -396,8 +396,11 @@ rules:
   # motivated granting anything at all — "what is vmRolloutStrategy set to",
   # "is virt-handler healthy", "which nodes may run VMs".
   - kubevirts
-  # Names a VMI to migrate plus an optional node selector; carries no VMI
-  # spec of its own. Migration is disabled on this cluster
+  # Carries no VMI spec of its own — that's the durable claim, not a field
+  # inventory: as of v1.9.0 the spec also has sendTo.connectURL, receive
+  # .migrationID and priority (decentralized-migration fields), and status
+  # has synchronizationAddresses, none of which existed when this rule was
+  # first written. Migration is disabled on this cluster
   # (evictionStrategy: None), so this is granted for diagnosis, not use.
   - virtualmachineinstancemigrations
   # spec.domain is a DomainSpec, which has no volumes field at all — the API
@@ -438,12 +441,15 @@ rules:
   # incapable of carrying cloud-init: the API server rejects spec.volumes on
   # an instancetype as an unknown field, and a preference's spec.volumes is a
   # single string, preferredStorageClassName. The one field worth naming is
-  # spec.launchSecurity.sev.{dhCert,session} on an instancetype — AMD SEV
-  # guest-owner launch material. It is accepted as readable because it is
-  # designed to transit the untrusted host (the session blob's transport keys
-  # are encrypted to the platform's PDH, so reading it does not defeat SEV),
-  # and because no SEV-capable hardware exists on this cluster. If confidential
-  # computing is ever actually used here, revisit this line first.
+  # launch-security material: spec.launchSecurity.sev.{dhCert,session} on an
+  # instancetype, and the same *v1.LaunchSecurity type via
+  # spec.preferredLaunchSecurity on a preference — both preference kinds are
+  # granted here, so both carry it. AMD SEV guest-owner launch material is
+  # accepted as readable because it is designed to transit the untrusted host
+  # (the session blob's transport keys are encrypted to the platform's PDH,
+  # so reading it does not defeat SEV), and because no SEV-capable hardware
+  # exists on this cluster. If confidential computing is ever actually used
+  # here, revisit this line first.
   - virtualmachineclusterinstancetypes
   - virtualmachineclusterpreferences
   - virtualmachineinstancetypes
@@ -464,8 +470,12 @@ rules:
   - watch
 #
 # KubeVirt API groups deliberately granted NOTHING, each for its own reason.
-# ci/policy-tests/rbac-clusterrole-readonly.yaml fails the build if any of the
-# first three reappears, or if any *.kubevirt.io rule uses a "*" resource:
+# ci/policy-tests/rbac-clusterrole-readonly.yaml's kubevirt-excluded-groups
+# rule fails the build if any of these ten groups reappears in a rule's
+# apiGroups, kubevirt-must-enumerate-kinds fails it if any *.kubevirt.io rule
+# uses a "*" resource, and kubevirt-excluded-kinds fails it if a rule names
+# one of the plaintext-bearing kinds enumerated above by exact match or via
+# its /status subresource:
 #
 # - subresources.kubevirt.io: the one that does not advertise itself in its
 #   name. It serves virtualmachineinstances/console, /vnc, /vnc/screenshot,
@@ -480,6 +490,12 @@ rules:
 #   /filesystemlist) are individually grantable and individually harmless-ish,
 #   but no guest agent runs on these VMs, so naming this group here at all
 #   would buy nothing and leave a line one careless edit away from "*".
+#   What this exclusion does NOT buy: KubeVirt v1.9 streams the guest serial
+#   console to a container log by default (the guest-console-log sidecar in
+#   every virt-launcher pod), and pods/log is granted cluster-wide above — so
+#   console *output* (not an interactive session, not an arbitrary VM-spec
+#   read) reaches this identity through that grant regardless of this
+#   exclusion. Tracked in #843.
 # - subresources.template.kubevirt.io: a second aggregated subresource group,
 #   new in v1.9.0 and served by virt-template-apiserver. Its two resources,
 #   virtualmachinetemplates/create and /process, are verb "create" only, so
@@ -507,6 +523,12 @@ rules:
 #   declared x-kubernetes-preserve-unknown-fields and stores an entire
 #   VirtualMachine object verbatim — confirmed by storing one with an inline
 #   userData marker and reading it straight back. New in v1.9.0 and unused.
+#   The group also carries virtualmachinetemplaterequests, which IS installed
+#   on this cluster today; its Go types ship from a separate virt-template
+#   component rather than kubevirt/kubevirt, so its schema hasn't been read
+#   from source. That gap is exactly why this exclusion is written at the
+#   group level rather than as a kind-by-kind allow-list: a new kind in an
+#   already-excluded group needs no review to stay excluded.
 # - pool.kubevirt.io: VirtualMachinePool.spec.virtualMachineTemplate is a VM
 #   template, so the same inline field. Unused.
 # - clone.kubevirt.io: VirtualMachineClone.spec.patches is a free-form JSON

--- a/clusters/homelab/cluster/rbac/mcp-kubernetes-readonly.yaml
+++ b/clusters/homelab/cluster/rbac/mcp-kubernetes-readonly.yaml
@@ -48,7 +48,20 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - controllerrevisions
+  # controllerrevisions deliberately absent, and this is the least obvious
+  # exclusion in this file: it is a wrapper kind for a workload spec, and
+  # KubeVirt uses it as one. Every time a VirtualMachine starts, virt-controller
+  # writes a ControllerRevision in the VM's namespace whose .data holds the
+  # entire vm.spec — verified by reading one on this cluster through this very
+  # identity, which returned the full talos-vm spec: disks, container image,
+  # node affinity, and the cloud-init volume. Today that volume is a secretRef
+  # so nothing sensitive comes back, but a VM using the inline
+  # cloudInitNoCloud.userData form would have its plaintext land here verbatim,
+  # in apiGroup "apps", with no kubevirt.io grant involved at all. Excluding
+  # virtualmachines/virtualmachineinstances below while granting this would be
+  # a paper exclusion. Trade-off: no read on StatefulSet/DaemonSet rollout
+  # history (the `kubectl rollout history` backing objects); no MCP tool
+  # depends on it.
   - daemonsets
   - daemonsets/status
   - deployments
@@ -355,6 +368,162 @@ rules:
   - get
   - list
   - watch
+# KubeVirt (infra-virtualization-core). Enumerated kind by kind, and NOT added
+# to the group-wide "*" rule above, for two independent reasons: KubeVirt
+# spreads across 11 API groups that mix benign config with VM specs, guest
+# consoles and disk-export control planes; and its API surface demonstrably
+# grows across minors — v1.9.0 added backup.kubevirt.io, template.kubevirt.io
+# and plugin.kubevirt.io, plus a second aggregated subresource group,
+# subresources.template.kubevirt.io, none of which existed when this role was
+# first written. A group-level grant would silently absorb the next such
+# addition. Re-audit this block on every KubeVirt minor bump.
+#
+# The field that decides everything below is
+# VirtualMachine.spec.template.spec.volumes[].cloudInitNoCloud.userData (and
+# .userDataBase64, and the cloudInitConfigDrive equivalents of both): inline
+# plaintext cloud-init. This cluster's sandbox Talos VM would carry the
+# cluster's CA *private key* there, so both VM manifests deliberately use
+# `secretRef` instead and say so inline. That is a convention, enforced by
+# nobody — so no kind that can carry the inline form is granted here,
+# regardless of what today's VMs happen to do.
+- apiGroups:
+  - kubevirt.io
+  resources:
+  # The KubeVirt CR: operator configuration only (vmRolloutStrategy,
+  # evictionStrategy, useEmulation, nodePlacement, monitorNamespace) plus
+  # component version/health in status. No workload spec, no volumes, no
+  # secret references. This is the kind that answers the questions that
+  # motivated granting anything at all — "what is vmRolloutStrategy set to",
+  # "is virt-handler healthy", "which nodes may run VMs".
+  - kubevirts
+  # Names a VMI to migrate plus an optional node selector; carries no VMI
+  # spec of its own. Migration is disabled on this cluster
+  # (evictionStrategy: None), so this is granted for diagnosis, not use.
+  - virtualmachineinstancemigrations
+  # spec.domain is a DomainSpec, which has no volumes field at all — the API
+  # server rejects spec.domain.volumes as an unknown field, so a preset
+  # structurally cannot carry cloud-init. Deprecated upstream (removed in
+  # KubeVirt v2) and unused here; granted only so that the exclusions below
+  # are visibly about cloud-init rather than about KubeVirt in general.
+  - virtualmachineinstancepresets
+  #
+  # DELIBERATELY EXCLUDED from this rule:
+  # - virtualmachines: holds the inline cloudInitNoCloud.userData described
+  #   above. Cost of the exclusion: agents cannot read VM configuration
+  #   (disks, interfaces, instancetype, runStrategy) or VM status/conditions,
+  #   and must read the module source in git instead. What they retain: the
+  #   virt-launcher Pod per running VMI (pods, pods/status, pods/log are
+  #   granted above) shows whether a VM is running and on which node, and
+  #   Events on the VirtualMachine object are readable via the core events
+  #   grant.
+  # - virtualmachineinstances: RBAC allows and denies by kind, never by
+  #   content, and the VMI is the wrapper kind here. virt-controller renders
+  #   the VM's template into VirtualMachineInstance.spec.volumes verbatim,
+  #   inline userData included — verified by creating a VM with inline
+  #   userData and reading the resulting VMI. So "grant the controller-written
+  #   VMI but not the human-written VM" is not a mitigation; it is the same
+  #   plaintext in a different envelope, exactly like ClusterGenerator vs Fake
+  #   above. Note also that a */status subresource grant is no help either: a
+  #   GET on <kind>/status returns the whole object, spec included.
+  # - virtualmachineinstancereplicasets: spec.template is a VMI template, so
+  #   same inline field. Unused on this cluster.
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - instancetype.kubevirt.io
+  resources:
+  # CPU/memory/device/scheduling preferences only. Verified structurally
+  # incapable of carrying cloud-init: the API server rejects spec.volumes on
+  # an instancetype as an unknown field, and a preference's spec.volumes is a
+  # single string, preferredStorageClassName. The one field worth naming is
+  # spec.launchSecurity.sev.{dhCert,session} on an instancetype — AMD SEV
+  # guest-owner launch material. It is accepted as readable because it is
+  # designed to transit the untrusted host (the session blob's transport keys
+  # are encrypted to the platform's PDH, so reading it does not defeat SEV),
+  # and because no SEV-capable hardware exists on this cluster. If confidential
+  # computing is ever actually used here, revisit this line first.
+  - virtualmachineclusterinstancetypes
+  - virtualmachineclusterpreferences
+  - virtualmachineinstancetypes
+  - virtualmachinepreferences
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - migrations.kubevirt.io
+  resources:
+  # Migration tuning (bandwidth, timeouts, auto-converge) plus a label
+  # selector. No workload spec.
+  - migrationpolicies
+  verbs:
+  - get
+  - list
+  - watch
+#
+# KubeVirt API groups deliberately granted NOTHING, each for its own reason.
+# ci/policy-tests/rbac-clusterrole-readonly.yaml fails the build if any of the
+# first three reappears, or if any *.kubevirt.io rule uses a "*" resource:
+#
+# - subresources.kubevirt.io: the one that does not advertise itself in its
+#   name. It serves virtualmachineinstances/console, /vnc, /vnc/screenshot,
+#   /portforward and /usbredir, and KubeVirt's own shipped kubevirt.io:admin
+#   ClusterRole grants every one of them with verb "get" — so "get" here is an
+#   interactive session inside the guest, the direct analogue of pods/exec and
+#   of the nodes/proxy exclusion at the top of this file. It also serves
+#   virtualmachines/expand-spec (verb "get"), which renders the full VM spec
+#   with instancetype applied and would hand back the inline cloud-init the
+#   virtualmachines exclusion above exists to withhold. The guest-agent
+#   introspection subresources in the same group (/guestosinfo, /userlist,
+#   /filesystemlist) are individually grantable and individually harmless-ish,
+#   but no guest agent runs on these VMs, so naming this group here at all
+#   would buy nothing and leave a line one careless edit away from "*".
+# - subresources.template.kubevirt.io: a second aggregated subresource group,
+#   new in v1.9.0 and served by virt-template-apiserver. Its two resources,
+#   virtualmachinetemplates/create and /process, are verb "create" only, so
+#   the read-only verb rule would already reject them — but the group is
+#   named here so a future reader does not have to rediscover that it exists.
+# - export.kubevirt.io: VirtualMachineExport is a disk-image exfiltration
+#   control plane. Measured, and contrary to the assumption this decision
+#   started from: spec.tokenSecretRef and status.tokenSecretRef are Secret
+#   *names*, not tokens, and status.links.*.volumes[].formats[].url is
+#   useless without the token, which lives in a Secret this role cannot read.
+#   So a read alone does not exfiltrate a disk. It is still excluded: it
+#   enumerates every export in flight and its download endpoints, nothing on
+#   this cluster creates exports, so the exclusion costs nothing, and "the
+#   token happens to be a reference in this version" is an upstream
+#   implementation detail, not a boundary.
+# - snapshot.kubevirt.io: VirtualMachineSnapshotContent.spec.source.virtualMachine
+#   embeds a whole VirtualMachine, cloudInitNoCloud.userData and
+#   cloudInitConfigDrive.userData included — the wrapper-kind problem again.
+#   VirtualMachineSnapshot and VirtualMachineRestore are references rather
+#   than embeddings, but VirtualMachineRestore.spec.patches is a free-form
+#   list of JSON patches that can set any field on the target, including
+#   userData. Nothing here takes snapshots (no CSI snapshot class), so the
+#   whole group goes.
+# - template.kubevirt.io: VirtualMachineTemplate.spec.virtualMachine is
+#   declared x-kubernetes-preserve-unknown-fields and stores an entire
+#   VirtualMachine object verbatim — confirmed by storing one with an inline
+#   userData marker and reading it straight back. New in v1.9.0 and unused.
+# - pool.kubevirt.io: VirtualMachinePool.spec.virtualMachineTemplate is a VM
+#   template, so the same inline field. Unused.
+# - clone.kubevirt.io: VirtualMachineClone.spec.patches is a free-form JSON
+#   patch list applied to the cloned VM, i.e. arbitrary inline spec content,
+#   the same argument that excludes generators.external-secrets.io/webhooks
+#   above. Unused.
+# - backup.kubevirt.io: VirtualMachineBackup/VirtualMachineBackupTracker are
+#   object references plus a tokenSecretRef by name, with no embedded VM spec
+#   — the least objectionable of the excluded groups. Excluded anyway because
+#   it is new in v1.9.0, unused here, and the status surface of a backup
+#   control plane has had no scrutiny; grant it when something starts using
+#   it, not before.
+# - plugin.kubevirt.io: new in v1.9.0, unused. Plugin.spec carries CEL
+#   conditions and libvirt domain-XML hooks; no credential-bearing field was
+#   found, but an unused kind is not worth a grant.
+# - cdi.kubevirt.io: CDI is not installed on this cluster — no DataVolume or
+#   CDI CRD exists — so this would be a grant for kinds that do not exist.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/clusters/nas/cluster/rbac/mcp-kubernetes-readonly.yaml
+++ b/clusters/nas/cluster/rbac/mcp-kubernetes-readonly.yaml
@@ -1,12 +1,22 @@
 ---
 # This ClusterRole MUST remain a strict subset of
 # clusters/homelab/cluster/rbac/mcp-kubernetes-readonly.yaml: every rule here
-# is intended to be identical to homelab's, and the ONLY permitted divergence
-# is the declared exclusion set on the group-wide "*" rule below —
-# longhorn.io, tailscale.com, deviceplugin.intel.com, fpga.intel.com — dropped
-# because nas structurally does not run the operators that own them (see the
-# comment on that rule for why each one is excluded). Anything granted on
-# this file that is NOT granted on the homelab file is a bug. This property
+# is intended to be identical to homelab's, and the ONLY permitted divergences
+# are two, both of the same shape — nas structurally does not run the operator
+# that owns the API group, so the group is not granted here, to avoid this
+# identity silently gaining read the moment someone installs that operator:
+#   1. the declared exclusion set on the group-wide "*" rule below —
+#      longhorn.io, tailscale.com, deviceplugin.intel.com, fpga.intel.com (see
+#      the comment on that rule for why each one is excluded);
+#   2. the three KubeVirt rules homelab carries at the end of its file
+#      (kubevirt.io, instancetype.kubevirt.io, migrations.kubevirt.io) are
+#      absent here entirely. infra-virtualization-core is a homelab-only
+#      module and nas has no *.kubevirt.io CRD at all, so there is nothing to
+#      read. If KubeVirt is ever deployed to nas, copy homelab's three rules
+#      and its whole exclusion commentary across verbatim rather than
+#      re-deriving which kinds are safe.
+# Anything granted on this file that is NOT granted on the homelab file is a
+# bug — the subset direction is what matters, an absent rule never is. This property
 # isn't testable (Kyverno can't express a cross-file subset check), so diff
 # the two files directly when reviewing a change to either. Replaces a
 # binding to the stock "view" ClusterRole: "view" excludes all cluster-scoped
@@ -64,7 +74,14 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - controllerrevisions
+  # controllerrevisions deliberately absent, mirroring homelab's copy. The
+  # reason there is KubeVirt-specific (virt-controller stores a whole vm.spec,
+  # cloud-init included, in a ControllerRevision on every VM start) and nas
+  # runs no KubeVirt — but this file's contract is to be rule-for-rule
+  # identical to homelab's apart from the two declared divergences in the
+  # header, and "nas happens to be safe today" is not one of them. See
+  # homelab's copy of this comment for the full reasoning. Trade-off: no read
+  # on StatefulSet/DaemonSet rollout history; no MCP tool depends on it.
   - daemonsets
   - daemonsets/status
   - deployments


### PR DESCRIPTION
## Decision

`kubevirt.io` read **can** be added safely, but only for kinds that cannot reference a volume — which is a much
smaller set than the ticket assumed, and the ticket's preferred option 2 turns out not to work.

**Granted** (`get`/`list`/`watch`), enumerated by kind rather than folded into the group-wide `"*"` rule:

| Group | Kinds | Why safe |
| --- | --- | --- |
| `kubevirt.io` | `kubevirts` | Operator config + component health. No workload spec. This is the kind that answers the question in the ticket (`vmRolloutStrategy`). |
| `kubevirt.io` | `virtualmachineinstancemigrations` | Names a VMI plus a node selector; carries no VMI spec. |
| `kubevirt.io` | `virtualmachineinstancepresets` | `spec.domain` is a `DomainSpec`, which has no `volumes` field — the API server rejects `spec.domain.volumes` outright. |
| `instancetype.kubevirt.io` | all four | Structurally cannot carry cloud-init; a preference's `spec.volumes` is a single string, `preferredStorageClassName`. |
| `migrations.kubevirt.io` | `migrationpolicies` | Tuning knobs and a label selector. |

**Excluded**, with per-kind reasoning recorded in the role file itself rather than here. The deciding field is the
inline `VirtualMachine.spec.template.spec.volumes[].cloudInitNoCloud.userData`:

- `virtualmachines` — holds it directly.
- `virtualmachineinstances` — **option 2 does not work.** virt-controller copies the VM template into `VMI.spec`
  verbatim (`vmi.Spec = *vm.Spec.Template.Spec.DeepCopy()`), inline `userData` included. Granting the
  controller-written VMI instead of the human-written VM is the same plaintext in a different envelope, exactly
  like `ClusterGenerator` vs `Fake`. A `*/status` grant is no help either: `GET <kind>/status` returns the whole
  object.
- `virtualmachineinstancereplicasets`, `pool.kubevirt.io`, `snapshot.kubevirt.io`, `template.kubevirt.io`,
  `clone.kubevirt.io` — wrappers holding a VM spec, or free-form JSON patches against one.
  `VirtualMachineTemplate.spec.virtualMachine` is `x-kubernetes-preserve-unknown-fields` and stores a whole VM.
- `subresources.kubevirt.io` — serves `virtualmachineinstances/console`, `/vnc`, `/portforward` at verb **`get`**
  (KubeVirt derives the RBAC verb from the HTTP method, and those routes are GET), plus
  `virtualmachines/expand-spec` at `get`, which returns the fully expanded VM object and would hand back exactly
  the cloud-init the `virtualmachines` exclusion withholds.
- `subresources.template.kubevirt.io` — a second aggregated subresource group, new in v1.9.0.
- `export.kubevirt.io` — excluded, but not for the reason expected: `spec.tokenSecretRef` and
  `status.tokenSecretRef` are Secret *names*, and the export URLs are token-gated, so a read alone does **not**
  exfiltrate a disk. Excluded because nothing here creates exports, so it costs nothing, and "the token happens
  to be a reference in this version" is an implementation detail rather than a boundary.
- `backup.kubevirt.io`, `plugin.kubevirt.io` — new in v1.9.0, unused, unscrutinised status surface.
- `cdi.kubevirt.io` — not installed.

## The bug this uncovered

While proving the exclusion, the marker leaked anyway — through `apps/controllerrevisions`, which the role
already granted.

virt-controller writes a `ControllerRevision` holding the **entire `vm.spec`** into the VM's namespace on every
VM start. So a VM using inline `userData` puts that plaintext in apiGroup `apps`, with no `kubevirt.io` grant
involved at all. This is live on `homelab` today: the `mcp-kubernetes-readonly` identity can currently read
`talos-vm`'s full spec that way. Nothing sensitive comes back only because both VMs use `secretRef` — the
convention is doing all the work, and RBAC was doing none of it.

`apps/controllerrevisions` is removed from both roles. Cost: no read on StatefulSet/DaemonSet rollout history;
no MCP tool uses it.

## CI guard

Five new CEL rules in `ci/policy-tests/rbac-clusterrole-readonly.yaml` (CEL, not JMESPath — literal `"*"` must
compare as data, not glob):

- `no-apigroup-wildcard` — one `apiGroups: ["*"]` rule would silently re-admit every other exclusion in the file.
- `kubevirt-must-enumerate-kinds` — no resource wildcard on any `*.kubevirt.io` group. Uses `endsWith`, so it
  covers KubeVirt groups that do not exist yet.
- `kubevirt-excluded-groups` / `kubevirt-excluded-kinds` — the console/export groups and the VM-spec-bearing kinds.
- `no-controllerrevisions`.

Mutation-tested: eight fixtures, each violating exactly one rule, each failing exactly that rule; one clean
fixture passing all nine. A rule that only ever passes proves nothing.

## Verification

Full KubeVirt v1.9.0 installed on a disposable single-node cluster; a `VirtualMachine` created with inline
`cloudInitNoCloud.userData` carrying a marker string; the candidate ClusterRole applied verbatim and bound to a
probe ServiceAccount; every read performed as that identity.

Before the `controllerrevisions` fix, the marker came back in full through `apps/controllerrevisions`. After it,
a sweep across **every namespaced kind the identity can list** returns **0** occurrences of the marker, against
**13** for an unrestricted identity on the same objects — so the sweep is not vacuous. `console`, `vnc`,
`portforward` and `expand-spec` are refused both by `auth can-i` and by a real request. The KubeVirt CR
(`vmRolloutStrategy: Stage`), instancetypes and migrationpolicies stay readable, as do the virt-launcher Pod and
the VM's Events — which is what remains for answering "is this VM running, and where".

## Notes for review

- `nas` is unchanged apart from the `controllerrevisions` removal and a header update declaring the KubeVirt
  rules as a second permitted divergence. nas runs no KubeVirt and has no `*.kubevirt.io` CRD, so the
  strict-subset invariant holds.
- Two things worth knowing, neither addressed here: KubeVirt's own `kubevirt.io:default` ClusterRole is bound to
  `system:authenticated`, so `kubevirts` read was already available to every identity on the cluster; and
  `kubevirt.io:view` carries `aggregate-to-view`, so the `oidc-readers` binding already grants `homelab-users`
  read on `virtualmachines` and `virtualmachines/expand-spec`. That exposure is unchanged by this PR.

Closes #824
