### PR TITLE
feat(cluster-homelab): add sandbox-lifecycle namespace, RBAC, and a Delete-reclaim StorageClass

### DIFF
--- a/clusters/homelab/kustomizations/config-services-sandbox-lifecycle.yaml
+++ b/clusters/homelab/kustomizations/config-services-sandbox-lifecycle.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: config-services-sandbox-lifecycle
+  namespace: flux-system
+spec:
+  dependsOn:
+  - name: infra-security-core
+    namespace: flux-system
+  - name: infra-networking-core
+    namespace: flux-system
+  # The Roles this module ships live in sandbox-docker/sandbox-talos (see
+  # role-sandbox-docker.yaml, role-sandbox-talos.yaml -- a Role is only valid once its
+  # namespace exists), so those two namespaces' own Kustomizations are hard prerequisites,
+  # not just something that happens to converge first.
+  - name: config-services-sandbox-docker
+    namespace: flux-system
+  - name: config-services-sandbox-talos
+    namespace: flux-system
+  # Short interval, split out of config-services.yaml's 15m0s on purpose, same reasoning as
+  # sandbox-docker/sandbox-talos's own Kustomizations: this module IS an isolation/RBAC
+  # boundary (the ServiceAccount and Roles that let the weekly rebuild CronJobs reach this
+  # host cluster's API), so drift correction needs to converge fast.
+  interval: 1m0s
+  path: ./clusters/homelab/services/sandbox-lifecycle
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: root
+    namespace: flux-system
+  timeout: 2m0s
+  wait: true

--- a/clusters/homelab/kustomizations/kustomization.yaml
+++ b/clusters/homelab/kustomizations/kustomization.yaml
@@ -26,5 +26,6 @@ resources:
 - config-services.yaml
 - config-services-sandbox-docker.yaml
 - config-services-sandbox-talos.yaml
+- config-services-sandbox-lifecycle.yaml
 - policy-pod-security-standards.yaml
 - policy-best-practices.yaml

--- a/clusters/homelab/services/sandbox-lifecycle/kustomization.yaml
+++ b/clusters/homelab/services/sandbox-lifecycle/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+- network-policy.yaml
+- serviceaccount.yaml
+- role-sandbox-docker.yaml
+- role-sandbox-talos.yaml
+
+commonAnnotations:
+  # This namespace's isolation (default-deny, one enumerated egress target) and the RBAC
+  # boundary it exists to hold are the point of the module -- prevent pruning
+  # unintentionally, same convention as sandbox-docker/sandbox-talos.
+  kustomize.toolkit.fluxcd.io/prune: disabled

