### PR TITLE
fix(cluster-homelab): constrain sandbox VM volumes to virtualization nodes

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -202,12 +202,31 @@ ssh beelink-ser8-1 'sudo install -o root -g root -m 0644 -D /tmp/90-kubevirt.yam
 #    time and both nodes are already registered.
 kubectl label node beelink-ser8-1 homelab-ops.internal/virtualization=enabled
 
-# Repeat both steps for minisforum-nab9-1.
+# 3. Tag the node in Longhorn. Longhorn node tags live on the nodes.longhorn.io
+#    CR and are NOT managed in git -- this is a second piece of out-of-band
+#    node state that must stay in step with the label above.
+#    sc-longhorn-local-non-replicated-ephemeral carries nodeSelector:
+#    "virtualization", so Longhorn will only place a sandbox VM's disk replica
+#    on a node carrying this tag. Note --type=merge REPLACES the whole tag
+#    list; read spec.tags first if the node already has others.
+kubectl -n longhorn-system patch nodes.longhorn.io beelink-ser8-1 \
+  --type=merge -p '{"spec":{"tags":["virtualization"]}}'
+
+# Repeat all three steps for minisforum-nab9-1.
 ```
 
 No `kubectl cordon`, no `systemctl stop/start k3s` — this path makes no
 change that a running k3s process, or anything scheduled on the node, would
 ever observe.
+
+**The label and the Longhorn tag are a pair, and the pairing is asymmetric.**
+Tag only nodes that also carry the label — never the reverse. A node that is
+labelled but untagged is harmless (the VM may run there; Longhorn just won't
+put a disk there). A node that is tagged but *not* labelled lets Longhorn
+place a VM's disk on a node the VM's own `nodeSelector` forbids it to run on,
+which pins the resulting PV's `nodeAffinity` to an unusable node and leaves
+the VM permanently unschedulable. See the reasoning block in
+`clusters/homelab/storage/infra/sc/sc-longhorn-local-non-replicated-ephemeral.yaml`.
 
 #### Path B — a fresh or rebuilt node
 
@@ -254,7 +273,21 @@ third node added to the KubeVirt pool later.
    below was verified against stock Ubuntu kernel packaging on these two
    specific nodes — confirm it still holds on whatever base image actually
    provisioned this one before assuming it for granted.
-5. `kubectl uncordon <node>` if step 1 applied.
+5. Tag the node in Longhorn. Unlike the k3s node label, this has no
+   registration-time equivalent — Longhorn creates the `nodes.longhorn.io`
+   CR itself with an empty `spec.tags`, so this step is manual on *both*
+   paths, and it must happen before any sandbox VM PVC is created against
+   `sc-longhorn-local-non-replicated-ephemeral`:
+
+   ```bash
+   kubectl -n longhorn-system patch nodes.longhorn.io <node> \
+     --type=merge -p '{"spec":{"tags":["virtualization"]}}'
+   ```
+
+   Only do this on a node that also carries the
+   `homelab-ops.internal/virtualization` label — see the asymmetry note at
+   the end of Path A for what breaks otherwise.
+6. `kubectl uncordon <node>` if step 1 applied.
 
 **Caveat verified against current k3s docs, and it's why Path A and Path B
 differ:** k3s's `--node-label` (and therefore the `config.yaml.d`
@@ -266,7 +299,9 @@ Both target nodes are already registered, so the drop-in alone will
 `kubectl label` step); a genuinely fresh or rejoining node picks it up
 automatically at registration (Path B's reason it doesn't need that step).
 Keep the drop-in and the `kubectl label` in sync on already-registered nodes
-— if one is ever removed, remove the other too.
+— if one is ever removed, remove the other too, and remove the Longhorn node
+tag first. Dropping the label while the tag remains is the one ordering that
+recreates the unschedulable-VM deadlock described in Path A.
 
 #### Why no kernel-module persistence step
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -283,17 +283,14 @@ third node added to the KubeVirt pool later.
    below was verified against stock Ubuntu kernel packaging on these two
    specific nodes — confirm it still holds on whatever base image actually
    provisioned this one before assuming it for granted.
-5. Tag the node in Longhorn, via git. Add
-   `clusters/homelab/storage/infra/node/<node-name>.yaml` (copy an existing
-   one — they are three lines of `spec` plus the reasoning header) and list
+5. Tag the node in Longhorn, via git — but **not yet**. Read the ordering
+   warning below first; getting this step early is the one mistake in this
+   runbook that permanently breaks a node.
+
+   Add `clusters/homelab/storage/infra/node/<node-name>.yaml` (copy an
+   existing one — three lines of `spec` plus the reasoning header) and list
    it in that directory's `kustomization.yaml`. The `config-storage`
    `Kustomization` applies it.
-
-   Wait for Longhorn to have created the node's own `nodes.longhorn.io` CR
-   first — it does that automatically once `longhorn-manager` runs on the
-   new node. Applying the tag manifest before that point creates a partial
-   `Node` object that Longhorn did not author; see the manifests' own
-   comments for why that is worth avoiding.
 
    The tag must be present before any sandbox VM PVC is created against
    `sc-longhorn-local-non-replicated-ephemeral` — Longhorn rejects volume
@@ -303,6 +300,41 @@ third node added to the KubeVirt pool later.
    `homelab-ops.internal/virtualization` label — see the asymmetry note at
    the end of Path A for what breaks otherwise.
 6. `kubectl uncordon <node>` if step 1 applied.
+
+#### Never add a node's tag manifest before Longhorn has created its CR
+
+This is the ordering hazard in step 5, and it is worth stating on its own
+because the damage is silent and permanent.
+
+**Correct order:** bring the node up and let it register → wait for
+`longhorn-manager` to create its `nodes.longhorn.io` CR → verify the CR
+exists → *then* add the tag manifest and merge.
+
+```bash
+# The gate. Do not add the manifest until this returns the node.
+kubectl -n longhorn-system get nodes.longhorn.io <node>
+```
+
+**Why the order matters.** `longhorn-manager` bootstraps a node with
+Get-then-Create (`app/daemon.go`, `initDaemonNode`): it looks for an existing
+`Node` object and only calls `CreateDefaultNode` if there isn't one. If Flux
+has already applied a tag manifest, that Get *succeeds* against a CR Longhorn
+never authored, so `CreateDefaultNode` never runs. The node is then left with
+`spec.name: ""`, `allowScheduling: false`, and **no default disk** — it
+contributes zero storage, permanently. There is no repair path:
+`CreateDefaultNode` is once-per-node by design, and it does not retry.
+
+It also resists being fixed by hand. The validating webhook rejects `Update`
+requests whose `spec.name` is empty, so the wedged object refuses the very
+patch that would repair it. Nothing prevents Flux creating it in the first
+place either — the CRD marks no `spec` field as required, and the webhook's
+`Create` path does not check `spec.name`.
+
+Recovery, if it happens: delete the partial CR
+(`kubectl -n longhorn-system delete nodes.longhorn.io <node>`) and restart
+that node's `longhorn-manager` pod so `initDaemonNode` runs again and finds
+nothing — but remove the manifest from git first, or Flux will simply
+recreate the partial object and you will be back where you started.
 
 **Caveat verified against current k3s docs, and it's why Path A and Path B
 differ:** k3s's `--node-label` (and therefore the `config.yaml.d`

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -202,22 +202,26 @@ ssh beelink-ser8-1 'sudo install -o root -g root -m 0644 -D /tmp/90-kubevirt.yam
 #    time and both nodes are already registered.
 kubectl label node beelink-ser8-1 homelab-ops.internal/virtualization=enabled
 
-# 3. Tag the node in Longhorn. Longhorn node tags live on the nodes.longhorn.io
-#    CR and are NOT managed in git -- this is a second piece of out-of-band
-#    node state that must stay in step with the label above.
-#    sc-longhorn-local-non-replicated-ephemeral carries nodeSelector:
-#    "virtualization", so Longhorn will only place a sandbox VM's disk replica
-#    on a node carrying this tag. Note --type=merge REPLACES the whole tag
-#    list; read spec.tags first if the node already has others.
-kubectl -n longhorn-system patch nodes.longhorn.io beelink-ser8-1 \
-  --type=merge -p '{"spec":{"tags":["virtualization"]}}'
-
-# Repeat all three steps for minisforum-nab9-1.
+# Repeat both steps for minisforum-nab9-1.
 ```
 
 No `kubectl cordon`, no `systemctl stop/start k3s` — this path makes no
 change that a running k3s process, or anything scheduled on the node, would
 ever observe.
