### PR TITLE
fix(cluster-homelab): move provision-agent-admin's trigger grant to sandbox-lifecycle

### DIFF
--- a/clusters/homelab/services/sandbox-lifecycle/kustomization.yaml
+++ b/clusters/homelab/services/sandbox-lifecycle/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - serviceaccount.yaml
 - role-sandbox-docker.yaml
 - role-sandbox-talos.yaml
+- role-sandbox-lifecycle.yaml
 
 commonAnnotations:
   # This namespace's isolation (default-deny, one enumerated egress target) and the RBAC

--- a/clusters/homelab/services/sandbox-lifecycle/namespace.yaml
+++ b/clusters/homelab/services/sandbox-lifecycle/namespace.yaml
@@ -4,10 +4,18 @@
 # as. Deliberately its own namespace, not sandbox-docker or sandbox-talos: those two run
 # default-deny egress with the host cluster's own API server inside the `except` list (see
 # their network-policy.yaml), so a pod there physically cannot delete anything on this
-# cluster -- and must not be able to, since both are namespaces AI agents can create pods
-# in. A host-API-capable ServiceAccount can only safely live somewhere agents cannot write
-# to. See network-policy.yaml in this directory for the egress this namespace is granted
-# instead.
+# cluster. That alone is sufficient reason not to put vm-rebuilder there.
+#
+# It would also be poor hygiene even if that network block were ever loosened -- not
+# because AI agents could reach it (they cannot: agents hold no write access to any
+# namespace on this HOST cluster, sandbox-docker/sandbox-talos included, full stop -- the
+# access they do hold is cluster-admin *inside the guest* Talos cluster/dockerd running in
+# each VM, a different API surface with no bearing on this namespace's placement), but
+# because sandbox-talos already holds talos-vm-talosconfig, a year-long, effectively
+# unrevocable os:admin client cert reachable by anything with pod-create rights there.
+# Colocating a host-API-capable ServiceAccount with that credential would mean a single
+# compromise of either yields both. See network-policy.yaml in this directory for the
+# egress this namespace is granted instead.
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/homelab/services/sandbox-lifecycle/role-sandbox-lifecycle.yaml
+++ b/clusters/homelab/services/sandbox-lifecycle/role-sandbox-lifecycle.yaml
@@ -1,0 +1,72 @@
+---
+# Grants vm-rebuilder what its weekly rebuild cycle for talos-vm needs to trigger
+# `provision-agent-admin` -- a SAME-namespace grant, unlike role-sandbox-docker.yaml/
+# role-sandbox-talos.yaml, because that CronJob now lives in `sandbox-lifecycle` itself
+# (homelab-ops-kubernetes-experiments#230: it needs this host cluster's API to relay the
+# agent-admin credential to Bitwarden, which `sandbox-talos` is permanently denied -- the
+# same reason vm-rebuilder itself lives here and not in `sandbox-talos`/`sandbox-docker`).
+# Before #230, this was one more `cronjobs`/`jobs` rule inside role-sandbox-talos.yaml,
+# reaching cross-namespace; that file no longer grants anything toward
+# `provision-agent-admin` at all -- this Role is the whole of what replaced it, not an
+# addition alongside it.
+#
+# `create` on `jobs` cannot be `resourceNames`-scoped, same limitation as
+# role-sandbox-talos.yaml's copy of this grant -- so this is transitively "run any pod in
+# sandbox-lifecycle", not just "trigger provision-agent-admin". State plainly what that
+# adds that role-sandbox-talos.yaml's grant didn't: provision-agent-admin's own
+# ServiceAccount (homelab-ops-kubernetes-experiments, sandbox-talos/lifecycle/agent-admin-
+# credentials.yaml) holds `get`/`patch` on exactly one Secret
+# (`sandbox-lifecycle/sandbox-talos-agent-admin`) -- nothing stops a Job created under this
+# grant from setting `serviceAccountName: provision-agent-admin` on its own pod spec (pod
+# creation does not gate which ServiceAccount a namespace's own pods may request), so full
+# compromise of vm-rebuilder now additionally yields read/patch of that one relay Secret.
+# Accepted rather than closed, for the same shape of reasoning role-sandbox-talos.yaml
+# already applies to its own `jobs:create`: the alternative (a poll-based trigger with no
+# `create` verb at all, see that file's own closing paragraph) has a real standing cost, and
+# what this grant reaches is one narrowly-scoped Secret behind a Role that itself grants
+# nothing else in the cluster -- not a talosconfig, not cluster-admin, not this host
+# cluster's control plane.
+#
+# This namespace holds only two ServiceAccounts total (vm-rebuilder, provision-agent-admin)
+# and, as of this Role, no Secret vm-rebuilder itself can read directly -- smaller blast
+# radius than the equivalent grant would have been reaching into sandbox-talos, which is why
+# this split (narrower cross-namespace reach into sandbox-talos, a same-namespace grant here
+# instead) is a net tightening of the boundary that matters most (sandbox-talos, where AI
+# agents hold full write), even though it is not a reduction in the raw number of
+# `jobs:create` grants this SA holds.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vm-rebuilder
+  namespace: sandbox-lifecycle
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  resourceNames:
+  - provision-agent-admin
+  verbs:
+  - get
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vm-rebuilder
+  namespace: sandbox-lifecycle
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: vm-rebuilder
+subjects:
+- kind: ServiceAccount
+  name: vm-rebuilder
+  namespace: sandbox-lifecycle