--- a/clusters/homelab/services/sandbox-lifecycle/namespace.yaml
+++ b/clusters/homelab/services/sandbox-lifecycle/namespace.yaml
@@ -1,0 +1,19 @@
+---
+# Holds the vm-rebuilder ServiceAccount that the weekly sandbox destroy-and-rebuild
+# CronJobs (homelab-ops-kubernetes-experiments, experiments/apps/sandbox-lifecycle/) run
+# as. Deliberately its own namespace, not sandbox-docker or sandbox-talos: those two run
+# default-deny egress with the host cluster's own API server inside the `except` list (see
+# their network-policy.yaml), so a pod there physically cannot delete anything on this
+# cluster -- and must not be able to, since both are namespaces AI agents can create pods
+# in. A host-API-capable ServiceAccount can only safely live somewhere agents cannot write
+# to. See network-policy.yaml in this directory for the egress this namespace is granted
+# instead.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sandbox-lifecycle
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    kustomize.toolkit.fluxcd.io/ssa: merge
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/clusters/homelab/services/sandbox-lifecycle/network-policy.yaml
+++ b/clusters/homelab/services/sandbox-lifecycle/network-policy.yaml
@@ -1,0 +1,87 @@
+---
+# Default-deny both directions. Nothing needs to reach a pod in this namespace (no ingress
+# rule exists below at all), and everything a rebuild pod needs outbound is enumerated by
+# name below -- CoreDNS and this host cluster's own API server, nothing else. Unlike
+# sandbox-docker/sandbox-talos, this namespace does NOT get a broad internet-egress allow:
+# the CronJobs here run the official registry.k8s.io/kubectl image (see this module's own
+# README and homelab-ops-kubernetes-experiments' sandbox-lifecycle module), so they need no
+# internet access at all -- image *pulls* are performed by the kubelet and are unaffected
+# by NetworkPolicy, so this stays tight without breaking anything.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: sandbox-lifecycle
+  # Kubernetes strips YAML comments before persisting to etcd -- this annotation is the
+  # discoverable-on-the-live-object half of the CAVEAT below; see
+  # sandbox-talos/network-policy.yaml for the original wording and the full mechanism this
+  # is a shortened copy of. `homelab-ops.internal/*` is this platform's established
+  # self-defined-key prefix.
+  annotations:
+    homelab-ops.internal/netpol-caveat: >-
+      CAVEAT: k3s's kube-router netpol controller programs a pod's firewall rules
+      reactively, after the pod exists, so a very short-lived pod can complete before
+      enforcement is programmed. It matters less here than in sandbox-docker/sandbox-talos
+      -- this namespace's pods are *supposed* to reach the host API server, and hold no
+      credential an unenforced window would expose that RBAC doesn't already grant --
+      but the property is real and is recorded here for the same reason it is there. Full
+      explanation: sandbox-talos/network-policy.yaml and OPERATIONS.md, "Known limitation:
+      the per-pod NetworkPolicy enforcement window".
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+# Same shape and reasoning as sandbox-docker/sandbox-talos's own copy: CoreDNS has no
+# NetworkPolicies of its own, so this podSelector-based rule is the only place DNS egress
+# is enforced here, and it has to be podSelector-based (not the kube-dns ClusterIP) to
+# avoid landing inside the RFC1918 range that other sandbox namespaces except -- not
+# relevant to the rule below since this namespace's egress is enumerated by allow-list
+# rather than a broad allow-with-except, but kept identical in shape for consistency.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: sandbox-lifecycle
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+---
+# The one thing this whole namespace exists to be able to reach: the host cluster's own
+# in-cluster API server ClusterIP, which sandbox-docker/sandbox-talos deliberately cannot
+# reach (it sits inside their egress `except` list -- see this repo's network-policy.yaml
+# files there, and the live falsifiability probe that asserts it stays BLOCKED on every
+# cycle). /32, not a broader range: 10.43.0.1 is this cluster's fixed kube-apiserver
+# ClusterIP (the default Service CIDR's first address), and nothing else in that range is
+# ever a legitimate destination for these CronJobs.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-kube-apiserver
+  namespace: sandbox-lifecycle
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 10.43.0.1/32
+    ports:
+    - protocol: TCP
+      port: 443

--- a/clusters/homelab/services/sandbox-lifecycle/network-policy.yaml
+++ b/clusters/homelab/services/sandbox-lifecycle/network-policy.yaml
@@ -1,8 +1,9 @@
 ---
 # Default-deny both directions. Nothing needs to reach a pod in this namespace (no ingress
-# rule exists below at all), and everything a rebuild pod needs outbound is enumerated by
-# name below -- CoreDNS and this host cluster's own API server, nothing else. Unlike
-# sandbox-docker/sandbox-talos, this namespace does NOT get a broad internet-egress allow:
+# rule exists below at all), and everything a rebuild/relay pod needs outbound is
+# enumerated by name below -- CoreDNS, this host cluster's own API server, and the
+# sandbox-talos VM (Kubernetes + Talos APIs), nothing else. Unlike sandbox-docker/
+# sandbox-talos, this namespace does NOT get a broad internet-egress allow:
 # the CronJobs here run the official registry.k8s.io/kubectl image (see this module's own
 # README and homelab-ops-kubernetes-experiments' sandbox-lifecycle module), so they need no
 # internet access at all -- image *pulls* are performed by the kubelet and are unaffected
@@ -63,12 +64,33 @@ spec:
       port: 53
 ---
 # The one thing this whole namespace exists to be able to reach: the host cluster's own