+
+Then give the node its Longhorn tag — **in git, not by hand**:
+
+```yaml
+# clusters/homelab/storage/infra/node/<node-name>.yaml
+# (add the filename to that directory's kustomization.yaml too)
+```
+
+`sc-longhorn-local-non-replicated-ephemeral` carries
+`nodeSelector: "virtualization"`, so Longhorn will only place a sandbox VM's
+disk replica on a node carrying that tag. The tag is declared declaratively
+per node in `clusters/homelab/storage/infra/node/` and applied by the
+`config-storage` Flux `Kustomization` — see the reasoning block in any of
+those manifests for why they declare `spec.tags` and nothing else.
 
 **The label and the Longhorn tag are a pair, and the pairing is asymmetric.**
 Tag only nodes that also carry the label — never the reverse. A node that is
@@ -227,6 +231,12 @@ place a VM's disk on a node the VM's own `nodeSelector` forbids it to run on,
 which pins the resulting PV's `nodeAffinity` to an unusable node and leaves
 the VM permanently unschedulable. See the reasoning block in
 `clusters/homelab/storage/infra/sc/sc-longhorn-local-non-replicated-ephemeral.yaml`.
+
+The two halves live in different places on purpose and that is the drift
+risk: the label is hand-applied node prep (k3s only reads `node-label+` at
+registration), while the tag is GitOps. Adding a node to the KubeVirt pool
+means doing **both** — the `kubectl label` above *and* a PR adding the node's
+tag manifest. Neither one alone is a working node.
 
 #### Path B — a fresh or rebuilt node
 
