### PR TITLE
feat(cluster-homelab): add image-builder namespace and NetworkPolicy

### DIFF
--- a/clusters/homelab/cluster/secrets/bitwarden-secret-store.yaml
+++ b/clusters/homelab/cluster/secrets/bitwarden-secret-store.yaml
@@ -35,6 +35,14 @@ spec:
   # ExternalSecret-create rights in a sandbox namespace, or a paid tier/second project
   # removes the reason a dedicated store isn't used instead.
   #
+  # image-builder is here for its own ExternalSecret (a Harbor robot-account credential,
+  # scoped push-only to the `kubevirt/` project -- see
+  # ppat/homelab-ops-kubernetes-experiments#218). Same acceptance basis as the sandboxes:
+  # only Flux creates ExternalSecrets in this namespace, and this namespace runs nothing
+  # with the ability to author its own -- its only workloads are suspended CronJobs
+  # triggered by `kubectl create job`, not an open-ended compute surface like
+  # sandbox-talos's agent-admin access.
+  #
   # Prune an entry when its consumer goes away, not just add one when a new consumer
   # shows up: `pihole` was removed here because no ExternalSecret uses it (or `dns`,
   # where Pi-hole actually lives) -- dead config surviving a rename. An allowlist that
@@ -51,6 +59,7 @@ spec:
     - flux-system
     - freeradius
     - home-automation
+    - image-builder
     - logging
     - longhorn-system
     - maddy

--- a/clusters/homelab/kustomizations/config-services-image-builder.yaml
+++ b/clusters/homelab/kustomizations/config-services-image-builder.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: config-services-image-builder
+  namespace: flux-system
+spec:
+  dependsOn:
+  - name: infra-security-core
+    namespace: flux-system
+  - name: infra-networking-core
+    namespace: flux-system
+  # Split out of config-services.yaml, same reasoning as config-services-sandbox-talos.yaml/
+  # config-services-sandbox-docker.yaml: a brand-new namespace's own manifests failing to
+  # apply (e.g. before this namespace exists at all, on first merge) must not fail the
+  # shared Kustomization that ai/dns/downloaders/logging/longhorn-system/monitoring/
+  # tailscale also reconcile through. 15m0s, not those two's 1m0s -- neither the "AI agents
+  # have full write access" nor the "fronts a real dockerd" reasoning that justifies their
+  # fast drift-correction interval applies here.
+  interval: 15m0s
+  path: ./clusters/homelab/services/image-builder
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: root
+    namespace: flux-system
+  timeout: 2m0s
+  wait: true

--- a/clusters/homelab/kustomizations/kustomization.yaml
+++ b/clusters/homelab/kustomizations/kustomization.yaml
@@ -24,6 +24,7 @@ resources:
 - apps-misc.yaml
 - config-storage.yaml
 - config-services.yaml
+- config-services-image-builder.yaml
 - config-services-sandbox-docker.yaml
 - config-services-sandbox-talos.yaml
 - policy-pod-security-standards.yaml

--- a/clusters/homelab/services/image-builder/kustomization.yaml
+++ b/clusters/homelab/services/image-builder/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+- network-policy.yaml
+
+commonAnnotations:
+  # This namespace's own isolation is the point of the module -- prevent pruning
+  # unintentionally, same convention as sandbox-talos/sandbox-docker.
+  kustomize.toolkit.fluxcd.io/prune: disabled

--- a/clusters/homelab/services/image-builder/namespace.yaml
+++ b/clusters/homelab/services/image-builder/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: image-builder
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    kustomize.toolkit.fluxcd.io/ssa: merge

