### PR TITLE
docs(cluster-homelab): follow the sandbox-talos lifecycle/ directory split

### DIFF
--- a/clusters/homelab/services/sandbox-lifecycle/role-sandbox-talos.yaml
+++ b/clusters/homelab/services/sandbox-lifecycle/role-sandbox-talos.yaml
@@ -15,11 +15,11 @@
 # not, for the same reason this SA doesn't hold a talosconfig or a sandbox kubeconfig
 # anywhere). So the rebuild delegates both steps by *triggering* the CronJobs that hold
 # the right credentials (bootstrap-talos-vm, provision-agent-admin -- see
-# homelab-ops-kubernetes-experiments, experiments/apps/sandbox-talos/) and waiting on their
-# exit codes, never reading a Secret itself. `provision-agent-admin` is that CronJob's name
-# today; `bootstrap-talos-vm` names the CronJob homelab-ops-kubernetes-experiments#227's
-# design calls for `sandbox-talos/bootstrap-job.yaml` (still a one-shot Job as of this
-# module) to become -- forward-declared here on the same PR as the rest of this RBAC, not
+# homelab-ops-kubernetes-experiments, experiments/apps/sandbox-talos/lifecycle/) and waiting on
+# their exit codes, never reading a Secret itself. `provision-agent-admin` is that CronJob's
+# name today; `bootstrap-talos-vm` names the CronJob homelab-ops-kubernetes-experiments#227's
+# design calls for `sandbox-talos/lifecycle/bootstrap-job.yaml` (still a one-shot Job as of
+# this module) to become -- forward-declared here on the same PR as the rest of this RBAC, not
 # yet backed by an object with that name. Nothing in this Role depends on it existing yet;
 # it simply grants nothing until it does.
 #

--- a/clusters/homelab/services/sandbox-talos/network-policy.yaml
+++ b/clusters/homelab/services/sandbox-talos/network-policy.yaml
@@ -267,11 +267,11 @@ spec:
 # is not exempt from an ingress policy once default-deny plus any ingress-admitting rule
 # selects a pod -- every client has to be listed explicitly, including ones that live right
 # next to the target. Concretely, that gap denied
-# homelab-ops-kubernetes-experiments/experiments/apps/sandbox-talos/bootstrap-job.yaml's
+# homelab-ops-kubernetes-experiments/experiments/apps/sandbox-talos/lifecycle/bootstrap-job.yaml's
 # `talosctl bootstrap` call (port 50000, surfaced as `connection refused` -- this stack's
 # kube-router REJECTs a denied packet rather than dropping it, indistinguishable at the
 # TCP level from a closed port) and would equally have denied
-# provision-agent-admin-cronjob.yaml's kubectl calls against the sandbox cluster's own API
+# lifecycle/provision-agent-admin-cronjob.yaml's kubectl calls against the sandbox cluster's own API
 # server (port 6443) the first time it ran after a bootstrap. Both Jobs/CronJobs run as
 # pods in this same namespace and have no other path to the VM.
 #


### PR DESCRIPTION
ppat/homelab-ops-kubernetes-experiments#230 splits `experiments/apps/sandbox-talos/` into the VM itself at the top level and everything that acts *on* it under `lifecycle/`. Three comments in this repo point at the old paths and would become dangling:

| File | Reference |
| --- | --- |
| `services/sandbox-talos/network-policy.yaml` | `bootstrap-job.yaml` and `provision-agent-admin-cronjob.yaml` — cited as the callers whose denial motivated `allow-same-namespace-ingress-to-vm` |
| `services/sandbox-lifecycle/role-sandbox-talos.yaml` | the `sandbox-talos/` directory, and `bootstrap-job.yaml` when forward-declaring the Job name #227 will need |

**Comment-only — no rendered object changes**, so this is safe to land before or after the experiments PR. A stale comment path misleads a reader either way and breaks nothing in between.

Filed because #231 left exactly this kind of dangling reference behind when it moved `mise.toml` out of `sandbox-talos/`, and it took a separate pass to find. Doing the sweep with the move this time.