### PR TITLE
feat(cluster-homelab): admit sandbox-lifecycle to the sandbox VM and the Bitwarden store

### DIFF
--- a/clusters/homelab/cluster/secrets/bitwarden-secret-store.yaml
+++ b/clusters/homelab/cluster/secrets/bitwarden-secret-store.yaml
@@ -35,6 +35,18 @@ spec:
   # ExternalSecret-create rights in a sandbox namespace, or a paid tier/second project
   # removes the reason a dedicated store isn't used instead.
   #
+  # sandbox-lifecycle is here on a strictly stronger footing than either of those two, and
+  # the difference is worth keeping straight: it is the namespace for workloads that operate
+  # on the sandboxes from outside (../services/sandbox-lifecycle/, #842), and AI agents have
+  # no rights in it at all -- not pod-create, not cluster-admin-in-a-VM, nothing. It needs
+  # the store in both directions, which is also new here: an ExternalSecret pulling
+  # sandbox_talos_vm_talosconfig down so provision-agent-admin can authenticate to the
+  # sandbox VM's Talos API, and a PushSecret relaying the minted
+  # sandbox_talos_vm_agent_admin_kubeconfig back up. The push direction is not a new
+  # capability for the machine account -- apps/subsystems/{downloaders,home-automation} have
+  # been pushing through this same store in production -- but it is the first time a sandbox
+  # namespace does it, so it is called out rather than left to be inferred from the list.
+  #
   # image-builder is here for its own ExternalSecret (a Harbor robot-account credential,
   # scoped push-only to the `kubevirt/` project -- see
   # ppat/homelab-ops-kubernetes-experiments#218). Same acceptance basis as the sandboxes:
@@ -69,6 +81,7 @@ spec:
     - obsidian-vault
     - openclaw
     - sandbox-docker
+    - sandbox-lifecycle
     - sandbox-talos
     - tailscale
     - traefik

--- a/clusters/homelab/cluster/secrets/bitwarden-secret-store.yaml
+++ b/clusters/homelab/cluster/secrets/bitwarden-secret-store.yaml
@@ -37,8 +37,8 @@ spec:
   #
   # sandbox-lifecycle is here on a strictly stronger footing than either of those two, and
   # the difference is worth keeping straight: it is the namespace for workloads that operate
-  # on the sandboxes from outside (../services/sandbox-lifecycle/, #842), and AI agents have
-  # no rights in it at all -- not pod-create, not cluster-admin-in-a-VM, nothing. It needs
+  # on the sandboxes from outside (../services/sandbox-lifecycle/, #842) rather than
+  # a namespace holding a sandbox itself, so nothing an agent is ever handed touches it. It needs
   # the store in both directions, which is also new here: an ExternalSecret pulling
   # sandbox_talos_vm_talosconfig down so provision-agent-admin can authenticate to the
   # sandbox VM's Talos API, and a PushSecret relaying the minted

--- a/clusters/homelab/services/sandbox-talos/network-policy.yaml
+++ b/clusters/homelab/services/sandbox-talos/network-policy.yaml
@@ -221,6 +221,37 @@ spec:
       podSelector:
         matchLabels:
           app.kubernetes.io/component: mcp-server
+    # Third peer, and deliberately a bare namespaceSelector rather than another workload hung
+    # off the mcp-server label above -- see issue #841, which this closes: that label means
+    # "this pod is an MCP server" everywhere in apps/subsystems/ai, and it had started being
+    # used as a second, unrelated thing ("this pod may reach the sandbox"). Once those two
+    # populations diverge, `kubectl get pods -n ai -l app.kubernetes.io/component=mcp-server`
+    # answers both "which pods are MCP servers?" and "what can reach the sandbox?" -- wrongly.
+    # Keeping them as separate peers keeps each grant readable and revocable on its own.
+    #
+    # What this admits: sandbox-lifecycle, the namespace whose entire purpose is operating on
+    # the sandboxes from *outside* (see ../sandbox-lifecycle/, added in #842). Its
+    # provision-agent-admin CronJob mints the sandbox cluster's agent-admin credential and
+    # relays it to Bitwarden, which means reaching both this VM's Kubernetes API (6443) and
+    # its Talos API (50000) -- the same pair, for the same reason, as the two peers above.
+    #
+    # READ THIS BEFORE CONCLUDING THE ISOLATION MODEL WAS RELAXED -- it was not, and the
+    # direction is the whole distinction. This is INGRESS *to* the sandbox: it grants reaching
+    # the VM, which is what this entire rule exists to do. It does NOT give anything in
+    # `sandbox-talos` egress *to this host cluster's API server*. That denial
+    # (allow-egress-internet's 10.0.0.0/8 `except`, asserted every cycle by
+    # netpol-falsifiability-probe against 10.43.0.1) is untouched, and stays that way by
+    # explicit decision -- sandbox-talos has no host-API access, full stop.
+    #
+    # Which is exactly why the provisioner is not simply run inside `sandbox-talos` with an
+    # egress hole punched for it: writing its result to a Secret on this cluster needs the host
+    # API, and that namespace is deliberately and permanently denied it. A namespace whose
+    # purpose is operating on the sandboxes from outside already exists for workloads in this
+    # position, and holds the host-API RBAC to match. This is separation of concerns landing
+    # where it already was, not a new boundary invented for one CronJob.
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: sandbox-lifecycle
     ports:
     - protocol: TCP
       port: 6443