@@ -273,18 +283,23 @@ third node added to the KubeVirt pool later.
    below was verified against stock Ubuntu kernel packaging on these two
    specific nodes — confirm it still holds on whatever base image actually
    provisioned this one before assuming it for granted.
-5. Tag the node in Longhorn. Unlike the k3s node label, this has no
-   registration-time equivalent — Longhorn creates the `nodes.longhorn.io`
-   CR itself with an empty `spec.tags`, so this step is manual on *both*
-   paths, and it must happen before any sandbox VM PVC is created against
-   `sc-longhorn-local-non-replicated-ephemeral`:
+5. Tag the node in Longhorn, via git. Add
+   `clusters/homelab/storage/infra/node/<node-name>.yaml` (copy an existing
+   one — they are three lines of `spec` plus the reasoning header) and list
+   it in that directory's `kustomization.yaml`. The `config-storage`
+   `Kustomization` applies it.
 
-   ```bash
-   kubectl -n longhorn-system patch nodes.longhorn.io <node> \
-     --type=merge -p '{"spec":{"tags":["virtualization"]}}'
-   ```
+   Wait for Longhorn to have created the node's own `nodes.longhorn.io` CR
+   first — it does that automatically once `longhorn-manager` runs on the
+   new node. Applying the tag manifest before that point creates a partial
+   `Node` object that Longhorn did not author; see the manifests' own
+   comments for why that is worth avoiding.
 
-   Only do this on a node that also carries the
+   The tag must be present before any sandbox VM PVC is created against
+   `sc-longhorn-local-non-replicated-ephemeral` — Longhorn rejects volume
+   creation outright if a referenced tag exists on no node.
+
+   Only tag a node that also carries the
    `homelab-ops.internal/virtualization` label — see the asymmetry note at
    the end of Path A for what breaks otherwise.
 6. `kubectl uncordon <node>` if step 1 applied.
@@ -299,9 +314,15 @@ Both target nodes are already registered, so the drop-in alone will
 `kubectl label` step); a genuinely fresh or rejoining node picks it up
 automatically at registration (Path B's reason it doesn't need that step).
 Keep the drop-in and the `kubectl label` in sync on already-registered nodes
-— if one is ever removed, remove the other too, and remove the Longhorn node
+— if one is ever removed, remove the other too, and retire the Longhorn node
 tag first. Dropping the label while the tag remains is the one ordering that
 recreates the unschedulable-VM deadlock described in Path A.
+
+Retiring the tag is **not** just deleting the manifest: `prune` is patched to
+`false` for every `Kustomization` in this cluster (see
+`clusters/homelab/kustomization.yaml`), so removing the file leaves the tag
+in place on the live object. Clear `spec.tags` to `[]` in the manifest, let
+Flux apply it, and only then delete the file.
 
 #### Why no kernel-module persistence step
 

--- a/clusters/homelab/kustomizations/config-storage.yaml
+++ b/clusters/homelab/kustomizations/config-storage.yaml
@@ -17,6 +17,22 @@ spec:
     namespace: flux-system
   timeout: 2m0s
   wait: true
+  # Decouples this Kustomization's health gate from Longhorn node health. wait: true makes
+  # kstatus assess every applied object, and the nodes.longhorn.io CRs under
+  # storage/infra/node/ carry a status condition of type Ready that kstatus matches -- so
+  # without this, one node going NotReady would fail all of config-storage (StorageClasses,
+  # PVs, PVCs, RecurringJobs), not just that object. That coupling is not something this
+  # Kustomization ever asked for; it only appeared because those manifests introduced a
+  # Ready-bearing kind into it. A literal "true" says plainly that Flux does not gate on
+  # these objects' health, rather than string-matching a condition we do not own -- node
+  # health is Longhorn's to report and ours to alert on, not Flux's to block reconciliation
+  # over. Defining current for a kind REPLACES kstatus's built-in readiness check for it;
+  # matching is by API group + kind, so this affects only longhorn.io Node objects and not
+  # the RecurringJob CRs applied alongside them (nor core v1 Node, a different group).
+  healthCheckExprs:
+  - apiVersion: longhorn.io/v1beta2
+    kind: Node
+    current: "true"
   postBuild:
     substituteFrom:
     - kind: Secret

