### PR TITLE
feat(cluster-nas): front Harbor with a docker.io mirror ingress

### DIFF
--- a/clusters/nas/README.md
+++ b/clusters/nas/README.md
@@ -39,10 +39,14 @@ sources from `root`, not a module `GitRepository`):
 | Directory | Purpose |
 | --- | --- |
 | `outpost/` | Deploys a remote Authentik outpost, with the routing/ingress to reach it, so this cluster's Ingress can authenticate against the Authentik instance running on `homelab` without running Authentik itself here |
+| `harbor-dockerio-mirror/` | An `Ingress` + rewrite `Middleware` pair fronting `harbor-core` on its own hostname (`dockerio-harbor.${domain_name}`), rewriting `/v2/<repo>/...` to `/v2/docker.io/<repo>/...` so Docker Hub pulls from any Docker client on the network land in Harbor's `docker.io` proxy-cache project. Exists because Docker's `registry-mirrors` has no equivalent of containerd's `overridePath`, so it can only work against a registry that accepts unprefixed `/v2/...` paths — see `apps-harbor-dockerio-mirror`'s `Kustomization` and ppat/homelab-ops-kubernetes-experiments#226 |
 
 This exists because SSO (`components/sso`) is used across both clusters, but
 Authentik itself (`security-extra`) only runs on `homelab` — the outpost lets
-`nas`'s apps (Harbor, Bitwarden) participate in the same SSO domain.
+`nas`'s apps (Harbor, Bitwarden) participate in the same SSO domain. The
+`docker.io` mirror ingress exists for the unrelated reason above, and is
+listed here purely because it shares the same "content authored directly in
+this repo, sourced from `root`" shape as `outpost/`.
 
 ## Module dependency graph
 
@@ -51,6 +55,7 @@ flowchart TB
     classDef core fill:#dcfce7,stroke:#059669,color:#064e3b
     classDef apps fill:#93c5fd,stroke:#2563eb,color:#1e3a8a
     classDef outpost fill:#fde68a,stroke:#d97706,color:#92400e
+    classDef mirror fill:#fecaca,stroke:#dc2626,color:#7f1d1d
 
     subgraph Core["Infrastructure (Core)"]
         sec[security-core]:::core
@@ -68,11 +73,13 @@ flowchart TB
     end
 
     out[Authentik outpost]:::outpost
+    dio[docker.io mirror ingress]:::mirror
 
     net --> sec & nfs
     minio --> nfs
     db --> net & nfs
     out --> sec & net
+    dio --> net & harbor
 
     Core --> Apps
 ```

--- a/clusters/nas/harbor-dockerio-mirror/ingress-dockerio-harbor.yaml
+++ b/clusters/nas/harbor-dockerio-mirror/ingress-dockerio-harbor.yaml
@@ -1,0 +1,40 @@
+---
+# A plain networking.k8s.io Ingress, not a Traefik IngressRoute: this cluster's
+# external-dns only watches `sources: [ingress, service]` (apps repo,
+# infrastructure/subsystems/networking-core/external-dns/helm-release-external-dns.yaml)
+# -- an IngressRoute would get no DNS record at all. Every other hostname on
+# this cluster (harbor.${domain_name}, whoami.${domain_name}, the Authentik
+# outpost) already follows this same plain-Ingress-plus-Traefik-annotations
+# shape for the same reason; this stays consistent with it rather than
+# introducing IngressRoute as a one-off.
+#
+# Routes directly to harbor-core (the same internal Service Harbor's own
+# Ingress targets), not back out through Harbor's own external hostname --
+# there is no need to leave the cluster to reach it, and doing so would need a
+# second round of TLS plus a real risk of routing back through this same
+# Ingress if the hostnames were ever confused.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dockerio-harbor
+  namespace: harbor
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: dockerio-harbor.${domain_name}
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.middlewares: harbor-dockerio-rewrite@kubernetescrd,harbor-dockerio-host@kubernetescrd
+spec:
+  # empty tls, so that the default (wildcard *.${domain_name}) certificate is
+  # assigned -- same convention as whoami-ingress.yaml/harbor's own ingress.
+  tls: []
+  rules:
+  - host: dockerio-harbor.${domain_name}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: harbor-core
+            port:
+              number: 80

--- a/clusters/nas/harbor-dockerio-mirror/kustomization.yaml
+++ b/clusters/nas/harbor-dockerio-mirror/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- middleware-dockerio-rewrite.yaml
+- middleware-dockerio-host.yaml
+- ingress-dockerio-harbor.yaml

--- a/clusters/nas/harbor-dockerio-mirror/middleware-dockerio-host.yaml
+++ b/clusters/nas/harbor-dockerio-mirror/middleware-dockerio-host.yaml
@@ -1,0 +1,26 @@
+---
+# Overrides the outgoing Host header to Harbor's own canonical hostname before
+# the request reaches harbor-core, rather than leaving it as this mirror's own
+# hostname (dockerio-harbor.${domain_name}). This is deliberate, not
+# incidental: Harbor's token-auth challenge (`Www-Authenticate: Bearer
+# realm=...`) and any Location/redirect it constructs are built from its
+# configured `externalURL` (apps repo, apps/subsystems/harbor/helm-release-harbor.yaml),
+# and the prototype this module ships was validated with the Host header
+# explicitly pinned to Harbor's real hostname for exactly that reason -- an
+# unpinned Host was never tested and is not assumed to behave the same.
+#
+# `customRequestHeaders` special-cases the "Host" key (traefik/traefik,
+# pkg/middlewares/headers/header.go, modifyCustomRequestHeaders: `case
+# strings.EqualFold(header, "Host"): req.Host = value`) -- it sets the actual
+# outgoing request's Host, not just an entry in the header map, which is what
+# makes this reliable rather than a no-op some Traefik versions have been
+# reported to silently ignore.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: dockerio-host
+  namespace: harbor
+spec:
+  headers:
+    customRequestHeaders:
+      Host: harbor.${domain_name}

