### PR TITLE
fix(cluster-homelab): correct sandbox agent write-access claim in netpol docs

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -637,11 +637,11 @@ directly, every time its container (re)starts, rather than assuming.
   pod is policed within seconds of creation and stays policed for the VM's
   entire lifetime. This window is irrelevant to them.
 - Any short-lived pod created in `sandbox-docker` or `sandbox-talos` — most
-  importantly, anything an agent with pod-create rights in `sandbox-talos`
-  runs — can complete its entire lifecycle inside this window. A Job that
-  opens an egress connection and exits within the first few seconds may
-  never be policed at all. **This is a real gap in the isolation model, not
-  a testing artifact:** the NetworkPolicies, though correct, are not a
+  importantly, the bootstrap Job or either CronJob that runs in
+  `sandbox-talos` — can complete its entire lifecycle inside this window. A
+  Job that opens an egress connection and exits within the first few seconds
+  may never be policed at all. **This is a real gap in the isolation model,
+  not a testing artifact:** the NetworkPolicies, though correct, are not a
   complete mediation guarantee against a short-lived process — only against
   anything that outlives the window.
 - The mechanism (`KUBE-ROUTER-FORWARD` dispatch) is symmetric for ingress
@@ -676,11 +676,12 @@ probe's own self-reported result.
 
 **Standing mitigation:** the falsifiability probe's warm-up gate (above) is
 the automated version of this same check, run against its own pod every
-time it (re)starts. There is no equivalent gate today for pods an agent
-creates directly in `sandbox-talos` — that would require something like a
-validating admission policy or a delay before granting network access to
-new pods, neither of which exists. Treat this window as a standing,
-accepted property of the current isolation model, not a closed issue.
+time it (re)starts. There is no equivalent gate today for the other
+short-lived pods created directly in `sandbox-talos` (the bootstrap Job, the
+CronJobs) — that would require something like a validating admission policy
+or a delay before granting network access to new pods, neither of which
+exists. Treat this window as a standing, accepted property of the current
+isolation model, not a closed issue.
 
 ## Runbook: reach the sandbox VMs
 

--- a/clusters/homelab/kustomizations/config-services-sandbox-talos.yaml
+++ b/clusters/homelab/kustomizations/config-services-sandbox-talos.yaml
@@ -11,8 +11,9 @@ spec:
   - name: infra-networking-core
     namespace: flux-system
   # Short interval, split out of config-services.yaml's 15m0s on purpose: this namespace
-  # is the one AI agents get full write access to, so drift correction on its isolation
-  # boundary needs to converge fast.
+  # hosts the Talos VM that AI agents get full write access to (inside its guest cluster,
+  # not this host-cluster namespace itself, which stays read-only to agents), so drift
+  # correction on its isolation boundary needs to converge fast.
   interval: 1m0s
   path: ./clusters/homelab/services/sandbox-talos
   prune: true

--- a/clusters/homelab/services/sandbox-docker/deployment-netpol-falsifiability-probe.yaml
+++ b/clusters/homelab/services/sandbox-docker/deployment-netpol-falsifiability-probe.yaml
@@ -25,7 +25,7 @@
 # created* pod in this namespace, and it's still exercised here, just less often: every
 # container (re)start (a rollout, a node drain, an eviction, a crash) re-runs the warm-up
 # gate against a brand-new pod. See network-policy.yaml and OPERATIONS.md for why this
-# matters beyond this probe: an agent-created Job in this namespace faces the identical
+# matters beyond this probe: any short-lived pod in this namespace faces the identical
 # window, and it's documented there as a standing caveat of the isolation model, not
 # something this probe alone can close.
 #

--- a/clusters/homelab/services/sandbox-talos/network-policy.yaml
+++ b/clusters/homelab/services/sandbox-talos/network-policy.yaml
@@ -2,19 +2,24 @@
 # Default-deny both directions -- see sandbox-docker/network-policy.yaml for why this
 # namespace also locks down egress, not just ingress like every other NetworkPolicy in the
 # apps repo. Here the reasoning is symmetric rather than about the workload itself: this
-# namespace is the one AI agents get full write access to (today they only have read-only
-# cluster access, via mcp-kubernetes-readonly), so egress from it has to be closed by
-# default on the same footing as ingress into it.
+# namespace hosts the Talos VM that AI agents get full write access to -- inside the guest
+# cluster it runs, not to this host-cluster namespace itself, which stays read-only to
+# agents (via mcp-kubernetes-readonly) as a matter of policy, not a placeholder for future
+# write access -- so egress from it has to be closed by default on the same footing as
+# ingress into it, since whatever the guest can be made to do must be contained here at
+# the host-cluster boundary.
 #
