### PR TITLE
docs(cluster-homelab): correct stale and overclaimed sandbox/KubeVirt statements

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -482,8 +482,9 @@ kubectl label node beelink-ser8-1 homelab-ops.internal/virtualization-
 
 ### 6. Sequencing hazard: label before `infra-virtualization-core` reconciles
 
-**As of this writing, no node carries `homelab-ops.internal/virtualization=enabled`
-yet** — step 2 above is written but not yet applied. If the
+**Both target nodes now carry `homelab-ops.internal/virtualization=enabled`** —
+step 2 above has been applied to `beelink-ser8-1` and `minisforum-nab9-1`, so
+this hazard is live only for a node added or rebuilt later. If the
 `infra-virtualization-core` `Kustomization` reconciles first, `virt-handler` has
 nowhere to schedule and the `KubeVirt` custom resource sits un-`Deployed`
 indefinitely. From the outside that looks identical to a real failure
@@ -503,7 +504,9 @@ belong in this file (see this file's own opening paragraph).
 - **The runbook and its reasoning:**
   [`experiments/apps/sandbox-talos/OPERATIONS.md`](https://github.com/ppat/homelab-ops-kubernetes-experiments/blob/main/experiments/apps/sandbox-talos/OPERATIONS.md)
 - **The runnable task itself** (`mise run build-containerdisk`), not a script in a fence:
-  [`experiments/apps/sandbox-talos/mise.toml`](https://github.com/ppat/homelab-ops-kubernetes-experiments/blob/main/experiments/apps/sandbox-talos/mise.toml)
+  [`experiments/apps/image-builder/mise.toml`](https://github.com/ppat/homelab-ops-kubernetes-experiments/blob/main/experiments/apps/image-builder/mise.toml)
+  — it lives in `image-builder/`, not `sandbox-talos/`, and the primary way it runs today is
+  in-cluster via that module's `CronJob`; the by-hand run on the Docker VM is the fallback
 - **Where it actually runs, and why**, plus the mise base/per-use-case split and the per-build
   setup sequence:
   [`experiments/apps/docker-host/OPERATIONS.md`](https://github.com/ppat/homelab-ops-kubernetes-experiments/blob/main/experiments/apps/docker-host/OPERATIONS.md)
@@ -589,11 +592,17 @@ kubectl run netpol-baseline --rm -it --restart=Never -n sandbox-docker \
 ```
 
 (swap `sandbox-docker`/its node-IP-only targets for `sandbox-talos` — same
-target list plus `docker-vm.sandbox-docker.svc.cluster.local:22`, which is
-expected to fail DNS resolution until Phase 4 creates that Service — to
-baseline the other namespace).
+target list plus `docker-vm.sandbox-docker.svc.cluster.local:22` — to baseline
+the other namespace. That one target is the exception to the expectation
+below, and it is the only one: it now *resolves* (the Service exists), but it
+must still fail to connect even at baseline, because what denies it is
+`sandbox-docker`'s own default-deny `NetworkPolicy`, whose sole ingress allow
+is the `coder` namespace — and this procedure removes `sandbox-talos`'s
+policy, not that one. Two independent policies deny that path; the baseline
+only lifts one of them.)
 
-**Expected result: every target above connects (or resolves) successfully.**
+**Expected result: every target above connects (or resolves) successfully**
+(except the cross-namespace one just noted).
 A connection failure here means the probe target itself is wrong (bad IP,
 bad port, a target that was never reachable in the first place, i.e. not
 actually exposed on a node IP) — fix
@@ -794,14 +803,20 @@ pre-explained here so it reads as expected behavior, not a bug to debug.
 `kubectl port-forward` is the supported substitute — a completely different mechanism, not
 subject to that NetworkPolicy: containerd's CRI implementation enters the *pod's own*
 network namespace and dials `localhost`, so it never reaches the veth where policy is
-enforced. Target the VM's `virt-launcher` pod directly by its standard KubeVirt label
-(`kubevirt.io/domain=<vm-name>`) — substitute the actual VM name once the VM workload
-manifests (a separate, not-yet-merged phase) exist:
+enforced. Target the VM's `virt-launcher` pod directly by the KubeVirt label
+`vm.kubevirt.io/name=<vm-name>` — the VM workload manifests live in the experiments repo
+and are deployed, and the VM names are `talos-vm` and `docker-vm`.
+
+**Not `kubevirt.io/domain`, which is an annotation on that pod, not a label** — measured on
+both live `virt-launcher` pods. `-l kubevirt.io/domain=talos-vm` therefore matches nothing
+and the `$(...)` below expands to an empty string, so `port-forward` fails with a usage
+error rather than anything that points at the real cause. The labels KubeVirt actually sets
+are `vm.kubevirt.io/name`, `vmi.kubevirt.io/id` and `kubevirt.io=virt-launcher`.
 
 ```bash
 # Talos API (talosctl, :50000) -- sandbox-talos namespace
 kubectl port-forward -n sandbox-talos \
-  "$(kubectl get pod -n sandbox-talos -l kubevirt.io/domain=<talos-vm-name> -o name)" \
+  "$(kubectl get pod -n sandbox-talos -l vm.kubevirt.io/name=talos-vm -o name)" \
   50000:50000
 # then point talosctl at the forwarded port:
 talosctl --talosconfig <path> config endpoint 127.0.0.1
@@ -809,17 +824,16 @@ talosctl --talosconfig <path> config node 127.0.0.1
 
 # Sandbox Kubernetes API (:6443) -- sandbox-talos namespace
 kubectl port-forward -n sandbox-talos \
-  "$(kubectl get pod -n sandbox-talos -l kubevirt.io/domain=<talos-vm-name> -o name)" \
+  "$(kubectl get pod -n sandbox-talos -l vm.kubevirt.io/name=talos-vm -o name)" \
   6443:6443
 # then point kubectl at it -- set `server: https://127.0.0.1:6443` in that sandbox
 # cluster's own kubeconfig, not this cluster's.
 
-# SSH to the Docker VM (:22) -- sandbox-docker namespace. cronjob-netpol-falsifiability-
-# probe.yaml's DOCKER_SSH_SERVICE already anticipates this landing as a Service named
-# docker-vm -- once Phase 4 creates it, `svc/docker-vm` replaces the pod lookup below.
-kubectl port-forward -n sandbox-docker \
-  "$(kubectl get pod -n sandbox-docker -l kubevirt.io/domain=<docker-vm-name> -o name)" \
-  2222:22
+# SSH to the Docker VM (:22) -- sandbox-docker namespace. sandbox-talos's
+# deployment-netpol-falsifiability-probe.yaml probes this same Service by name as its
+# cross-namespace deny check; it exists now, so `svc/docker-vm` works here too and is
+# preferable to the pod lookup -- it survives the VM being destroyed and rebuilt.
+kubectl port-forward -n sandbox-docker svc/docker-vm 2222:22
 ssh -p 2222 <user>@127.0.0.1
 ```
 

--- a/clusters/homelab/kustomizations/config-services-image-builder.yaml
+++ b/clusters/homelab/kustomizations/config-services-image-builder.yaml
@@ -14,9 +14,9 @@ spec:
   # config-services-sandbox-docker.yaml: a brand-new namespace's own manifests failing to
   # apply (e.g. before this namespace exists at all, on first merge) must not fail the
   # shared Kustomization that ai/dns/downloaders/logging/longhorn-system/monitoring/
-  # tailscale also reconcile through. 15m0s, not those two's 1m0s -- neither the "AI agents
-  # have full write access" nor the "fronts a real dockerd" reasoning that justifies their
-  # fast drift-correction interval applies here.
+  # tailscale also reconcile through. 15m0s, not those two's 1m0s -- neither the "hosts a
+  # VM whose guest AI agents have full write access to" nor the "fronts a real dockerd"
+  # reasoning that justifies their fast drift-correction interval applies here.
   interval: 15m0s
   path: ./clusters/homelab/services/image-builder
   prune: true

--- a/clusters/homelab/services/sandbox-talos/deployment-netpol-falsifiability-probe.yaml
+++ b/clusters/homelab/services/sandbox-talos/deployment-netpol-falsifiability-probe.yaml
@@ -10,12 +10,13 @@
 #
 # One probe here has no sandbox-docker equivalent: reachability of the Docker namespace's
 # SSH Service from this namespace, which is the one that must NEVER pass -- see
-# network-policy.yaml for why. That Service doesn't exist until Phase 4 creates the
-# dockerd VM, so the probe below treats "name doesn't resolve yet" as SKIP rather than
-# a violation: this Deployment has to make sense with no VM ever built (an unresolvable
-# name isn't evidence the policy works, it's evidence there's nothing there yet), and it
-# starts actually asserting the moment Phase 4 creates a Service at DOCKER_SSH_SERVICE
-# below with no change needed here. Update the env var if Phase 4 names it differently.
+# network-policy.yaml for why. That Service now exists -- `docker-vm` in sandbox-docker,
+# the exact name DOCKER_SSH_SERVICE below was written to anticipate -- so this check
+# resolves and asserts on every cycle rather than skipping. The SKIP-on-unresolvable
+# branch below stays anyway: it has to hold whenever that Service is absent (a
+# destroy-and-rebuild window, or a cluster where the dockerd VM was never built), because
+# an unresolvable name isn't evidence the policy works, it's evidence there's nothing
+# there. Update the env var if that Service is ever renamed.
 #
 # A second probe here also has no sandbox-docker equivalent, and for a sharper reason than
 # "no such need there": same-namespace reachability of this VM's own Service, on both
@@ -84,8 +85,8 @@ spec:
           # it and the ipBlock allow actually applies.
           value: "192.168.8.192"
         - name: DOCKER_SSH_SERVICE
-          # Anticipated name/port of the Service Phase 4 fronts dockerd's SSH with, in the
-          # sandbox-docker namespace. Doesn't exist yet -- see the file-level comment above.
+          # Name/port of the Service fronting dockerd's SSH in the sandbox-docker namespace.
+          # Live today -- see the file-level comment above for what happens when it isn't.
           value: "docker-vm.sandbox-docker.svc.cluster.local"
         - name: DOCKER_SSH_PORT
           value: "22"
@@ -272,9 +273,9 @@ spec:
           # See sandbox-docker's copy of this Deployment for the full rationale (Fix 2):
           # catches the probe loop hanging mid-cycle on something with no timeout of its
           # own (the plain `nslookup api.github.com` call above, or -- unique to this
-          # namespace -- a DNS lookup on DOCKER_SSH_SERVICE before Phase 4 creates that
-          # Service, though `nslookup` failing fast on NXDOMAIN is the expected case there,
-          # not a hang). Every `nc` call in this script is `-w`-bounded, so a hung `nc`
+          # namespace -- a DNS lookup on DOCKER_SSH_SERVICE during a window where that
+          # Service is absent, though `nslookup` failing fast on NXDOMAIN is the expected
+          # case there, not a hang). Every `nc` call is `-w`-bounded, so a hung `nc`
           # can't happen here either. `exec: ["true"]` would satisfy Kyverno's
           # require-pod-probes policy too, and would detect nothing; this is deliberately
           # not that.


### PR DESCRIPTION
Adversarial audit of markdown docs and YAML comments for claims that would mislead a
future reader, focused on everything the recent sandbox/KubeVirt work touched.

Every correction below was **measured** — against the live cluster, the live probe log,
or the sibling repos' actual tree — not reasoned from surrounding text.

## Fixed here

| Where | Was | Now |
| --- | --- | --- |
| `clusters/homelab/services/sandbox-lifecycle/namespace.yaml` | "both are namespaces AI agents can create pods in" | agents have full write access *inside* each sandbox's guest; they hold no write access to this host cluster in any namespace. What disqualifies those two namespaces is the agent-controlled guest behind their pod network, not RBAC an agent holds here. |
| `clusters/homelab/kustomizations/config-services-image-builder.yaml` | quoted `"AI agents have full write access"` as sandbox-talos's 1m0s justification | `"hosts a VM whose guest AI agents have full write access to"` |
| `OPERATIONS.md` §6 sequencing hazard | "no node carries `homelab-ops.internal/virtualization=enabled` yet — step 2 is written but not yet applied" | both target nodes carry it (measured); the hazard is live only for a node added or rebuilt later |
| `OPERATIONS.md` containerDisk runbook pointer | `experiments/apps/sandbox-talos/mise.toml` | `experiments/apps/image-builder/mise.toml` — the file moved, and the in-cluster CronJob is now the primary path with the by-hand run as fallback |
| `OPERATIONS.md` "reach the sandbox VMs" | "substitute the actual VM name once the VM workload manifests (a separate, not-yet-merged phase) exist" | the manifests are deployed; the names are `talos-vm` and `docker-vm` |
| `clusters/homelab/services/sandbox-talos/deployment-netpol-falsifiability-probe.yaml` (3 places) + `OPERATIONS.md` baseline step | `docker-vm` Service "doesn't exist until Phase 4 creates it" | it exists and the probe asserts `BLOCKED (ok)` against it every cycle (live probe log). The SKIP-on-unresolvable branch is kept and re-justified for a destroy-and-rebuild window instead of for a VM that was never built. |

## Not touched, deliberately

The same false agent-access claim survives in files that in-flight PRs are actively
editing (#846, #849, #850) — reported separately rather than edited here, to avoid a
collision. Likewise one `Phase 4` claim inside #836's own OPERATIONS.md hunk.

Docs and comments only — no rule, RBAC, or manifest behaviour changed.