-# in-cluster API server ClusterIP, which sandbox-docker/sandbox-talos deliberately cannot
-# reach (it sits inside their egress `except` list -- see this repo's network-policy.yaml
-# files there, and the live falsifiability probe that asserts it stays BLOCKED on every
-# cycle). /32, not a broader range: 10.43.0.1 is this cluster's fixed kube-apiserver
-# ClusterIP (the default Service CIDR's first address), and nothing else in that range is
-# ever a legitimate destination for these CronJobs.
+# in-cluster API server, which sandbox-docker/sandbox-talos deliberately cannot reach (it
+# sits inside their egress `except` list -- see this repo's network-policy.yaml files
+# there, and the live falsifiability probe that asserts it stays BLOCKED on every cycle).
+#
+# NOT an ipBlock on the 10.43.0.1 ClusterIP -- that was tried first and does not work, for
+# the same DNAT-vs-NetworkPolicy reason documented in allow-dns-egress above and at length
+# in sandbox-talos/network-policy.yaml's allow-egress-lb-ingress-vips comment: k3s's
+# embedded kube-proxy DNATs a ClusterIP to a real backend in the `nat` table's
+# PREROUTING/OUTPUT chains, which runs before kube-router's FORWARD-chain NetworkPolicy
+# enforcement ever sees the packet -- so the destination NetworkPolicy evaluates is the
+# post-DNAT backend, never the ClusterIP a pod dials. k3s runs the API server as a host
+# process, not a pod, so the fix here can't be a podSelector either (unlike
+# allow-egress-lb-ingress-vips' Traefik fix) -- it has to name the backends directly.
+# Confirmed for this Service specifically, not just inferred from the other two writeups:
+# `Endpoints/kubernetes` in `default` resolves to the four node IPs below on port 6443,
+# not 10.43.0.1:443. /32 per node, not a range: these are this cluster's fixed control
+# -plane node IPs (already hardcoded as DENY targets in
+# sandbox-docker/sandbox-talos's own netpol-falsifiability-probe Deployments, NODE_IPS env
+# var), and nothing else in 192.168.8.0/24 is ever a legitimate destination for these
+# CronJobs.
+#
+# DEBUGGING HINT: this cluster's kube-router controller REJECTs a denied packet instead of
+# DROPping it, so if this rule is ever wrong again (wrong IP, wrong port, selector typo),
+# the CronJob's symptom is `connection refused` against a perfectly healthy API server --
+# indistinguishable at the TCP level from a closed port, and nothing about that symptom
+# points at a NetworkPolicy. If vm-rebuilder ever gets connection-refused against the host
+# API, check this rule before assuming the API server itself is down.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -81,7 +103,60 @@ spec:
   egress:
   - to:
     - ipBlock:
-        cidr: 10.43.0.1/32
+        cidr: 192.168.8.65/32
+    - ipBlock:
+        cidr: 192.168.8.67/32
+    - ipBlock:
+        cidr: 192.168.8.68/32
+    - ipBlock:
+        cidr: 192.168.8.69/32
     ports:
     - protocol: TCP
-      port: 443
+      port: 6443
+---
+# Lets the provision-agent-admin credential-relay CronJob
+# (homelab-ops-kubernetes-experiments#230, this repo's companion PR #845) reach the Talos
+# sandbox VM directly: talos-vm's own Kubernetes API (6443, to authenticate the freshly
+# minted agent-admin kubeconfig before pushing it to Bitwarden) and its Talos API (50000,
+# to pull sandbox_talos_vm_talosconfig and drive the bootstrap). #845 adds the matching
+# ingress peer in sandbox-talos/network-policy.yaml's allow-coder-and-mcp-ingress -- read
+# that PR before changing either side, so labels and ports stay in agreement.
+#
+# namespaceSelector + podSelector on the VM's own pod label
+# (app.kubernetes.io/name: talos-vm), deliberately NOT an ipBlock on talos-vm's Service
+# ClusterIP -- same post-DNAT reason as allow-egress-kube-apiserver above: kube-proxy DNATs
+# the ClusterIP to the virt-launcher pod's IP before kube-router's NetworkPolicy
+# enforcement ever evaluates the packet, so an ipBlock naming the ClusterIP would silently
+# never match, exactly like allow-egress-lb-ingress-vips' original homelab-VIP mistake in
+# sandbox-talos/network-policy.yaml. A pod IP is not a Service backed by a host process
+# here (unlike the kube-apiserver case above), so podSelector is available and is the
+# correct fix, not a node-IP ipBlock.
+#
+# DEBUGGING HINT: this cluster's kube-router controller REJECTs a denied packet instead of
+# DROPping it, so a labeling/namespace mismatch here (or on #845's ingress half) surfaces
+# as `connection refused` against a healthy, reachable VM -- not as anything that points at
+# a NetworkPolicy. If the relay CronJob fails with connection-refused against talos-vm,
+# check that this rule's selectors still match #845's ingress peer before assuming the VM
+# itself is unreachable or down.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-sandbox-talos-vm
+  namespace: sandbox-lifecycle
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: sandbox-talos
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: talos-vm
+    ports:
+    - protocol: TCP
+      port: 6443
+    - protocol: TCP
+      port: 50000

