### PR TITLE
feat(cluster-homelab): add cluster-wide namespace egress dashboard

### DIFF
--- a/clusters/homelab/services/monitoring/dashboards/cluster-network-egress.json
+++ b/clusters/homelab/services/monitoring/dashboards/cluster-network-egress.json
@@ -1,0 +1,296 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [ ],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Cluster-wide network egress/ingress broken down by namespace, so a spike on a given namespace (notably the sandbox-* namespaces, which have deliberately wide-open internet egress) can be judged against what every other workload on the cluster is doing. Metrics-only visibility, no alert rules — alerting stays deferred until an AI triage layer exists.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [ ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [ ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [ ]
+          }
+        },
+        "overrides": [ ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "code": {
+          "language": "markdown",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "Source: cAdvisor's `container_network_{receive,transmit}_bytes_total`, cluster-wide, restricted to `interface=\"eth0\"`. Every pod's `eth0` is its pod-network-namespace interface; ordinary pods only ever report `eth0`. KubeVirt's `virt-launcher-*` pods additionally report `k6t-eth0` (the libvirt bridge) and `tap0` (the VM's tap device) — both mirror the same frames as they cross the bridge internally, at roughly 260x the `eth0` byte count for these VMs (measured). Summing all three interfaces would both double/triple-count the VM's own traffic and make it non-comparable to every other namespace, which has no such interfaces. `eth0` alone was confirmed (measured) to match the Sandbox VM Egress dashboard's `kubevirt_vmi_network_*`-based totals within rounding, so it's the correct interface to sum here.\n\nEach panel below is `topk(8, ...) or sum(... namespace=~\"sandbox-.*\")` — the top 8 namespaces by traffic, plus the sandbox namespaces whenever they'd otherwise fall outside that top 8, so they never silently drop off the graph.\n\nThis is a different question from the Sandbox VM Egress dashboard (\"is this VM's traffic unusual for itself\" vs. \"how does it compare to the rest of the cluster\"), so it's kept as its own dashboard rather than added as panels there.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.2.0",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Egress: bytes/sec transmitted, by namespace. Top 8 namespaces by traffic, plus the sandbox namespaces if not already among them.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [ ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": [ ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "topk(8, sum by (namespace) (rate(container_network_transmit_bytes_total{interface=\"eth0\"}[$__rate_interval]))) or sum by (namespace) (rate(container_network_transmit_bytes_total{interface=\"eth0\", namespace=~\"sandbox-.*\"}[$__rate_interval]))",
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Egress rate by namespace (top 8 + sandbox)",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Ingress: bytes/sec received, by namespace. Top 8 namespaces by traffic, plus the sandbox namespaces if not already among them.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [ ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": [ ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "topk(8, sum by (namespace) (rate(container_network_receive_bytes_total{interface=\"eth0\"}[$__rate_interval]))) or sum by (namespace) (rate(container_network_receive_bytes_total{interface=\"eth0\", namespace=~\"sandbox-.*\"}[$__rate_interval]))",
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Ingress rate by namespace (top 8 + sandbox)",
+      "transparent": true,
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": [ ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [ ],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": { },
+  "timezone": "",
+  "title": "Cluster Network Egress by Namespace",
+  "weekStart": ""
+}

--- a/clusters/homelab/services/monitoring/kustomization.yaml
+++ b/clusters/homelab/services/monitoring/kustomization.yaml
@@ -41,6 +41,16 @@ configMapGenerator:
     labels:
       grafana_dashboard: "1"
     disableNameSuffixHash: true
+- name: dashboard-cluster-network-egress
+  namespace: monitoring
+  files:
+  - dashboards/cluster-network-egress.json
+  options:
+    annotations:
+      kustomize.toolkit.fluxcd.io/substitute: disabled
+    labels:
+      grafana_dashboard: "1"
+    disableNameSuffixHash: true
 - name: snmp-exporter-extra-config
   namespace: monitoring
   files:


### PR DESCRIPTION
## Summary

Follow-up to #835 (Sandbox VM Egress dashboard). The operator asked for two extensions; this implements the one that's actually possible and documents why the other isn't.

**Ask A — breakdown by namespace: implemented, as a separate dashboard.**
New `Cluster Network Egress by Namespace` dashboard (`dashboards/cluster-network-egress.json`), sourced from cAdvisor's `container_network_{receive,transmit}_bytes_total`, filtered to `interface="eth0"` and summed by `namespace` cluster-wide. Two timeseries panels (egress, ingress), each `topk(8, ...) or sum(... namespace=~"sandbox-.*")` so the sandbox namespaces always show up even when they're not among the top talkers.

Kept as a **separate dashboard**, not added panels: "is this VM's traffic unusual for itself" (Sandbox VM Egress) and "how does it compare to the rest of the cluster" (this one) are different questions, and cramming ~10 cluster-wide series into the VM-specific dashboard would dilute the one panel someone opens it to read.

Interface choice was verified, not assumed — see Evidence below. `virt-launcher-*` pods report three interfaces (`eth0`, `k6t-eth0`, `tap0`); summing all three would triple/quadruple-count the same frames as they cross the bridge, and would make sandbox namespaces non-comparable to every other namespace (which only ever has `eth0`).

**Ask B — internet vs internal split: not implemented, confirmed not possible today.**
Checked what actually runs on this cluster (k3s + kube-router, no Cilium/Hubble):
- `kube_router_*` metrics expose only iptables sync durations and policy-chain/ipset counts — no byte/packet counters, no per-rule or per-destination breakdown.
- No NFLOG collector exists. The `nflog` metrics that do exist (`alertmanager_nflog_*`, `grafana_alerting_nflog_*`) are Alertmanager's/Grafana's own notification log, unrelated to the netpol falsifiability probes' NFLOG group 100 — that group is a kernel-side signal with nothing currently subscribed to it.
- Conntrack-related metrics (`node_nf_conntrack_entries`, `kubeproxy_conntrack_reconciler_*`) are entry/deletion counts, not byte counters, and carry no destination dimension.
- Both `kubevirt_vmi_network_*` and `container_network_*` are per-interface byte counters — no destination dimension exists at that layer regardless of which interface is chosen.

None of this can be turned into an internet-vs-internal panel without lying about precision, so no panel was built for it. What it would actually take:
- **Cheapest, scoped to the sandboxes**: a small exporter (textfile collector or sidecar) parsing the per-rule byte counters (`iptables -L -v -x` / nft counters) on the sandbox VMs' existing allow-RFC1918-deny / allow-internet chains, published as a Prometheus metric. Coarse (rule-level, not per-flow) but accurate, and reuses rules that already exist for the falsifiability probes.
- **General, cluster-wide**: an NFLOG-based collector subscribing to group 100 and classifying by destination CIDR — more general, more moving parts (a new DaemonSet).
- **Heaviest**: replacing kube-router's NetworkPolicy engine with Cilium for Hubble flow visibility — well outside the scope of "add a panel."

## Evidence (measured via Grafana MCP against live Prometheus)

Interface verification (1h `increase`, `docker-vm` / `sandbox-docker`, confirms `eth0` matches the KubeVirt metric and `k6t-eth0`/`tap0` do not):

| interface | bytes (1h) |
|---|---|
| `kubevirt_vmi_network_transmit_bytes_total` (existing dashboard's source) | 3,490,101 |
| `container_network_transmit_bytes_total{interface="eth0"}` | 3,493,722 |
| `container_network_transmit_bytes_total{interface="k6t-eth0"}` | 914,734,744 |
| `container_network_transmit_bytes_total{interface="tap0"}` | 914,734,815 |

Same pattern held for `talos-vm` (`eth0`: 10,779,471 vs. `kubevirt_vmi_network`: 10,820,270; bridge/tap: ~107M each).

Panel query, executed live (`topk(8, sum by (namespace) (rate(container_network_transmit_bytes_total{interface="eth0"}[10m]))) or sum by (namespace) (rate(container_network_transmit_bytes_total{interface="eth0", namespace=~"sandbox-.*"}[10m]))`):

```
longhorn-system  1,508,722 B/s
logging            381,354 B/s
authentik           283,766 B/s
downloaders          259,098 B/s
coder                249,196 B/s
monitoring           135,048 B/s
home-automation       134,276 B/s
ai                     91,254 B/s
sandbox-docker            25 B/s
sandbox-talos             25 B/s
```

A 6h range pull of the same query also showed real spikes in `sandbox-docker` (up to ~1.48M B/s) and `sandbox-talos` (up to ~16K B/s) earlier in the window — exactly the "is this spike unusual relative to the rest of the cluster" context the dashboard exists to give.

## Test plan

- [x] `kustomize build clusters/homelab/services/monitoring` renders the new ConfigMap with the `grafana_dashboard: "1"` label
- [x] `python3 -m json.tool` validates the dashboard JSON
- [x] `pre-commit run` (yamllint, kubeconform, etc.) passes on the changed files
- [x] Every PromQL expression executed live against Grafana MCP (`query_prometheus`) and returned sane values (see Evidence)
- [ ] Sidecar picks up the dashboard in-cluster (verify after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)