--- a/clusters/homelab/services/sandbox-lifecycle/role-sandbox-lifecycle.yaml
+++ b/clusters/homelab/services/sandbox-lifecycle/role-sandbox-lifecycle.yaml
@@ -31,9 +31,16 @@
 # and, as of this Role, no Secret vm-rebuilder itself can read directly -- smaller blast
 # radius than the equivalent grant would have been reaching into sandbox-talos, which is why
 # this split (narrower cross-namespace reach into sandbox-talos, a same-namespace grant here
-# instead) is a net tightening of the boundary that matters most (sandbox-talos, where AI
-# agents hold full write), even though it is not a reduction in the raw number of
-# `jobs:create` grants this SA holds.
+# instead) is a net tightening of the boundary that matters most. That boundary is
+# sandbox-talos not because of any agent access to it -- AI agents hold no write access to
+# any namespace on this HOST cluster, sandbox-talos included, full stop (see
+# role-sandbox-talos.yaml's own correction of an earlier draft's false claim to the
+# contrary) -- but because it holds talos-vm-talosconfig, a year-long, effectively
+# unrevocable os:admin client cert reachable by anything with pod-create rights there.
+# Keeping the cross-namespace reach into *that* namespace as narrow as possible (one target,
+# not two) matters regardless of who or what could ever compromise the principal reaching
+# into it. This is not a reduction in the raw number of `jobs:create` grants vm-rebuilder
+# holds overall -- see role-sandbox-talos.yaml's own comment for that count.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/clusters/homelab/services/sandbox-lifecycle/role-sandbox-talos.yaml
+++ b/clusters/homelab/services/sandbox-lifecycle/role-sandbox-talos.yaml
@@ -34,25 +34,38 @@
 # os:admin client cert). That raw exposure does NOT shrink just because one fewer workload
 # is triggered through it -- `jobs:create` is still unscoped, same as before. What narrows is
 # the *justification* (one legitimate target, not two) and the RoleBinding's declared intent
-# (this Role, in this namespace, exists solely to reach `bootstrap-talos-vm` now). Three
-# things bound accepting the grant at all, unchanged from before:
-#   1. It grants nothing AI agents don't already hold in sandbox-talos -- that namespace is
-#      defined as the one agents get full write access to (see its own network-policy.yaml
-#      "CAVEAT" annotation), so this creates no new capability *class*, only one more
-#      principal equal to an existing one.
-#   2. vm-rebuilder lives in sandbox-lifecycle, which agents cannot write to -- a
-#      compromised agent does not acquire this SA or its token.
-#   3. Full compromise of vm-rebuilder's access to *this* Role yields: delete talos-vm and
+# (this Role, in this namespace, exists solely to reach `bootstrap-talos-vm` now).
+#
+# THIS IS A NEW CAPABILITY ON THE HOST CLUSTER, NOT A RESTATEMENT OF EXISTING ACCESS -- an
+# earlier draft of this comment justified the grant partly by claiming it "grants nothing AI
+# agents don't already hold in sandbox-talos." That claim is false and has been removed: AI
+# agents hold no write access to *any* namespace on this HOST cluster, sandbox-talos
+# included -- the host cluster is read-only to agents, full stop. (What agents *do* hold is
+# cluster-admin *inside the guest Talos cluster* running in talos-vm -- a different API
+# server entirely, reachable only from inside that VM, with no bearing on this Role or any
+# other host-cluster RBAC.) So this grant is not "one more principal equal to existing
+# occupants" -- sandbox-talos has no agent-controlled occupant on the host side for it to be
+# equal to. It is a genuinely new write-capable credential on this host cluster.
+#
+# What actually justifies accepting it, on the correct grounds:
+#   1. Reachability, not equivalence. This capability exists only in a namespace no agent
+#      can reach (`sandbox-lifecycle` -- see namespace.yaml: no ingress rule at all, no
+#      principal, agent or otherwise, that can create a pod there or read its
+#      ServiceAccount's token), held by a ServiceAccount no agent can mount, on a cluster
+#      agents cannot write to at all. The only ways to invoke it are Flux's own scheduled
+#      reconcile of this CronJob and an operator running `kubectl` by hand.
+#   2. Full compromise of vm-rebuilder's access to *this* Role yields: delete talos-vm and
 #      its PVC, read pod logs in this namespace, and run pods in sandbox-talos specifically