--- a/clusters/homelab/services/sandbox-lifecycle/role-sandbox-docker.yaml
+++ b/clusters/homelab/services/sandbox-lifecycle/role-sandbox-docker.yaml
@@ -1,0 +1,78 @@
+---
+# Grants vm-rebuilder (sandbox-lifecycle namespace -- see serviceaccount.yaml and the
+# RoleBinding below) exactly what its weekly destroy-and-rebuild cycle for docker-vm needs
+# to do, in sandbox-docker, and nothing else. Written from the threat model, not copied:
+# this is the first RBAC of any kind for this namespace, and it is deliberately narrower
+# than "the obvious KubeVirt admin role" in three ways worth stating up front.
+#
+# - `delete` targets the VirtualMachine, never the VirtualMachineInstance: deleting the VM
+#   is what cascades to the VMI and its virt-launcher pod via ownerReferences, so no
+#   `virtualmachineinstances` verb and no `pods: delete` verb need to exist here at all.
+#   Deleting only the VMI would be actively wrong -- docker-vm's runStrategy is Always, so
+#   KubeVirt would just recreate the VMI within seconds against the same PVC.
+# - Every delete/get is `resourceNames`-scoped to the one named VM and the one named PVC.
+#   This SA can never touch pyload-data, radarr-x-data, or any other object in this
+#   namespace or cluster -- compromise of this SA yields exactly "delete docker-vm and its
+#   storage," nothing broader.
+# - No `secrets`, `pods/exec`, `pods/ephemeralcontainers`, `subresources.kubevirt.io/*`
+#   (no start/stop/restart/console needed), or anything cluster-scoped (including
+#   `persistentvolumes` -- the Delete-reclaim StorageClass, not a PV patch, is what closes
+#   the reclaim-policy leak; see sc-longhorn-local-non-replicated-ephemeral.yaml).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vm-rebuilder
+  namespace: sandbox-docker
+rules:
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines
+  resourceNames:
+  - docker-vm
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  resourceNames:
+  - docker-vm-storage
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  # Cannot be resourceNames-scoped: the virt-launcher pod's name is generated
+  # (virt-launcher-docker-vm-<suffix>) and has to be discovered by label to read its
+  # console log below. The one unavoidably broad verb this Role grants, and it is
+  # read-only, in one namespace, against pods this SA cannot delete or exec into.
+  - list
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  # Reads the guest-console-log sidecar (virt-tail) -- the provisioning-verdict sentinels
+  # cloud-init-secret.yaml writes to /dev/console. That console output carries the SSH
+  # host key's *public* fingerprint and authorized_keys entries, never private material.
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vm-rebuilder
+  namespace: sandbox-docker
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: vm-rebuilder
+subjects:
+- kind: ServiceAccount
+  name: vm-rebuilder
+  namespace: sandbox-lifecycle