--- a/clusters/homelab/storage/infra/node/beelink-ser8-1.yaml
+++ b/clusters/homelab/storage/infra/node/beelink-ser8-1.yaml
@@ -1,0 +1,63 @@
+---
+# Gives this node the "virtualization" Longhorn node tag, which is what
+# sc-longhorn-local-non-replicated-ephemeral's nodeSelector parameter matches on. Longhorn
+# will only place a sandbox VM's disk replica on a node carrying it; see that StorageClass
+# for the full reasoning and for what breaks if this tag and the node's
+# homelab-ops.internal/virtualization label ever disagree.
+#
+# THIS OBJECT IS NOT OURS, AND THERE IS NO SAFETY NET. Unlike every other manifest under
+# storage/infra/, Longhorn creates one nodes.longhorn.io CR per Kubernetes node itself and
+# owns it -- Flux is patching a pre-existing, foreign-owned object, not creating one. And
+# kustomize-controller applies with client.ForceOwnership set unconditionally
+# (fluxcd/pkg ssa/manager_apply.go), so it does not merely request the fields it declares:
+# it *seizes* them from whichever manager held them, with no conflict error to warn you.
+# That is what makes this manifest work at all -- longhorn-manager already owned spec.tags
+# (as an empty list), so without force the apply would fail -- and it is exactly why the
+# next rule is absolute:
+#
+#   DECLARE spec.tags AND NOTHING ELSE.
+#
+# Server-side apply gives an applier ownership of only the fields it specifies; fields it
+# omits stay owned by whoever set them. That -- not any annotation -- is what leaves
+# Longhorn's spec.disks (disk paths, storageReserved, per-disk tags), spec.allowScheduling,
+# spec.evictionRequested, spec.instanceManagerCPURequest and spec.name untouched and still
+# owned by longhorn-manager. Add any one of them here and Flux silently takes it over and
+# pins live storage state to whatever got hardcoded. To change a disk, change it in
+# Longhorn, not here.
+#
+# What kustomize.toolkit.fluxcd.io/ssa: Merge actually does -- read this before assuming.
+# It does NOT mean "merge my fields into the live object and leave the rest alone"; the
+# fields this manifest declares are still applied wholesale (Flux docs: "The fields defined
+# in the manifests applied by the controller will always be overridden"). It means this
+# object is excluded from kustomize-controller's metadata *cleanup* step, which otherwise
+# strips kubectl.kubernetes.io/last-applied-configuration and rewrites managedFields
+# entries for disallowed field managers. These CRs carry no last-applied-configuration
+# today, so it is a no-op right now; it is here as a guard for the day someone runs a
+# client-side `kubectl apply` against one, because that cleanup path is the known mechanism
+# by which Flux prunes fields it never declared. Keep it, but do not mistake it for the
+# thing protecting spec.disks -- that is the "declare nothing else" rule above. The value
+# is matched case-insensitively (strings.EqualFold), so "merge" also works; don't "fix" it.
+#
+# spec.tags is an atomic list (the CRD sets no x-kubernetes-list-type), so it is owned
+# whole, not per-element. Every tag this node should carry must be listed here; a tag added
+# out-of-band via the Longhorn UI or kubectl is reverted on the next reconcile.
+#
+# Two lifecycle gotchas:
+#  - prune is patched to false for every Kustomization in this cluster (see
+#    clusters/homelab/kustomization.yaml), so deleting this file does NOT untag the node --
+#    it just stops managing it, stranding the tag. To retire a node from the VM pool, set
+#    tags to [] here first, let Flux apply it, then delete the file.
+#  - On a brand-new node, wait for longhorn-manager to create the node's CR before adding
+#    its manifest here. The CRD marks no spec field required, so Flux would happily create
+#    a partial Node object that Longhorn never authored -- no spec.name, no spec.disks --
+#    rather than failing loudly. Add the node to the pool after it is registered.
+apiVersion: longhorn.io/v1beta2
+kind: Node
+metadata:
+  name: beelink-ser8-1
+  namespace: longhorn-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: Merge
+spec:
+  tags:
+  - virtualization

--- a/clusters/homelab/storage/infra/node/beelink-ser8-1.yaml
+++ b/clusters/homelab/storage/infra/node/beelink-ser8-1.yaml
@@ -42,15 +42,37 @@
 # whole, not per-element. Every tag this node should carry must be listed here; a tag added
 # out-of-band via the Longhorn UI or kubectl is reverted on the next reconcile.
 #