-#      (to reach bootstrap-talos-vm). It cannot read a Secret here, and cannot touch this
-#      host cluster's control plane from this namespace. See role-sandbox-lifecycle.yaml for
-#      what compromise of *that* Role additionally yields -- it is not zero, now that a
-#      second grant exists.
+#      (to reach bootstrap-talos-vm) -- reachable only through compromise of vm-rebuilder
+#      itself (its image, its own script), never through anything an agent controls. It
+#      cannot read a Secret here, and cannot touch this host cluster's control plane from
+#      this namespace. See role-sandbox-lifecycle.yaml for what compromise of *that* Role
+#      additionally yields -- it is not zero, now that a second grant exists.
 # The zero-grant variant costs roughly hourly bootstrap cadence instead of triggered-on-
-# demand (~1.2 GB/day of repeated talosctl downloads) to avoid a grant that is already equal
-# to what the namespace's normal occupants hold. If that trade is judged wrong on review, the
-# fix is deleting `create` below and switching rebuild-talos-vm-cronjob.yaml's Step 4 to the
-# poll-based variant -- both are correct, only the standing cost differs.
+# demand (~1.2 GB/day of repeated talosctl downloads) as the standing price of not holding
+# this capability at all. If that trade is judged wrong on review, the fix is deleting
+# `create` below and switching rebuild-talos-vm-cronjob.yaml's Step 4 to the poll-based
+# variant -- both are correct, only the standing cost differs.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/clusters/homelab/services/sandbox-lifecycle/role-sandbox-talos.yaml
+++ b/clusters/homelab/services/sandbox-lifecycle/role-sandbox-talos.yaml
@@ -6,47 +6,53 @@
 # virt-launcher pod name, pods/log:get for the guest console) -- see that file's comments
 # for the full "why", not repeated here.
 #