--- a/clusters/homelab/services/sandbox-lifecycle/role-sandbox-talos.yaml
+++ b/clusters/homelab/services/sandbox-lifecycle/role-sandbox-talos.yaml
@@ -1,0 +1,112 @@
+---
+# Grants vm-rebuilder (sandbox-lifecycle namespace -- see serviceaccount.yaml and the
+# RoleBinding below) what its weekly destroy-and-rebuild cycle for talos-vm needs, in
+# sandbox-talos. The first four rules mirror role-sandbox-docker.yaml's reasoning exactly
+# (named VM/PVC delete via the VM's ownerRef cascade, pods:list for the generated
+# virt-launcher pod name, pods/log:get for the guest console) -- see that file's comments
+# for the full "why", not repeated here.
+#
+# The two rules below it are what talos-vm needs beyond docker-vm, and the second one is
+# the grant most worth scrutinizing in this whole module: talos-vm's rebuild is not
+# complete once qemu is running -- etcd has to be bootstrapped and the agent-admin
+# credential re-minted inside the sandbox cluster's own etcd, and neither can be done from
+# this namespace (sandbox-talos's own NetworkPolicy admits the Talos/sandbox-API ports
+# only from `coder` and `ai` mcp-server pods, never from sandbox-lifecycle -- and it must
+# not, for the same reason this SA doesn't hold a talosconfig or a sandbox kubeconfig
+# anywhere). So the rebuild delegates both steps by *triggering* the CronJobs that already
+# hold the right credentials (bootstrap-talos-vm, provision-agent-admin -- see
+# homelab-ops-kubernetes-experiments, experiments/apps/sandbox-talos/) and waiting on their
+# exit codes, never reading a Secret itself.
+#
+# `create` on `jobs` cannot be `resourceNames`-scoped -- a Job carries an arbitrary pod
+# template, so this grant is transitively equivalent to running any pod in sandbox-talos,
+# including one that mounts talos-vm-talosconfig (a year-long, effectively unrevocable
+# os:admin client cert). Three things bound accepting that rather than the zero-grant
+# observe-only alternative (poll `kube_job_complete` on a job that started after the
+# recorded destroy timestamp, letting bootstrap-talos-vm/provision-agent-admin run on a
+# much tighter schedule instead of being triggered):
+#   1. It grants nothing AI agents don't already hold in sandbox-talos -- that namespace is
+#      defined as the one agents get full write access to (see its own network-policy.yaml
+#      "CAVEAT" annotation), so this creates no new capability *class*, only one more
+#      principal equal to an existing one.
+#   2. vm-rebuilder lives in sandbox-lifecycle, which agents cannot write to -- a
+#      compromised agent does not acquire this SA or its token.
+#   3. Full compromise of vm-rebuilder yields: delete two named VMs/PVCs across two
+#      namespaces, read pod logs in those two namespaces, and run pods in sandbox-talos
+#      specifically. It cannot read a Secret, cannot reach any other namespace, and cannot
+#      touch this host cluster's control plane.
+# The zero-grant variant costs roughly hourly bootstrap/provision cadence instead of
+# triggered-on-demand (~2.4 GB/day of repeated talosctl/kubectl downloads, 24 token mints
+# a day, and a rebuild cycle taking ~65 minutes instead of ~25) to avoid a grant that is
+# already equal to what the namespace's normal occupants hold. If that trade is judged
+# wrong on review, the fix is deleting `create` below and switching
+# rebuild-talos-vm-cronjob.yaml's steps 4-5 to the poll-based variant -- both are correct,
+# only the standing cost differs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vm-rebuilder
+  namespace: sandbox-talos
+rules:
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines
+  resourceNames:
+  - talos-vm
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  resourceNames:
+  - talos-vm-storage
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  resourceNames:
+  - bootstrap-talos-vm
+  - provision-agent-admin
+  verbs:
+  - get
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vm-rebuilder
+  namespace: sandbox-talos
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: vm-rebuilder
+subjects:
+- kind: ServiceAccount
+  name: vm-rebuilder
+  namespace: sandbox-lifecycle

--- a/clusters/homelab/services/sandbox-lifecycle/role-sandbox-talos.yaml
+++ b/clusters/homelab/services/sandbox-lifecycle/role-sandbox-talos.yaml
@@ -13,10 +13,15 @@
 # this namespace (sandbox-talos's own NetworkPolicy admits the Talos/sandbox-API ports
 # only from `coder` and `ai` mcp-server pods, never from sandbox-lifecycle -- and it must
 # not, for the same reason this SA doesn't hold a talosconfig or a sandbox kubeconfig
-# anywhere). So the rebuild delegates both steps by *triggering* the CronJobs that already
-# hold the right credentials (bootstrap-talos-vm, provision-agent-admin -- see
+# anywhere). So the rebuild delegates both steps by *triggering* the CronJobs that hold
+# the right credentials (bootstrap-talos-vm, provision-agent-admin -- see
 # homelab-ops-kubernetes-experiments, experiments/apps/sandbox-talos/) and waiting on their