-# Two lifecycle gotchas:
+# Lifecycle gotchas. The first one can permanently break a node -- read it before adding a
+# manifest for a new one:
+#
+#  - NEVER add a node's manifest here before longhorn-manager has created that node's CR.
+#    longhorn-manager bootstraps a node with Get-then-Create (app/daemon.go,
+#    initDaemonNode): if a Node object is already present it skips CreateDefaultNode
+#    entirely. A CR that Flux created first therefore leaves the node with spec.name "",
+#    allowScheduling false, and NO default disk -- contributing zero storage, permanently,
+#    with no repair path (CreateDefaultNode is once-per-node by design). It then gets
+#    harder to fix, not easier: the validating webhook rejects Updates whose spec.name is
+#    empty, so the wedged object resists being patched back into shape. Nothing stops Flux
+#    creating it either -- the CRD marks no spec field required and the webhook's Create
+#    path does not check spec.name. Wait for the node to register, confirm its CR exists,
+#    then add the file.
 #  - prune is patched to false for every Kustomization in this cluster (see
 #    clusters/homelab/kustomization.yaml), so deleting this file does NOT untag the node --
 #    it just stops managing it, stranding the tag. To retire a node from the VM pool, set
-#    tags to [] here first, let Flux apply it, then delete the file.
-#  - On a brand-new node, wait for longhorn-manager to create the node's CR before adding
-#    its manifest here. The CRD marks no spec field required, so Flux would happily create
-#    a partial Node object that Longhorn never authored -- no spec.name, no spec.disks --
-#    rather than failing loudly. Add the node to the pool after it is registered.
+#    tags to [] here, let Flux apply that, then delete the file. Do not instead delete the
+#    spec.tags key while keeping the file: once Flux is sole owner of a field, dropping it
+#    from the manifest makes SSA *delete* it from the live object -- a different and much
+#    less obvious operation than setting it empty.
+#  - config-storage sets wait: true, so kstatus health-checks every object it applies,
+#    these included. The Longhorn Node CR carries a status condition of type Ready, which
+#    kstatus matches -- so a node going NotReady now fails the entire config-storage
+#    Kustomization (timeout 2m0s), not merely this object. That coupling did not exist
+#    before these manifests were added. Longhorn's validator also rejects updates with 403
+#    while a node's disk spec and status are mid-sync, so transient apply failures here are
+#    expected rather than alarming.
+#  - If a node ever needs more than one tag, write the list pre-sorted alphabetically:
+#    Longhorn's mutating webhook sorts spec.tags on every write, so an unsorted manifest
+#    reconciles into a permanent drift loop.
 apiVersion: longhorn.io/v1beta2
 kind: Node
 metadata:

--- a/clusters/homelab/storage/infra/node/beelink-ser8-1.yaml
+++ b/clusters/homelab/storage/infra/node/beelink-ser8-1.yaml
@@ -63,13 +63,14 @@
 #    spec.tags key while keeping the file: once Flux is sole owner of a field, dropping it
 #    from the manifest makes SSA *delete* it from the live object -- a different and much
 #    less obvious operation than setting it empty.
-#  - config-storage sets wait: true, so kstatus health-checks every object it applies,
-#    these included. The Longhorn Node CR carries a status condition of type Ready, which
-#    kstatus matches -- so a node going NotReady now fails the entire config-storage
-#    Kustomization (timeout 2m0s), not merely this object. That coupling did not exist
-#    before these manifests were added. Longhorn's validator also rejects updates with 403
-#    while a node's disk spec and status are mid-sync, so transient apply failures here are
-#    expected rather than alarming.
+#  - config-storage sets wait: true, so kstatus would normally assess every object it
+#    applies -- and this CR carries a status condition of type Ready that kstatus matches,
+#    which would have made one node going NotReady fail the entire config-storage
+#    Kustomization rather than just this object. That is why config-storage now carries a
+#    healthCheckExprs entry for longhorn.io Node pinning current to "true"; see the comment
+#    there. If that entry is ever removed, this coupling comes straight back. Separately,
+#    Longhorn's validator rejects updates with 403 while a node's disk spec and status are
+#    mid-sync, so transient apply failures here are expected rather than alarming.
 #  - If a node ever needs more than one tag, write the list pre-sorted alphabetically:
 #    Longhorn's mutating webhook sorts spec.tags on every write, so an unsorted manifest
 #    reconciles into a permanent drift loop.

--- a/clusters/homelab/storage/infra/node/kustomization.yaml
+++ b/clusters/homelab/storage/infra/node/kustomization.yaml
@@ -3,8 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- job/
-- node/
-- sc/
-- pv/
-- pvc/
+- beelink-ser8-1.yaml
+- minisforum-nab9-1.yaml

--- a/clusters/homelab/storage/infra/node/minisforum-nab9-1.yaml
+++ b/clusters/homelab/storage/infra/node/minisforum-nab9-1.yaml
@@ -1,0 +1,15 @@
+---
+# Gives this node the "virtualization" Longhorn node tag. See beelink-ser8-1.yaml in this
+# directory for the full reasoning -- why this manifest declares spec.tags and nothing
+# else, why the ssa: merge annotation is required, and the prune/new-node lifecycle
+# gotchas. All of it applies here identically.
+apiVersion: longhorn.io/v1beta2
+kind: Node
+metadata:
+  name: minisforum-nab9-1
+  namespace: longhorn-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: Merge
+spec:
+  tags:
+  - virtualization