-# The two rules below it are what talos-vm needs beyond docker-vm, and the second one is
-# the grant most worth scrutinizing in this whole module: talos-vm's rebuild is not
-# complete once qemu is running -- etcd has to be bootstrapped and the agent-admin
-# credential re-minted inside the sandbox cluster's own etcd, and neither can be done from
-# this namespace (sandbox-talos's own NetworkPolicy admits the Talos/sandbox-API ports
-# only from `coder` and `ai` mcp-server pods, never from sandbox-lifecycle -- and it must
-# not, for the same reason this SA doesn't hold a talosconfig or a sandbox kubeconfig
-# anywhere). So the rebuild delegates both steps by *triggering* the CronJobs that hold
-# the right credentials (bootstrap-talos-vm, provision-agent-admin -- see
-# homelab-ops-kubernetes-experiments, experiments/apps/sandbox-talos/lifecycle/) and waiting on
-# their exit codes, never reading a Secret itself. `provision-agent-admin` is that CronJob's
-# name today; `bootstrap-talos-vm` names the CronJob homelab-ops-kubernetes-experiments#227's
-# design calls for `sandbox-talos/lifecycle/bootstrap-job.yaml` (still a one-shot Job as of
-# this module) to become -- forward-declared here on the same PR as the rest of this RBAC, not
-# yet backed by an object with that name. Nothing in this Role depends on it existing yet;
-# it simply grants nothing until it does.
+# The two rules below it are what talos-vm needs beyond docker-vm: etcd has to be
+# bootstrapped after a destroy, and that can't be done from this namespace (sandbox-talos's
+# own NetworkPolicy admits the Talos API only from `coder` and `ai` mcp-server pods, never
+# from sandbox-lifecycle -- and it must not, for the same reason this SA doesn't hold a
+# talosconfig anywhere). So the rebuild delegates by *triggering*
+# sandbox-talos/lifecycle/bootstrap-job.yaml (once it becomes the CronJob named
+# `bootstrap-talos-vm` below -- homelab-ops-kubernetes-experiments#227's design calls for
+# that conversion; it's still a one-shot Job as of this Role, so this grants nothing until
+# it does) and waiting on its exit code, never reading a Secret itself.
+#
+# ONLY ONE TARGET HERE NOW, NOT TWO. `provision-agent-admin` used to be the second one --
+# this Role's `cronjobs` rule granted `get` on it alongside `bootstrap-talos-vm`, because
+# both lived in `sandbox-talos` and both were triggered cross-namespace from here. That
+# CronJob has since moved to the `sandbox-lifecycle` namespace itself
+# (homelab-ops-kubernetes-experiments#230 -- it needs this host cluster's API to relay the
+# agent-admin credential to Bitwarden, which `sandbox-talos` is permanently denied, the same
+# reason this whole module exists outside `sandbox-talos`/`sandbox-docker`). Triggering it is
+# now a same-namespace call from the rebuild pod's own namespace -- see
+# role-sandbox-lifecycle.yaml for that grant. This Role's `cronjobs` rule below dropped
+# `provision-agent-admin` accordingly: **the set of workloads this Role lets vm-rebuilder
+# reach cross-namespace into sandbox-talos narrows from two to one.**
 #
 # `create` on `jobs` cannot be `resourceNames`-scoped -- a Job carries an arbitrary pod
 # template, so this grant is transitively equivalent to running any pod in sandbox-talos,
 # including one that mounts talos-vm-talosconfig (a year-long, effectively unrevocable
-# os:admin client cert). Three things bound accepting that rather than the zero-grant
-# observe-only alternative (poll `kube_job_complete` on a job that started after the
-# recorded destroy timestamp, letting bootstrap-talos-vm/provision-agent-admin run on a
-# much tighter schedule instead of being triggered):
+# os:admin client cert). That raw exposure does NOT shrink just because one fewer workload
+# is triggered through it -- `jobs:create` is still unscoped, same as before. What narrows is
+# the *justification* (one legitimate target, not two) and the RoleBinding's declared intent
+# (this Role, in this namespace, exists solely to reach `bootstrap-talos-vm` now). Three
+# things bound accepting the grant at all, unchanged from before:
 #   1. It grants nothing AI agents don't already hold in sandbox-talos -- that namespace is
 #      defined as the one agents get full write access to (see its own network-policy.yaml
 #      "CAVEAT" annotation), so this creates no new capability *class*, only one more
 #      principal equal to an existing one.
 #   2. vm-rebuilder lives in sandbox-lifecycle, which agents cannot write to -- a
 #      compromised agent does not acquire this SA or its token.
-#   3. Full compromise of vm-rebuilder yields: delete two named VMs/PVCs across two
-#      namespaces, read pod logs in those two namespaces, and run pods in sandbox-talos
-#      specifically. It cannot read a Secret, cannot reach any other namespace, and cannot
-#      touch this host cluster's control plane.
-# The zero-grant variant costs roughly hourly bootstrap/provision cadence instead of
-# triggered-on-demand (~2.4 GB/day of repeated talosctl/kubectl downloads, 24 token mints
-# a day, and a rebuild cycle taking ~65 minutes instead of ~25) to avoid a grant that is
-# already equal to what the namespace's normal occupants hold. If that trade is judged
-# wrong on review, the fix is deleting `create` below and switching
-# rebuild-talos-vm-cronjob.yaml's steps 4-5 to the poll-based variant -- both are correct,
-# only the standing cost differs.
+#   3. Full compromise of vm-rebuilder's access to *this* Role yields: delete talos-vm and
+#      its PVC, read pod logs in this namespace, and run pods in sandbox-talos specifically
+#      (to reach bootstrap-talos-vm). It cannot read a Secret here, and cannot touch this
+#      host cluster's control plane from this namespace. See role-sandbox-lifecycle.yaml for
+#      what compromise of *that* Role additionally yields -- it is not zero, now that a
+#      second grant exists.
+# The zero-grant variant costs roughly hourly bootstrap cadence instead of triggered-on-
+# demand (~1.2 GB/day of repeated talosctl downloads) to avoid a grant that is already equal
+# to what the namespace's normal occupants hold. If that trade is judged wrong on review, the
+# fix is deleting `create` below and switching rebuild-talos-vm-cronjob.yaml's Step 4 to the
+# poll-based variant -- both are correct, only the standing cost differs.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -90,7 +96,6 @@ rules:
   - cronjobs
   resourceNames:
   - bootstrap-talos-vm