--- a/clusters/homelab/services/image-builder/network-policy.yaml
+++ b/clusters/homelab/services/image-builder/network-policy.yaml
@@ -1,0 +1,145 @@
+---
+# This namespace is not a copy-paste of sandbox-talos/sandbox-docker's NetworkPolicy, even
+# though the shapes rhyme (default-deny both directions, DNS carve-out, Harbor-VIP
+# carve-out) -- see ppat/homelab-ops-kubernetes-experiments#218, which asked for exactly
+# that: "write policy that fits this workload," not inherit theirs. What's different, and
+# why:
+#
+# - No ingress-admitting rule exists here at all, for any source. The sandboxes admit
+#   `coder`/`ai` mcp-server pods because something needs to reach a long-lived VM's API
+#   (Kubernetes on :6443, Talos on :50000, SSH on :22). Nothing in this namespace ever
+#   listens on anything -- it runs suspended CronJobs, triggered with `kubectl create
+#   job --from=cronjob/...`, that build an OCI image and exit. A caller needs `create` on
+#   `Job`s (RBAC, not NetworkPolicy) to trigger a build and reads its result from `kubectl
+#   logs`/Harbor, never by connecting to the pod. default-deny's own `Ingress` policyType
+#   with zero admitting rules is therefore the complete, correct ingress posture -- not a
+#   placeholder waiting for a rule to be added later.
+# - No allow-same-namespace-egress rule either, for the same reason in reverse: the
+#   sandboxes need it so a VM's virt-launcher pod can reach a Service also living in that
+#   namespace. Every pod here is a short-lived, one-shot build -- there is currently only
+#   ever one build pod running at a time (concurrencyPolicy: Forbid on every CronJob in
+#   this namespace) and it has no peer in-namespace to talk to.
+# - Egress scope is narrower in *kind*, not just in what's carved out of the RFC1918
+#   `except`: this namespace's whole reason to exist (ppat/homelab-ops-kubernetes-
+#   experiments#218) is that a build pod needs zero KubeVirt/VM reachability, zero SSH
+#   key, zero host API access -- so unlike the sandboxes there is no "why not admit
+#   `kubevirt` here" discussion to have; nothing in this design ever considered it.
+#
+# CAVEAT, same mechanism as both sandbox copies of this note, repeated because it applies
+# here too and every NetworkPolicy in this repo restates it locally rather than assuming
+# a reader has the other copy open: k3s's bundled kube-router-derived NetworkPolicy
+# controller programs a pod's firewall chain and its KUBE-ROUTER-FORWARD dispatch rule
+# *reactively*, watching the API server for new pods. A pod with no dispatch rule yet
+# falls straight through to `-P FORWARD ACCEPT`, fully unpoliced -- for a short-lived pod
+# (which is the *only* kind of pod this namespace ever runs) that window can span the
+# pod's entire lifetime. This isn't a bug in the policy below; it's a property of how
+# quickly kube-router picks up a brand-new pod. See sandbox-docker/network-policy.yaml
+# (clusters repo) for how this was discovered and OPERATIONS.md for how to verify a given
+# pod is actually policed.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: image-builder
+  annotations:
+    homelab-ops.internal/netpol-caveat: >-
+      CAVEAT: a freshly created pod is unpoliced for a short window (k3s's kube-router
+      netpol controller programs firewall rules reactively) -- every pod this namespace
+      ever runs is short-lived, so that window can span a build's entire lifetime. Full
+      explanation and how to verify a given pod is actually policed: sandbox-docker's
+      OPERATIONS.md (clusters repo), "Known limitation: the per-pod NetworkPolicy
+      enforcement window".
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+# DNS is the only path out that isn't the allow-list below. CoreDNS lives in kube-system,
+# which carries no NetworkPolicies of its own -- this is the only place the boundary is
+# enforced. podSelector-scoped, not the kube-dns ClusterIP, so this rule doesn't land
+# inside the 10.0.0.0/8 `except` carved out below (same reasoning as both sandbox copies).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: image-builder
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+---
+# Open internet egress, needed for: the Talos Image Factory (factory.talos.dev, resolving
+# a version and downloading the boot asset), and whatever hosts a build's tool-install step
+# pulls from (github.com releases, mise's own installer/registry). Same `except` list as
+# every other NetworkPolicy in this repo that opens internet egress: closes the prod
+# kube-apiserver, Longhorn's manager API, kubelet, etcd, the UniFi gateway, and the NAS in
+# one object -- RFC1918 plus link-local and loopback. Do not narrow this to a smaller CIDR
+# or drop a block to "simplify" it; see sandbox-docker/network-policy.yaml (clusters repo)
+# for the full reasoning, identical here.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-internet
+  namespace: image-builder
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+        - 169.254.0.0/16
+        - 127.0.0.0/8
+---
+# Punch-through for Harbor push, same VIP range and same DNAT-vs-NetworkPolicy mechanics
+# as both sandbox copies of this rule (see sandbox-docker/network-policy.yaml, clusters
+# repo, for the full "why only nas, not homelab" derivation -- not repeated here). Only
+# nas's MetalLB `standard-pool`, 192.168.8.192/28, is reachable -- homelab's own VIP range
+# is not, because a pod's packet to it gets DNAT'd to a Traefik pod IP (10.42.x.x) before
+# NetworkPolicy ever evaluates it, landing it inside allow-egress-internet's own
+# 10.0.0.0/8 `except` above.
+#
+# The one thing worth restating rather than just cross-referencing: for this namespace,
+# reaching nas's ingress VIP also L3-exposes nas's own prod Kubernetes API (routed off the
+# identical VIP, per #828) the same way it does for the sandboxes -- but unlike
+# sandbox-talos, nothing in this namespace ever holds a credential that ingress would
+# accept (no kubeconfig, no token, no ambient identity beyond the Harbor robot credential
+# scoped to push-only on one project). The reachability is the same; what it's worth to an
+# attacker who gets a pod running here is not.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-lb-ingress-vips
+  namespace: image-builder
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 192.168.8.192/28
+    ports:
+    - protocol: TCP
+      port: 80
+    - protocol: TCP
+      port: 443