--- a/clusters/homelab/storage/infra/node/minisforum-nab9-1.yaml
+++ b/clusters/homelab/storage/infra/node/minisforum-nab9-1.yaml
@@ -1,8 +1,13 @@
 ---
 # Gives this node the "virtualization" Longhorn node tag. See beelink-ser8-1.yaml in this
-# directory for the full reasoning -- why this manifest declares spec.tags and nothing
-# else, why the ssa: merge annotation is required, and the prune/new-node lifecycle
+# directory for the full reasoning -- why this manifest declares spec.tags and nothing else
+# (that rule, not the ssa annotation, is what protects Longhorn's own fields), what the
+# ssa: Merge annotation actually does and does not do, and the prune/new-node lifecycle
 # gotchas. All of it applies here identically.
+#
+# Adding a second tag: write the list pre-sorted alphabetically. Longhorn's mutating
+# webhook sorts spec.tags on every write, so an unsorted manifest puts Flux and the webhook
+# in a permanent drift loop. Latent today with one tag; it bites the moment there are two.
 apiVersion: longhorn.io/v1beta2
 kind: Node
 metadata:

--- a/clusters/homelab/storage/infra/sc/sc-longhorn-local-non-replicated-ephemeral.yaml
+++ b/clusters/homelab/storage/infra/sc/sc-longhorn-local-non-replicated-ephemeral.yaml
@@ -29,6 +29,56 @@ parameters:
   dataLocality: "strict-local"
   numberOfReplicas: "1"
   recurringJobSelector: '[{"name":"default", "isGroup":true}]'
+  # Restricts Longhorn replica placement to nodes that can actually run the VM that will
+  # consume the volume. The value is a comma-separated list of Longhorn *node tags*
+  # (nodes.longhorn.io spec.tags) -- NOT Kubernetes node labels; the two namespaces are
+  # unrelated despite the parameter's name. Longhorn treats it as a hard filter: a node
+  # without every listed tag is dropped from replica candidacy outright, with no fallback.
+  #
+  # Without it, a numberOfReplicas: 1 volume on this class deadlocks the scheduler, and it
+  # deadlocks by luck rather than reliably -- which is what makes it a weekly-recurring
+  # defect for the sandbox VMs' destroy-and-rebuild rather than a one-off. The sandbox VM
+  # pods carry a hard nodeSelector on homelab-ops.internal/virtualization: "enabled",
+  # satisfied by 2 of this cluster's 4 nodes. Longhorn's replica scheduler knew nothing
+  # about that, so it placed the single replica wherever it had free space; the resulting
+  # PV gets spec.nodeAffinity pinned to that node, and if it isn't a virtualization node
+  # the VM pod can never be scheduled -- the PV demands one node, the pod's nodeSelector
+  # forbids it, and no retry fixes it because deleting and recreating the PVC just re-rolls
+  # the same dice.
+  #
+  # Two things that look like they should already prevent this, and do not:
+  #  - volumeBindingMode: WaitForFirstConsumer makes kube-scheduler pick a node first and
+  #    record it as the PVC's volume.kubernetes.io/selected-node, but Longhorn does not
+  #    honour that hint when choosing where to put the replica.
+  #  - dataLocality: strict-local governs replica-vs-attachment locality (it keeps the one
+  #    replica on whichever node the volume is attached to) -- it does not constrain the
+  #    provisioning-time node choice, which is what goes wrong here.
+  #
+  # Drift risk, and it is asymmetric -- this is the thing to get right when adding a node.
+  # The node tag and the homelab-ops.internal/virtualization label are two separate pieces
+  # of out-of-band state: neither nodes.longhorn.io CRs nor node labels are managed in git,
+  # so both are applied by hand. The node-prep runbook in this repo's OPERATIONS.md applies
+  # them together for exactly that reason; keep them together.
+  #  - Labelled but untagged: the VM may run there, Longhorn will never put a disk there.
+  #    Harmless -- it only narrows placement.
+  #  - Tagged but unlabelled: Longhorn may place a disk on a node the VM cannot run on.
+  #    That is precisely the deadlock above, reintroduced. So the tagged set must always be
+  #    a SUBSET of the labelled set; never tag a node that isn't label-eligible.
+  #  - Tagged nowhere at all: Longhorn rejects volume creation outright ("specified node
+  #    tag ... does not exist") and the PVC stays Pending. Loud and obvious, which is the
+  #    good failure mode -- but it does mean the tag must exist before the first PVC on
+  #    this class is created, not after.
+  #
+  # Not applied to the sc-longhorn-local-non-replicated (Retain) twin on purpose: its
+  # consumers (coder/authentik/litellm/home-automation databases) have no virtualization
+  # constraint, and pinning them to 2 of 4 nodes would shrink their placement pool to solve
+  # a problem they do not have. A node tag encodes where the *workload* may run, so it only
+  # belongs on a class whose consumers all share one placement constraint. That is true of
+  # this class (sandbox VMs only) and false of the Retain twin -- which also means this
+  # class is now VM-scoped despite its generic name: a future non-VM consumer would silently
+  # inherit the 2-node restriction. Give that consumer its own class rather than removing
+  # this parameter.
+  nodeSelector: "virtualization"
 provisioner: driver.longhorn.io
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer

--- a/clusters/homelab/storage/infra/sc/sc-longhorn-local-non-replicated-ephemeral.yaml
+++ b/clusters/homelab/storage/infra/sc/sc-longhorn-local-non-replicated-ephemeral.yaml
@@ -55,10 +55,12 @@ parameters:
   #    provisioning-time node choice, which is what goes wrong here.
   #
   # Drift risk, and it is asymmetric -- this is the thing to get right when adding a node.
-  # The node tag and the homelab-ops.internal/virtualization label are two separate pieces
-  # of out-of-band state: neither nodes.longhorn.io CRs nor node labels are managed in git,
-  # so both are applied by hand. The node-prep runbook in this repo's OPERATIONS.md applies
-  # them together for exactly that reason; keep them together.
+  # The tag itself is declared per node in ../node/*.yaml and applied by the same
+  # config-storage Kustomization as this file. Its counterpart, the
+  # homelab-ops.internal/virtualization node label, is NOT: k3s only reads node-label+ at
+  # registration time, so on an already-registered node it is a hand-applied node-prep
+  # step. Two halves, two mechanisms, and nothing enforces agreement between them -- which
+  # is why the node-prep runbook in this repo's OPERATIONS.md walks both together.
   #  - Labelled but untagged: the VM may run there, Longhorn will never put a disk there.
   #    Harmless -- it only narrows placement.
   #  - Tagged but unlabelled: Longhorn may place a disk on a node the VM cannot run on.


### PR DESCRIPTION
## Problem

`talos-vm` in `sandbox-talos` cannot start. `virt-launcher-talos-vm-5z5sn` is `Pending` with no node assigned:

```
0/4 nodes are available: 2 node(s) didn't match PersistentVolume's node affinity,
                         2 node(s) didn't match Pod's node affinity/selector.
```

Three measured facts compose into the deadlock:

1. PV `pvc-e47597a6-1f64-450e-9cef-53a73dc8f92e` has `spec.nodeAffinity` pinned to `gmktec-g3plus-1`, and its `longhorn.io/volume-scheduling-error` annotation is empty — Longhorn believes it placed the replica successfully.
2. The PVC's `volume.kubernetes.io/selected-node` is `minisforum-nab9-1` — kube-scheduler picked that node and Longhorn provisioned elsewhere anyway.
3. The VM pod has a hard `nodeSelector: homelab-ops.internal/virtualization: "enabled"`, carried by only `beelink-ser8-1` and `minisforum-nab9-1` (read from the live nodes). `gmktec-g3plus-1` is not one of them.

**Root cause:** `sc-longhorn-local-non-replicated-ephemeral` carried no `nodeSelector` parameter, so Longhorn's replica scheduler was unconstrained. With `numberOfReplicas: 1` it places the single replica wherever *it* has free space, with no knowledge of where the consuming pod is permitted to run.

This is not a one-off. `docker-vm`'s 200Gi volume landing on a usable node was luck; deleting and retrying the PVC just re-rolls the dice, which is why it recurs on every weekly destroy-and-rebuild.

Two mechanisms that look like they should already prevent this, and do not:

- `volumeBindingMode: WaitForFirstConsumer` makes kube-scheduler choose first and record `selected-node`, but Longhorn does not honour that hint for replica placement.
- `dataLocality: strict-local` governs replica-vs-attachment locality, not the provisioning-time node choice.

## Fix

`nodeSelector: "virtualization"` on the ephemeral class.