-  - provision-agent-admin
   verbs:
   - get
 - apiGroups:


### PR DESCRIPTION
## Summary

Follow-up to #842 (merged), which shipped `role-sandbox-talos.yaml` granting
`vm-rebuilder` a cross-namespace `cronjobs:get`/`jobs:create` reach into
`sandbox-talos` to trigger both `bootstrap-talos-vm` and
`provision-agent-admin`. ppat/homelab-ops-kubernetes-experiments#230 (also
merged via this repo's #845 for its NetworkPolicy half) moves
`provision-agent-admin` out of `sandbox-talos` into `sandbox-lifecycle`
itself — it needs this host cluster's API to relay the minted agent-admin
credential to Bitwarden, the identical reason `sandbox-lifecycle` exists in
the first place. `role-sandbox-talos.yaml`'s grant toward it now targets a
CronJob that isn't there.

Verified directly against #230's actual diff before writing this (not taken
on faith) — `provision-agent-admin-cronjob.yaml` now carries `namespace:
sandbox-lifecycle` and its own dedicated ServiceAccount
(`provision-agent-admin`, distinct from `vm-rebuilder`), with a Role scoped
to `get`/`patch` on exactly one named Secret
(`sandbox-lifecycle/sandbox-talos-agent-admin`).

## What changed

- **`role-sandbox-talos.yaml`**: drops `provision-agent-admin` from the
  `cronjobs` rule's `resourceNames` (keeps `bootstrap-talos-vm` only).
  **This narrows the set of workloads `vm-rebuilder` can trigger
  cross-namespace into `sandbox-talos` from two to one** — worth stating
  plainly since `sandbox-talos` is the boundary that matters most here (the
  namespace AI agents hold full write in). The `jobs:create` verb itself
  doesn't shrink (still unscoped, unavoidably, same as before) — what
  narrows is the number of legitimate targets and the RoleBinding's declared
  intent.
- **New `role-sandbox-lifecycle.yaml`**: a same-namespace grant
  (`cronjobs:get[provision-agent-admin]`, `jobs:create/get/list`) bound to
  `vm-rebuilder` in its own namespace, replacing what the dropped rule used
  to cover.

**Is this a net reduction in grants? No, stated plainly rather than
glossed over.** The cross-namespace reach into `sandbox-talos` narrows, but
a new (same-shaped) `jobs:create` grant now exists in `sandbox-lifecycle`
too — total grant count doesn't shrink. It's a smaller blast radius than the
grant it replaces would have been (this namespace holds no talosconfig, no
year-long client cert, nothing `sandbox-talos` does), but it isn't zero:
`jobs:create` can't be scoped to "only trigger `provision-agent-admin`", so
a compromised `vm-rebuilder` could create a Job in this namespace requesting
`serviceAccountName: provision-agent-admin` and reach the one Secret that
identity holds `get`/`patch` on. Documented in `role-sandbox-lifecycle.yaml`'s
own comment as accepted, not closed — same shape of trade
`role-sandbox-talos.yaml` already makes for its own `jobs:create`.

## Consuming PR

ppat/homelab-ops-kubernetes-experiments#233 (not yet merged) assumes this
placement — its `rebuild-talos-vm-cronjob.yaml` Step 5 now targets
`-n sandbox-lifecycle` for `provision-agent-admin` (previously
`sandbox-talos`, corrected in the same round as this PR). That PR's manifests
are independent of this one's merge order (no shared files, different
repos), but its RBAC assumptions depend on this PR's shape landing as
written here.

## Test plan

- [x] `pre-commit run --all-files` clean (yamllint, markdownlint, shellcheck,
      kubeconform)
- [x] `kubectl kustomize clusters/homelab/services/sandbox-lifecycle` and the
      full `clusters/homelab` tree both build cleanly; confirmed the new
      Role/RoleBinding render with no name collision against #230's own
      `provision-agent-admin` Role/RoleBinding (different names, same
      namespace, applied by different Kustomizations/repos — a normal,
      already-established pattern here)
- [ ] Live reconcile (out of scope for this session — no destroy was
      performed against either sandbox VM)