--- a/clusters/nas/harbor-dockerio-mirror/middleware-dockerio-rewrite.yaml
+++ b/clusters/nas/harbor-dockerio-mirror/middleware-dockerio-rewrite.yaml
@@ -1,0 +1,26 @@
+---
+# Rewrites Docker's registry-mirror requests into Harbor's proxy-cache path
+# convention. Docker's `registry-mirrors` daemon.json option has no equivalent
+# of containerd's `overridePath` (see this module's README), so there is no
+# mirror URL that makes dockerd itself request `/v2/docker.io/...` -- this
+# Middleware is what makes up the difference, on Harbor's behalf, for a
+# hostname dedicated to this one proxy-cache project.
+#
+# The bare `/v2/` version-check ping (Docker's initial probe, and the path the
+# 401 challenge/token flow round-trips through) is deliberately excluded from
+# the rewrite: `(.+)` requires at least one character after `/v2/`, so `/v2/`
+# alone never matches this regex and passes through unprefixed. Rewriting it
+# too -- tried and measured against the real Harbor first -- sends
+# `GET /v2/docker.io/`, which is not a Harbor endpoint: Harbor answers `401`
+# with an *empty* `Www-Authenticate` header ("un-recognized request"), Docker's
+# probe gets no realm to authenticate against, and the mirror looks dead even
+# though Harbor itself is healthy. See ppat/homelab-ops-kubernetes-experiments#226.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: dockerio-rewrite
+  namespace: harbor
+spec:
+  replacePathRegex:
+    regex: ^/v2/(.+)$
+    replacement: /v2/docker.io/$1

--- a/clusters/nas/kustomizations/apps-harbor-dockerio-mirror.yaml
+++ b/clusters/nas/kustomizations/apps-harbor-dockerio-mirror.yaml
@@ -1,0 +1,29 @@
+---
+# Content authored directly in this repo, sourced from `root` rather than a
+# module GitRepository -- same shape as infra-security-outpost.yaml, and for
+# the same reason: this is cluster-local wiring (an Ingress/Middleware pair),
+# not a versioned module from the apps repo.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps-harbor-dockerio-mirror
+  namespace: flux-system
+spec:
+  dependsOn:
+  - name: apps-harbor
+    namespace: flux-system
+  - name: infra-networking-core
+    namespace: flux-system
+  interval: 15m0s
+  path: ./clusters/nas/harbor-dockerio-mirror
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: root
+    namespace: flux-system
+  timeout: 2m0s
+  wait: true
+  postBuild:
+    substituteFrom:
+    - kind: Secret
+      name: cluster-secrets

--- a/clusters/nas/kustomizations/kustomization.yaml
+++ b/clusters/nas/kustomizations/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - apps-bitwarden.yaml
 - infra-database-core.yaml
 - apps-harbor.yaml
+- apps-harbor-dockerio-mirror.yaml
 - config-storage.yaml
 - policy-baseline-pss.yaml
 - policy-best-practices.yaml


### PR DESCRIPTION
## Summary

Docker's `registry-mirrors` has no equivalent of containerd's `overridePath`, so it can never produce the `/v2/<project>/<repo>/...` path shape Harbor's registry API requires — measured against the real Harbor (both plausible URL shapes fail: one doubles `/v2/` and silently falls back to upstream with exit 0, the other 200s an HTML catch-all that corrupts the pull). Full investigation: ppat/homelab-ops-kubernetes-experiments#226.

This adds an `Ingress` + rewrite `Middleware` pair, on its own hostname (`dockerio-harbor.${domain_name}`), that inserts the `docker.io` project segment on Harbor's behalf — so any Docker client's `registry-mirrors` (which can only ever express a plain origin, no path) still lands in Harbor's `docker.io` proxy-cache project. `docker-vm`'s `daemon.json` is the first consumer (companion PR, below), but this benefits any Docker client on the network.