### PR DESCRIPTION
## What

Two additive grants that let `sandbox-lifecycle` host the agent-admin credential provisioner (ppat/homelab-ops-kubernetes-experiments#230). Both are inert until #842 creates that namespace, so this has no blast radius on its own.

1. **`allow-coder-and-mcp-ingress` gains a third peer** — a bare `namespaceSelector` on `sandbox-lifecycle`, admitting it to the Talos VM on 6443/50000.
2. **`bitwarden-secret-manager-store` gains `sandbox-lifecycle`** in its namespace allowlist. The relay needs the store in *both* directions: an `ExternalSecret` pulling `sandbox_talos_vm_talosconfig` down so the provisioner can authenticate to the VM's Talos API, and a `PushSecret` relaying the minted `sandbox_talos_vm_agent_admin_kubeconfig` back up. Pushing is not a new capability for the machine account (`downloaders`/`home-automation` already push through this store in production), but it is the first time a sandbox namespace does, so the entry says so.

## Closes #841

The peer is a bare `namespaceSelector` rather than another workload hung off the `mcp-server` `podSelector` — which is exactly what #841 asked for. That label means "this pod is an MCP server" everywhere in `apps/subsystems/ai`; using it as a second, unrelated thing ("this pod may reach the sandbox") makes `kubectl get pods -n ai -l app.kubernetes.io/component=mcp-server` answer both questions, wrongly, the moment the two populations diverge.

**It closes #841 outright rather than partly.** The relay was the *only* prospective non-MCP rider on that label; every pod in `ai` carrying it today (`mcp-context7`, `mcp-github`, `mcp-grafana`, `mcp-home-assistant`, `mcp-kubernetes-homelab`, `mcp-kubernetes-nas`, `mcp-playwright`, `mcp-unifi-network`, `mcp-unifi-protect`, plus both `obsidian-vault/mcp-obsidian-*`) is a genuine MCP server. With the relay moved to its own peer, the label's two meanings are back in agreement.

## This is ingress, not a relaxation

Stated in the rule's own comment because it is the thing most likely to be misread later. This admits traffic **to** the sandbox, which is what the rule exists for. It does **not** give anything in `sandbox-talos` egress **to this cluster's API server** — that denial, and `netpol-falsifiability-probe` asserting it every cycle against `10.43.0.1`, are untouched and stay that way by explicit decision.

Running the provisioner inside `sandbox-talos` with an egress carve-out was considered and rejected for exactly that reason: writing its result to a `Secret` needs the host API, `sandbox-talos` is permanently denied it, and a namespace for workloads that operate on the sandboxes from *outside* already exists.

## Merge order

**This PR first, then ppat/homelab-ops-kubernetes-experiments#230.** #230's workload is denied and fails with a connection error against a healthy VM otherwise — this stack's kube-router REJECTs rather than drops, so it surfaces as `connection refused`, not as anything pointing at a policy.

**#842 must also merge before #230**, since it creates the `sandbox-lifecycle` namespace itself. This PR is safe in any order relative to #842 (the peer and the allowlist entry match nothing until the namespace exists).

## Two things found in #842 while wiring this up — flagged, not fixed here

Both are in files this PR does not touch, and #842 is the right place for them:

1. **`sandbox-lifecycle`'s `default-deny` blocks reaching the sandbox VM.** Its only egress rules are CoreDNS and the host apiserver, so `provision-agent-admin` cannot reach `talos-vm.sandbox-talos.svc.cluster.local` on 6443/50000 — this PR opens the ingress half, but the egress half is missing. It needs a rule scoped to `namespaceSelector: sandbox-talos` + `podSelector: app.kubernetes.io/name: talos-vm`, and specifically **not** an `ipBlock` on the Service ClusterIP: kube-router evaluates post-DNAT (this repo's own `allow-egress-lb-ingress-vips` comment documents the mechanism and the probe confirmed it), so by evaluation time the destination is the virt-launcher pod IP, not the ClusterIP.
2. **`allow-egress-kube-apiserver`'s `ipBlock: 10.43.0.1/32` port 443 may never match, for the same reason.** *Measured:* `Endpoints/kubernetes` in `default` resolves to `192.168.8.65/.67/.68/.69` on port **6443**, so post-DNAT the destination is a node IP on 6443 — neither the address nor the port in that rule. *Reasoned from this repo's own precedent, not directly observed for this ClusterIP:* if that is right, `vm-rebuilder` cannot reach the API server at all and #842's whole purpose fails closed on first run. Cheap to falsify with a one-off pod in that namespace once it exists; worth doing before unsuspending anything.