-# CAVEAT -- and it matters more here than anywhere else in this repo, because this is the
-# namespace agents can write to: a pod is unpoliced for a window after it's created, not
-# from the instant it exists. k3s's bundled kube-router-derived NetworkPolicy controller
-# programs each pod's firewall chain and its KUBE-ROUTER-FORWARD dispatch rule
-# *reactively*, watching the API server for new pods -- a pod with no dispatch rule yet
-# falls straight through to `-P FORWARD ACCEPT`, fully unpoliced. An agent with pod-create
-# rights here could run a Job that exfiltrates toward the prod cluster or the LAN in its
-# first seconds and exits before enforcement ever arrives -- for a short-lived pod, this
-# window can span the pod's entire lifetime. It does not affect the sandbox VM itself
+# CAVEAT -- and it matters more here than anywhere else in this repo, because this
+# namespace runs several short-lived pods (the bootstrap Job, two CronJobs, the
+# falsifiability probe) alongside the long-lived VM workload: a pod is unpoliced for a
+# window after it's created, not from the instant it exists. k3s's bundled
+# kube-router-derived NetworkPolicy controller programs each pod's firewall chain and its
+# KUBE-ROUTER-FORWARD dispatch rule *reactively*, watching the API server for new pods --
+# a pod with no dispatch rule yet falls straight through to `-P FORWARD ACCEPT`, fully
+# unpoliced. A short-lived pod here -- the bootstrap Job or either CronJob -- could
+# exfiltrate toward the prod cluster or the LAN in its first seconds and exit before
+# enforcement ever arrives -- for a short-lived pod, this window can span the pod's entire
+# lifetime. It does not affect the sandbox VM itself
 # (long-lived, policed within seconds of creation), but it is a genuine, standing property
 # of this isolation model, not a bug to be fixed here. See
 # sandbox-docker/network-policy.yaml for how this was discovered (it produced a false
@@ -31,20 +36,23 @@ metadata:
   # someone reading git or OPERATIONS.md ever sees it. This annotation survives onto the
   # live object as the discoverable half of that same warning; the comment stays too, for
   # the git/PR reader who wants the full mechanism. Wording deliberately differs from
-  # sandbox-docker's copy of this annotation: this is the namespace AI agents get full
-  # write access to, so the hazard is framed around what an agent can do inside the
+  # sandbox-docker's copy of this annotation: this namespace runs several short-lived
+  # pods (the bootstrap Job, two CronJobs) that can complete within the enforcement
+  # window, so the hazard is framed around what a short-lived pod can do inside the
   # window, not just that the window exists. `homelab-ops.internal/*` is this platform's
   # established self-defined-key prefix (see the `homelab-ops.internal/virtualization`
   # node label in OPERATIONS.md) -- `.internal` is the RFC 9476 reserved, non-delegatable
   # TLD, so it can never collide with or be mistaken for a domain anyone actually owns.
   annotations:
     homelab-ops.internal/netpol-caveat: >-