Verified against the Longhorn docs rather than assumed. The value is a comma-separated list of Longhorn **node tags** (`nodes.longhorn.io` `spec.tags`), not Kubernetes node labels. It is a **hard** filter, not a preference — [Scheduling](https://longhorn.io/docs/1.12.0/nodes-and-volumes/nodes/scheduling/): *"The scheduler only goes to the next stage if the previous stage is satisfied. Otherwise, the scheduling will fail."* An untagged node is dropped from replica candidacy outright, with no fallback. Confirmed in `longhorn-manager` `scheduler/replica_scheduler.go`, which `continue`s past any node failing `IsSelectorsInTags`.

Per [Storage Class Parameters](https://longhorn.io/docs/1.12.0/references/storage-class-parameters/), parameters *"will be applied for new volume creation only"* — so this constrains new volumes, and the currently stuck PVC must be deleted and recreated. Acceptable here: the consumer is destroyed and rebuilt weekly by design.

Rejected alternatives: `allowedTopologies` is explicitly documented as incompatible with `strict-local`; the `Allow Empty Node Selector Volume` setting is cluster-global and inverts the wrong way (setting it `false` would stop every *other* volume in the cluster from scheduling on the two tagged nodes); `diskSelector` constrains one level too low for a "which nodes" question.

## The `Retain` twin is deliberately left alone

`sc-longhorn-local-non-replicated` keeps no `nodeSelector`, and the reasoning is written into the ephemeral class file.

A node tag encodes *where the workload may run*, so it only belongs on a class whose consumers all share one placement constraint. That is true of the ephemeral class (sandbox VMs only) and false of the Retain twin, whose consumers — coder DBs, authentik, litellm, home-automation, downloaders — have no virtualization constraint at all. Constraining it would shrink their placement pool from 4 nodes to 2 to solve a problem they do not have, and would risk exactly the scheduling failures this PR is trying to eliminate.

The tradeoff this creates is documented in-file: the ephemeral class is now effectively VM-scoped despite its generic name, so a future non-VM consumer would silently inherit the 2-node restriction. The note says to give such a consumer its own class rather than removing the parameter.

## Node tags are managed in git too

`storage/infra/node/beelink-ser8-1.yaml` and `minisforum-nab9-1.yaml` declare `spec.tags: ["virtualization"]`, following the `storage/infra/job/*.yaml` `RecurringJob` precedent for `longhorn.io` CRs in this same `config-storage` Kustomization. Without the tags present the new StorageClass cannot provision at all, so the two halves ship together.

These CRs are **created and owned by `longhorn-manager`** — Flux is patching a foreign object, which is the whole risk. Two things were verified against Flux source rather than assumed:

- **kustomize-controller applies with `client.ForceOwnership` unconditionally** (`fluxcd/pkg` `ssa/manager_apply.go`). That is why the apply succeeds despite `longhorn-manager` already owning `spec.tags` — but it also means a stray field in these manifests would be **silently seized, not rejected**. Hence `spec.tags` and nothing else. What actually leaves `spec.disks`, `allowScheduling`, `evictionRequested` and `instanceManagerCPURequest` with `longhorn-manager` is plain SSA field ownership: an applier owns only what it declares.
- **`kustomize.toolkit.fluxcd.io/ssa: Merge` does not mean "leave undeclared fields alone."** Per the Flux docs, *"The fields defined in the manifests applied by the controller will always be overridden"*, and a maintainer closing [fluxcd/flux2#5898](https://github.com/fluxcd/flux2/issues/5898) states it plainly: *"Merge here means not cleaning the object metadata (it does not mean merging the in-cluster object onto the desired one)."* In source it sets `Cleanup.Exclusions`, exempting the object from the step that strips `last-applied-configuration` and rewrites `managedFields`. It is kept as a guard against a future client-side `kubectl apply`, and the manifest says exactly that instead of implying it protects Longhorn's fields.

Measured from the live v1.11.2 CRD: `spec.tags` has no `x-kubernetes-list-type` (atomic — owned whole, so out-of-band UI tags get reverted) and no `spec` field is `required` (so Flux *would* create a schema-valid partial `Node` on a brand-new node before `longhorn-manager` gets there — the manifests say to wait for registration).

## Drift between the tag and the label

The two halves now live in different places, and that is the residual drift risk. The Longhorn tag is GitOps; the `homelab-ops.internal/virtualization` label is **not** — k3s only reads `node-label+` at registration, so on an already-registered node it stays a hand-applied node-prep step. `OPERATIONS.md`'s runbook now walks both together on both paths.

The pairing is **asymmetric**:

| State | Consequence |
|---|---|
| Labelled, untagged | Harmless — VM may run there, Longhorn just won't place a disk there |
| **Tagged, unlabelled** | **Recreates this deadlock** — Longhorn places a disk where the VM cannot run |
| Tagged nowhere | Longhorn rejects volume creation (`specified node tag ... does not exist`); PVC stays `Pending` — loud, and the good failure mode |

So the tagged set must always be a **subset** of the labelled set. `prune` is patched to `false` cluster-wide, so retiring a node means setting `tags: []` and letting Flux apply it *before* deleting the manifest — deleting the file alone strands the tag.

## Validation

`yamllint --strict`, `markdownlint-cli2`, `kustomize build`, and the full `pre-commit` suite (including kubeconform manifest validation) pass. `kustomize build` renders `nodeSelector: virtualization` on the ephemeral class and leaves the other four classes untouched.

## Not in this PR

Two separate findings are reported to the operator rather than bundled here: a `preferredDuringSchedulingIgnoredDuringExecution` nodeAffinity on `sandbox-talos`'s VM that contradicts an explicit warning in its `docker-host` sibling (different repo, different failure mode), and ~358Gi of orphaned `Released` PVs. Neither is load-bearing for this failure — both virtualization nodes were measured with ~1.45 TiB free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