-# exit codes, never reading a Secret itself.
+# exit codes, never reading a Secret itself. `provision-agent-admin` is that CronJob's name
+# today; `bootstrap-talos-vm` names the CronJob homelab-ops-kubernetes-experiments#227's
+# design calls for `sandbox-talos/bootstrap-job.yaml` (still a one-shot Job as of this
+# module) to become -- forward-declared here on the same PR as the rest of this RBAC, not
+# yet backed by an object with that name. Nothing in this Role depends on it existing yet;
+# it simply grants nothing until it does.
 #
 # `create` on `jobs` cannot be `resourceNames`-scoped -- a Job carries an arbitrary pod
 # template, so this grant is transitively equivalent to running any pod in sandbox-talos,

--- a/clusters/homelab/services/sandbox-lifecycle/serviceaccount.yaml
+++ b/clusters/homelab/services/sandbox-lifecycle/serviceaccount.yaml
@@ -1,0 +1,19 @@
+---
+# Identity for the weekly sandbox destroy-and-rebuild CronJobs
+# (homelab-ops-kubernetes-experiments, experiments/apps/sandbox-lifecycle/). Everything
+# this SA can do is granted by the Roles/RoleBindings in this directory, scoped into
+# sandbox-docker and sandbox-talos individually -- no ClusterRole exists anywhere in this
+# module, and no permissions are attached here.
+#
+# automountServiceAccountToken: false at the SA level, opted back in per-pod
+# (`automountServiceAccountToken: true` on the CronJob's pod template) -- the inverse of
+# sandbox-docker/sandbox-talos's own Jobs, which explicitly set it false and must never
+# hold a host-cluster token. Say so once, here, rather than repeating the reasoning on
+# every consuming pod spec: this SA existing at all, with a token that automounts, is the
+# entire reason those namespaces' own workloads don't get one.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vm-rebuilder
+  namespace: sandbox-lifecycle
+automountServiceAccountToken: false

--- a/clusters/homelab/storage/infra/sc/kustomization.yaml
+++ b/clusters/homelab/storage/infra/sc/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 
 resources:
 - sc-longhorn-local-non-replicated.yaml
+- sc-longhorn-local-non-replicated-ephemeral.yaml
 - sc-longhorn-replicated.yaml
 - sc-longhorn-rwx.yaml
 - sc-nfs-share.yaml

--- a/clusters/homelab/storage/infra/sc/sc-longhorn-local-non-replicated-ephemeral.yaml
+++ b/clusters/homelab/storage/infra/sc/sc-longhorn-local-non-replicated-ephemeral.yaml
@@ -1,0 +1,34 @@
+---
+# Identical to sc-longhorn-local-non-replicated except reclaimPolicy: Delete. That one field
+# is the whole reason this class exists: sc-longhorn-local-non-replicated is Retain, so
+# deleting a PVC on it leaves the PV Released and the underlying Longhorn volume intact --
+# the next PVC on the same name provisions a *brand new* volume, and the old one just sits
+# there. For a PVC that's supposed to be genuinely disposable (the sandbox VMs' weekly
+# destroy-and-rebuild -- see homelab-ops-kubernetes-experiments,
+# experiments/apps/sandbox-lifecycle/), that leaks storage forever, silently, in a fixed
+# amount per cycle. Retain was always the wrong policy for a PVC whose own manifest
+# documents itself as deliberately disposable; this class makes that policy match the
+# intent instead of relying on every consuming PVC to route around it.
+#
+# storageClassName is immutable on an existing PVC, so switching an already-bound PVC from
+# sc-longhorn-local-non-replicated to this class means: ship this StorageClass, change the
+# PVC's storageClassName in git, then let the PVC actually be deleted and recreated (a
+# real destroy, not a patch) before the new class takes effect -- editing the field alone
+# does not migrate live data. See that module's README for the exact sequencing this
+# requires before any automated destroy is allowed to run against a PVC still on the old
+# class.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: sc-longhorn-local-non-replicated-ephemeral
+allowVolumeExpansion: true
+parameters:
+  fsType: ext4
+  staleReplicaTimeout: "2880"
+  # as per https://longhorn.io/docs/1.7.1/best-practices/#io-performance
+  dataLocality: "strict-local"
+  numberOfReplicas: "1"
+  recurringJobSelector: '[{"name":"default", "isGroup":true}]'
+provisioner: driver.longhorn.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
## Summary