-      CAVEAT: AI agents have full pod-create rights in this namespace, and a freshly
-      created pod is unpoliced for a short window (k3s's kube-router netpol controller
-      programs firewall rules reactively) -- an agent-run Job could exfiltrate toward
-      prod or the LAN in that window before enforcement ever begins. Full explanation and
-      how to verify a given pod is actually policed: OPERATIONS.md, "Known limitation:
-      the per-pod NetworkPolicy enforcement window".
+      CAVEAT: a freshly created pod in this namespace is unpoliced for a short window
+      (k3s's kube-router netpol controller programs firewall rules reactively) -- a
+      short-lived Job (e.g. the bootstrap Job or either CronJob that runs here) could
+      exfiltrate toward prod or the LAN in that window before enforcement ever begins. AI
+      agents get full write access only inside the Talos VM this namespace runs (its
+      guest cluster), never to this namespace on the host cluster, which stays read-only.
+      Full explanation and how to verify a given pod is actually policed: OPERATIONS.md,
+      "Known limitation: the per-pod NetworkPolicy enforcement window".
 spec:
   podSelector: {}
   policyTypes:
@@ -97,8 +105,10 @@ spec:
 # See sandbox-docker/network-policy.yaml for why this exact `except` list is most of this
 # namespace's security value: it closes the prod kube-apiserver, Longhorn's manager API,
 # kubelet, etcd, the UniFi gateway, and the NAS in one object, and it is the control this
-# whole design leans on hardest, because this namespace is the one agents can write to.
-# Internet egress stays open on purpose (package/image pulls for the sandbox cluster
+# whole design leans on hardest, because this namespace hosts the Talos VM agents get
+# full write access to (inside its guest cluster) and runs the automation (bootstrap Job,
+# CronJobs) that provisions and manages it. Internet egress stays open on purpose
+# (package/image pulls for the sandbox cluster
 # itself); nothing about that weakens the boundary against the LAN and prod cluster, which
 # is the boundary that actually matters here.
 apiVersion: networking.k8s.io/v1
@@ -141,14 +151,15 @@ spec:
 # needed -- is a podSelector on Traefik's pods, not a bigger ipBlock, and why that would
 # unavoidably expose homelab's own API server too.
 #
-# The one thing that IS more acute here than in sandbox-docker: this is the namespace AI
-# agents get full write access to (see default-deny above), so nas's API server ingress
-# being L3-reachable from this namespace lands on the namespace with pod-create rights and
-# cluster-admin inside its own sandbox cluster, not just a single long-lived VM workload.
-# The "what bounds the risk" argument still holds -- no ambient credential exists here to
-# use against that ingress -- but it holds with less margin than in sandbox-docker,
-# precisely because this is the namespace built to run arbitrary agent-authored pods. #828
-# names this explicitly as one of the conditions worth re-checking.
+# The one thing that IS more acute here than in sandbox-docker: this namespace hosts the
+# Talos VM whose guest cluster AI agents get cluster-admin on (see default-deny above),
+# plus the automation (the bootstrap Job, two CronJobs) that provisions and manages that
+# access -- so nas's API server ingress being L3-reachable from this namespace lands on
+# more than a single long-lived VM workload, unlike sandbox-docker. The "what bounds the
+# risk" argument still holds -- no ambient credential exists here to use against that
+# ingress -- but it holds with less margin than in sandbox-docker, precisely because of
+# what this namespace's own automation provisions access to. #828 names this explicitly as
+# one of the conditions worth re-checking.
 #
 # Range (repeated here so this file doesn't require reading the other one to know what it
 # allows): nas `standard-pool`, 192.168.8.192/28 (192.168.8.192-192.168.8.207) -- Harbor's


### PR DESCRIPTION
## Summary

Corrects a factually wrong security claim that had propagated into this repo's sandbox NetworkPolicy comments and, more importantly, onto a **live cluster object** (the `homelab-ops.internal/netpol-caveat` annotation on `sandbox-talos`'s `default-deny` NetworkPolicy).

**The wrong claim:** AI agents have full write access (pod-create rights) in the `sandbox-talos`/`sandbox-docker` namespaces on the *host* cluster, sometimes hedged as "today they only have read-only" implying a future write-access state.

**Actual posture:** agents get full write access only *inside* the sandbox VMs' guest environments (the Talos cluster running in `talos-vm`). The host cluster stays read-only to agents, permanently, as a matter of policy — not a placeholder for future write access. Pod creation inside `sandbox-talos`/`sandbox-docker` on the host is Flux-managed automation only (bootstrap Job, CronJobs, the falsifiability probe).

This was not cosmetic: the false premise was the stated justification for at least one design conclusion drawn elsewhere ("labels aren't a trust boundary against a principal who can set arbitrary labels on pods they create" — a principal that doesn't exist on the host cluster).

## What changed / what didn't

- Corrected the false claim in:
  - `clusters/homelab/services/sandbox-talos/network-policy.yaml` (file comments **and** the live `homelab-ops.internal/netpol-caveat` annotation — highest priority, since it's the version an agent or operator reads straight off the cluster)
  - `clusters/homelab/kustomizations/config-services-sandbox-talos.yaml`
  - `OPERATIONS.md` (the per-pod NetworkPolicy enforcement window runbook)
  - `clusters/homelab/services/sandbox-docker/deployment-netpol-falsifiability-probe.yaml`
- **No policy rule, RBAC, or behavior changed** — every `NetworkPolicy`/`Kustomization` spec is byte-identical; only comments and the one annotation's text changed.
- Preserved the real, unrelated hazard these comments also carry: k3s's kube-router-derived NetworkPolicy controller programs firewall rules **reactively**, so a freshly-created pod is briefly unpoliced (~2s measured) regardless of who created it — only the threat-actor framing changed, from "an agent-run Job" to "any short-lived pod" (concretely, the bootstrap Job / CronJobs that actually run here).
- `sandbox-docker/network-policy.yaml`'s own comments were already agent-neutral and correct — left untouched.
- `DESIGN.md` and `clusters/homelab/README.md` have no sandbox-related mentions of this claim — nothing to change there.

## Test plan

- [x] YAML re-parsed for all 4 edited files (`yaml.safe_load_all`) — no syntax errors introduced
- [x] Diffed every edit against original to confirm no `spec:` block touched, only comments/annotation text
- [ ] Operator review of the annotation wording on the live object

🤖 Generated with [Claude Code](https://claude.com/claude-code)