New files, under `clusters/nas/harbor-dockerio-mirror/` (content authored directly in this repo and sourced from `root`, same shape as `outpost/` — not a versioned module from the apps repo):
- `ingress-dockerio-harbor.yaml` — a plain `networking.k8s.io/v1 Ingress` in the `harbor` namespace, routing directly to the internal `harbor-core` Service (port 80), with `traefik.ingress.kubernetes.io/router.middlewares` wiring in both Middlewares below.
- `middleware-dockerio-rewrite.yaml` — `ReplacePathRegex`, `^/v2/(.+)$` → `/v2/docker.io/$1`.
- `middleware-dockerio-host.yaml` — overrides the outgoing `Host` header to Harbor's own hostname before the request reaches `harbor-core`, matching how the validated prototype was actually run.
- `apps-harbor-dockerio-mirror.yaml` (in `kustomizations/`) — the Flux `Kustomization` wiring it in, `dependsOn: [apps-harbor, infra-networking-core]`.

## Decisions made, and how they were checked (not assumed)

- **Which cluster**: `nas`. Harbor's `Ingress`/`HelmRelease` only exist under `clusters/nas/` — confirmed by `find`, not assumed from the MetalLB-pool hint in the ticket.
- **Ingress kind — plain `Ingress`, not `IngressRoute`**: this cluster's `external-dns` is configured `sources: [ingress, service]` only (apps repo, `infrastructure/subsystems/networking-core/external-dns/helm-release-external-dns.yaml`) — an `IngressRoute` would get no DNS record at all. Every existing hostname on this cluster (`harbor.${domain_name}`, `whoami.${domain_name}`, the Authentik outpost) already uses this same plain-Ingress-plus-Traefik-annotations shape, for the same reason. This departs from the ticket's literal "IngressRoute" wording — the ticket itself asked me to determine the DNS mechanism and follow repo convention, so I did.
- **TLS**: no new certificate needed. The cluster's default TLS store (`traefik/certificate-default.yaml`) is a wildcard `*.${domain_name}` cert; `dockerio-harbor.${domain_name}` is a single label under it, same as every other hostname here (`tls: []` picks up the default cert, same convention as `whoami-ingress.yaml`).
- **DNS**: `external-dns.alpha.kubernetes.io/hostname` annotation on the `Ingress`, same as Harbor's own.
- **The bare `/v2/` special case**: `^/v2/(.+)$` requires at least one character after `/v2/`, so the exact path `/v2/` (Docker's version-check ping, and the path the token-challenge round-trips through) never matches and passes through unprefixed. Tested the regex in isolation against every path shape Docker's registry-mirror flow actually emits (bare `/v2/` and `/v2`, manifest-by-tag, manifest-by-digest, blobs, blob-upload-init, namespaced repos, tags list, referrers) — all behave as intended.
- **Host-header override**: verified against Traefik's own source (`pkg/middlewares/headers/header.go`, `modifyCustomRequestHeaders`) that `customRequestHeaders: {Host: ...}` sets `req.Host` directly (`case strings.EqualFold(header, "Host"): req.Host = value`), not just a header-map entry — some older reports online claim this doesn't work, so this was checked against the actual source rather than trusted secondhand.

## Verification

- `kustomize build clusters/nas/harbor-dockerio-mirror` renders correctly.
- `kustomize build clusters/nas/kustomizations` includes the new `Kustomization`.
- Rendered with `envsubst` against `ci/validation/.env`'s dummy `domain_name` — `${domain_name}` resolves correctly in every annotation/host/header.
- `yamllint --strict`, `markdownlint-cli2`, and the full `pre-commit` suite — including kubeconform manifest validation (`Validate Kubernetes manifests`) — all pass.
- **Not verified — remains unproven until deploy**: the actual request flow through a live Traefik/Harbor (no cluster write access here). The rewriting-proxy *shape* this ports was validated end-to-end against the real Harbor in the linked issue (two cold pulls landed in Harbor's `docker.io` proxy-cache project, Trivy-scanned, confirmed via Harbor's own API) — but that was an nginx prototype running externally on the VM, not this exact Traefik `Ingress`+`Middleware` pair talking to `harbor-core` internally. The Host-header override in particular is architecturally sound and traced through Traefik's own source, but was never exercised against a running Harbor.

## Merge order

**Companion PR**: ppat/homelab-ops-kubernetes-experiments#232 (`docker-vm`'s `daemon.json`). **This PR should merge first** — the experiments PR points `docker-vm` at this hostname, and while Docker's own `registry-mirrors` degrades gracefully to a direct, uncached pull if the mirror is unreachable (not a hard failure), the whole point of that PR doesn't take effect until this Ingress exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)