Clusters-repo half of the weekly sandbox VM destroy-and-rebuild mechanism
(ppat/homelab-ops-kubernetes-experiments#227). The CronJobs themselves ship in
a companion PR against that repo
(`experiments/apps/sandbox-lifecycle/`) — this PR is the "cage": the
namespace, isolation, and RBAC boundary that lets those CronJobs reach this
host cluster's API from a namespace AI agents cannot write to, plus the
StorageClass fix that must exist before either sandbox VM's PVC can safely be
destroyed on a schedule.

- **`sandbox-lifecycle` namespace + NetworkPolicy** — default-deny both
  directions, egress limited to CoreDNS and this cluster's own kube-apiserver
  ClusterIP (`10.43.0.1/32:443`), no ingress rule at all. Split out from
  `sandbox-docker`/`sandbox-talos` because those two deliberately *cannot*
  reach the host API (their egress policy excepts it, and the live
  falsifiability probe asserts that stays blocked every cycle) — a
  host-API-capable ServiceAccount can only safely live somewhere agents
  cannot create pods.
- **`vm-rebuilder` ServiceAccount** in `sandbox-lifecycle`, plus one
  `Role`+`RoleBinding` each in `sandbox-docker`/`sandbox-talos`
  (`role-sandbox-docker.yaml`, `role-sandbox-talos.yaml`), every verb scoped
  to the one named VM/PVC except `pods:list` (unavoidable — the virt-launcher
  pod name is generated). `sandbox-talos`'s Role additionally grants `create`
  on `jobs`, needed to trigger `bootstrap-talos-vm`/`provision-agent-admin`
  after a destroy — see that file's own comment for the full threat-model
  reasoning on why this was judged an acceptable grant (it equals what AI
  agents already hold in that namespace; the SA holding it lives somewhere
  agents can't reach).
- **`sc-longhorn-local-non-replicated-ephemeral`** — identical to the existing
  `sc-longhorn-local-non-replicated` except `reclaimPolicy: Delete`. The
  existing class is `Retain`: deleting a PVC on it leaves the PV `Released`
  and the Longhorn volume intact, so a weekly destroy against either sandbox
  PVC as declared today would leak 200Gi/40Gi of storage every single week
  while every other check reports success. `storageClassName` is immutable on
  an existing PVC, so this class has to exist, and each PVC has to be
  migrated onto it via a real destroy/recreate (not a live patch), before
  either rebuild CronJob is safe to unsuspend — see the companion PR's
  module README for the exact migration sequence. This PR ships the class
  only; migrating the PVCs is a separate, deliberate step.
- **`config-services-sandbox-lifecycle` Kustomization** — 1m0s interval
  (matches `sandbox-docker`/`sandbox-talos`'s own fast-reconcile isolation
  Kustomizations), depending on `infra-security-core`, `infra-networking-core`,
  and both existing sandbox Kustomizations (the Roles here target namespaces
  those own, so those namespaces must exist first).

## Ordering / what happens if this merges before or after the CronJobs PR

This PR has zero blast radius on its own — it's pure addition (new namespace,
new RBAC, new StorageClass) and nothing references any of it yet. The
companion CronJobs PR ships both CronJobs with `spec.suspend: true` and each
script's own Step 0 refuses to run against a PVC still on the `Retain` class,
so even an out-of-order merge (CronJobs before this PR, or either PR merged
without the other) cannot silently leak storage — the failure mode, if any,
is a loud, immediate "refusing to destroy" or an RBAC-denied error, never a
silent leak.

## Test plan

- [x] `pre-commit run --all-files` clean (yamllint, markdownlint, shellcheck,
      kubeconform via `validate-kubernetes-manifests`)
- [x] `kubectl kustomize clusters/homelab/services/sandbox-lifecycle` and
      `kubectl kustomize clusters/homelab` (full tree) both build cleanly;
      confirmed the Roles land in `sandbox-docker`/`sandbox-talos` and the
      RoleBindings' subjects correctly cross-reference the SA in
      `sandbox-lifecycle`
- [ ] Live reconcile (out of scope for this session — no destroy was
      performed against either sandbox VM; see companion PR for what remains
      unproven)

Part of ppat/homelab-ops-kubernetes-experiments#227 (that repo's companion PR
carries the closing keyword; this repo has no local issue for #227).