### PR DESCRIPTION
## Summary

Companion to [ppat/homelab-ops-kubernetes-experiments#218](https://github.com/ppat/homelab-ops-kubernetes-experiments/issues/218) (the containerDisk build pipeline PR). Ships the `image-builder` `Namespace` and `NetworkPolicy` this cluster needs before that pipeline's `CronJob`/`ConfigMap`/`ExternalSecret` resources can apply — following the same convention `sandbox-talos`/`sandbox-docker` already established: this repo owns and ships a service namespace's `Namespace`/`NetworkPolicy`, the apps-experiments repo never creates one for a namespace it doesn't own.

- **`clusters/homelab/services/image-builder/namespace.yaml`** — the namespace, `prune: disabled` (same convention as the two sandbox namespaces).
- **`clusters/homelab/services/image-builder/network-policy.yaml`** — default-deny both directions, then narrow, workload-specific carve-outs: DNS, general internet egress (Talos Image Factory, mise/crane's install/release hosts), and Harbor's push VIP (`192.168.8.192/28`, ports 80/443). **Deliberately not a copy of the sandbox NetworkPolicy** — no ingress-admitting rule exists at all (nothing in this namespace ever listens on anything; it only runs suspended, on-demand build `CronJob`s) and no same-namespace egress rule either (no in-namespace peer a build pod ever needs to reach). See the file's own comments for the full reasoning against both sandbox copies.
- **`clusters/homelab/kustomizations/config-services-image-builder.yaml`** — a dedicated Flux `Kustomization` (same split-out pattern as `config-services-sandbox-talos.yaml`/`config-services-sandbox-docker.yaml`), so a first-merge failure in a brand-new namespace can't take down `config-services.yaml`'s other consumers (`ai`, `dns`, `downloaders`, `logging`, `longhorn-system`, `monitoring`, `tailscale`).
- **`clusters/homelab/cluster/secrets/bitwarden-secret-store.yaml`** — adds `image-builder` to the shared Bitwarden store's namespace allowlist, for that pipeline's own Harbor robot-account `ExternalSecret`.

## Why this has to merge before the companion apps-experiments PR

The apps-experiments PR's `CronJob`/`ConfigMap`/`ExternalSecret` all target the `image-builder` namespace. That repo's own root Flux `Kustomization` (`apps-experiments`, `wait: true`, `prune: true`) builds and applies **all** of `experiments/` as one manifest — if the namespace doesn't exist yet, applying those new resources fails with a "namespace not found" error that fails the *entire* Kustomization, not just the new resources, which would also block reconciliation of every other already-deployed experiment (`blocky`, `downloaders`, `homepage`, `docker-host`, `sandbox-talos`) until fixed. **Merge and let this reconcile first.**

## Test plan

- [x] `kustomize build clusters/homelab/services/image-builder` — clean.
- [x] `kustomize build clusters/homelab/kustomizations` — clean, `config-services-image-builder` Kustomization present and correctly wired.
- [x] `yamllint --strict` on all new/changed files — clean.
- [x] `pre-commit run` (yamllint, markdownlint, Validate Kubernetes manifests) on all new/changed files — clean.
- [ ] Operator: merge, confirm `config-services-image-builder` Kustomization reconciles `Ready` before merging the companion apps-experiments PR.