### PR TITLE
fix(cluster-homelab): drop strict-local on the ephemeral VM storage class

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -223,14 +223,21 @@ per node in `clusters/homelab/storage/infra/node/` and applied by the
 `config-storage` Flux `Kustomization` — see the reasoning block in any of
 those manifests for why they declare `spec.tags` and nothing else.
 
-**The label and the Longhorn tag are a pair, and the pairing is asymmetric.**
-Tag only nodes that also carry the label — never the reverse. A node that is
-labelled but untagged is harmless (the VM may run there; Longhorn just won't
-put a disk there). A node that is tagged but *not* labelled lets Longhorn
-place a VM's disk on a node the VM's own `nodeSelector` forbids it to run on,
-which pins the resulting PV's `nodeAffinity` to an unusable node and leaves
-the VM permanently unschedulable. See the reasoning block in
-`clusters/homelab/storage/infra/sc/sc-longhorn-local-non-replicated-ephemeral.yaml`.
+**The label and the Longhorn tag are a pair — keep the two sets equal.** A
+node that carries one without the other no longer strands a VM, but it does
+silently cost disk locality in both directions: labelled-but-untagged means
+the VM may run on a node Longhorn will not place its replica on, so the
+volume runs over the network indefinitely with nothing reporting it;
+tagged-but-unlabelled means a replica may land where no VM will ever attach,
+costing a full rebuild to migrate it back.
+
+This is weaker than the rule that stood while that class used
+`dataLocality: strict-local`, when tagged-but-unlabelled recreated a
+permanent deadlock and the rule was the one-directional "tagged must be a
+subset of labelled". The class is `best-effort` now, which is what removed
+that failure mode. See the reasoning block in
+`clusters/homelab/storage/infra/sc/sc-longhorn-local-non-replicated-ephemeral.yaml`
+for the mechanism and for what would bring the deadlock back.
 
 The two halves live in different places on purpose and that is the drift
 risk: the label is hand-applied node prep (k3s only reads `node-label+` at
@@ -347,8 +354,9 @@ Both target nodes are already registered, so the drop-in alone will
 automatically at registration (Path B's reason it doesn't need that step).
 Keep the drop-in and the `kubectl label` in sync on already-registered nodes
 — if one is ever removed, remove the other too, and retire the Longhorn node
-tag first. Dropping the label while the tag remains is the one ordering that
-recreates the unschedulable-VM deadlock described in Path A.
+tag first. Dropping the label while the tag remains leaves replicas placeable
+on a node no VM can attach from, which is the locality cost described in
+Path A rather than an outage.
 
 Retiring the tag is **not** just deleting the manifest: `prune` is patched to
 `false` for every `Kustomization` in this cluster (see

--- a/clusters/homelab/storage/infra/sc/sc-longhorn-local-non-replicated-ephemeral.yaml
+++ b/clusters/homelab/storage/infra/sc/sc-longhorn-local-non-replicated-ephemeral.yaml
@@ -25,8 +25,30 @@ allowVolumeExpansion: true
 parameters:
   fsType: ext4
   staleReplicaTimeout: "2880"
-  # as per https://longhorn.io/docs/1.7.1/best-practices/#io-performance
-  dataLocality: "strict-local"
+  # best-effort, NOT strict-local -- and the difference is load-bearing, not cosmetic. It is
+  # half of the pair that makes the nodeSelector below actually work; read the two together.
+  #
+  # The best practice this class has always cited
+  # (https://longhorn.io/docs/1.7.1/best-practices/#io-performance) says two things, and the
+  # twin this class was cloned from only ever satisfied the second:
+  #   "Use best-effort as the default data locality of Longhorn StorageClasses."
+  #   ...and use strict-local "for applications supporting replication", so that a workload
+  #   replicating at its own layer keeps exactly one Longhorn replica underneath rather than
+  #   paying for replication twice.
+  # That condition holds for sc-longhorn-local-non-replicated, whose consumers are CNPG
+  # Postgres clusters running 2-3 instances that replicate themselves. It does not hold
+  # here: a sandbox VM's disk is a single copy of unreplicated state, with no application
+  # layer above it doing anything. This class was created as "identical to the twin except
+  # reclaimPolicy", so strict-local came across with everything else -- the parameter was
+  # inherited, its justification was not. best-effort also matches sc-longhorn-replicated
+  # and this cluster's default-data-locality setting, so this is the odd one out being
+  # brought back in line, not a new exception.
+  #
+  # strict-local was not merely unjustified here, it was actively incompatible with the
+  # nodeSelector below, and the pair of them left talos-vm unschedulable for 24h. Do not
+  # restore it without reading the nodeSelector block -- putting it back reintroduces that
+  # outage, and reintroduces it intermittently, which is worse than reintroducing it always.
+  dataLocality: "best-effort"
   numberOfReplicas: "1"
   recurringJobSelector: '[{"name":"default", "isGroup":true}]'
   # Restricts Longhorn replica placement to nodes that can actually run the VM that will
@@ -35,24 +57,126 @@ parameters:
   # unrelated despite the parameter's name. Longhorn treats it as a hard filter: a node
   # without every listed tag is dropped from replica candidacy outright, with no fallback.
   #
-  # Without it, a numberOfReplicas: 1 volume on this class deadlocks the scheduler, and it
-  # deadlocks by luck rather than reliably -- which is what makes it a weekly-recurring
-  # defect for the sandbox VMs' destroy-and-rebuild rather than a one-off. The sandbox VM
-  # pods carry a hard nodeSelector on homelab-ops.internal/virtualization: "enabled",
-  # satisfied by 2 of this cluster's 4 nodes. Longhorn's replica scheduler knew nothing
-  # about that, so it placed the single replica wherever it had free space; the resulting
-  # PV gets spec.nodeAffinity pinned to that node, and if it isn't a virtualization node
-  # the VM pod can never be scheduled -- the PV demands one node, the pod's nodeSelector
-  # forbids it, and no retry fixes it because deleting and recreating the PVC just re-rolls
-  # the same dice.
+  # What this parameter is and is NOT for, stated precisely because the previous version of
+  # this comment overstated it and that overstatement is what made the outage below possible.
+  # It is NOT what keeps the VM schedulable -- dataLocality: best-effort above is. It is a
+  # placement-quality control: the sandbox VM pods carry a hard nodeSelector on
+  # homelab-ops.internal/virtualization: "enabled", satisfied by 2 of this cluster's 4 nodes,
+  # and this tag keeps Longhorn from putting the single replica on the other two, where it
+  # would serve no attach and have to be rebuilt away the first time the VM started. Without
+  # it the volume still works; it just wastes a full rebuild more often and parks replicas on
+  # nodes that can never host their consumer.
   #
-  # Two things that look like they should already prevent this, and do not:
-  #  - volumeBindingMode: WaitForFirstConsumer makes kube-scheduler pick a node first and
-  #    record it as the PVC's volume.kubernetes.io/selected-node, but Longhorn does not
-  #    honour that hint when choosing where to put the replica.
-  #  - dataLocality: strict-local governs replica-vs-attachment locality (it keeps the one
-  #    replica on whichever node the volume is attached to) -- it does not constrain the
-  #    provisioning-time node choice, which is what goes wrong here.
+  # A node tag is a veto, not a chooser: Longhorn drops untagged nodes from replica
+  # candidacy, but nothing about it steers a placement toward a tagged one. That distinction
+  # is harmless while the scheduler has a candidate SET to filter -- and became an outage
+  # once dataLocality: strict-local narrowed that set to a single node before the filter ran,
+  # because then the tag could only turn a bad choice into a hard failure, never into a good
+  # one.
+  #
+  # Which is exactly what dataLocality: strict-local did, and why this class carried both
+  # settings for a day with talos-vm unschedulable throughout. strict-local copies
+  # Volume.spec.nodeID into the replica's HardNodeAffinity (volume_controller.go
+  # reconcileVolumeCondition), and the scheduler applies that pin BEFORE the tag filter --
+  # getNodeCandidates reduces the candidate map to that one node, then getDiskCandidates
+  # drops it again for failing IsSelectorsInTags, leaving nothing and no fallback.
+  #
+  # And spec.nodeID has nothing to do with where the workload may run. Traced end to end on
+  # this cluster (Longhorn v1.11.2), against both the live objects and longhorn-manager
+  # source at that tag:
+  #  1. On a brand-new Volume both spec.nodeID and status.ownerID are empty, so every
+  #     longhorn-manager considers itself eligible to take ownership -- ownership is settled
+  #     by an unordered first-writer race, not by hashing or by any workload input.
+  #  2. Internal controllers then open an attachment ticket using status.ownerID as its
+  #     nodeID, and the VolumeAttachment controller writes spec.nodeID from the winning
+  #     ticket. talos-vm's VolumeAttachment held exactly one ticket:
+  #       type: volume-rebuilding-controller   nodeID: gmktec-g3plus-1
+  #     opened in the same second the Volume was created. Not the CSI attacher -- the VM pod
+  #     never scheduled, so it never produced a ticket. (This ticket exists at all because
+  #     the offline-replica-rebuilding setting is true cluster-wide.)
+  #  3. So spec.nodeID landed on the untagged node that won a race, while the PVC's
+  #     volume.kubernetes.io/selected-node recorded beelink-ser8-1 -- a tagged node
+  #     kube-scheduler had already chosen. Longhorn's CSI layer receives that hint and
+  #     explicitly discards it for strict-local volumes (controller_server.go CreateVolume
+  #     logs that it "ignores AccessibilityRequirements because dataLocality is
+  #     strict-local"), so nothing ever reconciles the two.
+  # Both sandbox VM volumes provisioned while both settings were in effect show it:
+  #    talos-vm    nodeID = ownerID = gmktec-g3plus-1    (untagged) -> Scheduled=False,
+  #                                                       LocalReplicaSchedulingFailure
+  #    docker-vm   nodeID = ownerID = minisforum-nab9-1  (tagged)   -> healthy
+  # With 2 of 4 managers tagged that is a coin flip per volume; docker-vm won it, talos-vm
+  # lost it. Deleting and recreating the PVC only re-rolls the same coin, which is why no
+  # retry ever fixed it. There is no setting in v1.11.2 that steers this -- checked and
+  # ruled out from source: csi-allowed-topology-keys and the StorageClass strictTopology
+  # parameter (both live on the CreateVolume topology path that strict-local skips
+  # outright), the replica soft-anti-affinity family (they only choose between candidate
+  # buckets, and every bucket is empty once the pinned node fails the tag filter), and
+  # allow-empty-node-selector-volume (relaxes only the empty-selector case).
+  #
+  # Two counterintuitive consequences, stated because they are the first two levers anyone
+  # will reach for, and both make things worse:
+  #  - Tagging FEWER nodes. Under strict-local that narrows the winning side of the flip,
+  #    not the losing side -- one tagged node would have failed 3 times in 4, not 1 in 2.
+  #  - Tagging ALL nodes so "the race cannot land wrong". It makes the tag filter vacuous:
+  #    the pin then always survives, the replica schedules on whichever node won the race,
+  #    and the PV is pinned there -- including the two nodes that cannot run a VM at all.
+  #    That is the original pre-nodeSelector failure restored in full, and silently, because
+  #    Longhorn now reports the volume as healthy.
+  #
+  # Under best-effort the replica scheduler picks from every tag-matching node instead of
+  # from one pre-chosen node, so the tag filter finally has a set to filter and the candidate
+  # set becomes exactly {nodes the VM is permitted to run on}. Every placement Longhorn can
+  # reach is then a working one -- set inclusion rather than a lucky draw.
+  #
+  # That is the second of two independent reasons the deadlock is gone, and deliberately the
+  # weaker one. The first is sufficient on its own: the PV's
+  # spec.nodeAffinity is emitted only for strict-local volumes. Measured first --
+  #    sc-longhorn-replicated           (best-effort)  -> PV has NO nodeAffinity at all
+  #    sc-longhorn-local-non-replicated (strict-local) -> PV pinned to one hostname
+  # on the same cluster, version and CSI provisioner instance -- then confirmed in source:
+  # volume_controller.go ReconcilePersistentVolume writes that field inside an
+  # `if dataLocality == strict-local && spec.NodeID != ""` guard. It is gated on data
+  # locality alone, so the differing replica counts in those two samples are not a confound.
+  # On best-effort the PV therefore stops constraining pod scheduling at all, and the
+  # "2 node(s) didn't match PersistentVolume's node affinity" half of the failure cannot
+  # recur.
+  #
+  # WHAT WOULD MAKE THAT WRONG LATER, and it is a cluster-global switch nowhere near this
+  # file: PVs have a second, independent source of nodeAffinity -- the topology that CSI
+  # CreateVolume returns, which external-provisioner stamps onto the PV. That path is inert
+  # today only because the Longhorn setting csi-allowed-topology-keys is empty
+  # (filterTopologyByAllowedKeys returns nil for an empty allow-list). Setting it -- it
+  # lives in the infra-storage-core module's Longhorn HelmRelease, not here -- would start
+  # pinning every NON-strict-local PV in the cluster, and if a StorageClass also sets
+  # strictTopology: "true" the pin is to a single hostname. It would not resurrect the
+  # strict-local path (CreateVolume skips topology entirely for those), but it would give
+  # this class's volumes a hostname pin again by a different route. If that setting is ever
+  # turned on, re-verify that a freshly provisioned volume on this class still comes up with
+  # an unpinned PV. Note also that Longhorn requires a CSI plugin restart for that setting
+  # to take effect (longhorn/longhorn#12753), so a half-applied change looks like no change.
+  #
+  # What best-effort costs here, so the trade is on the record rather than assumed:
+  #  - The engine-to-replica local data path is lost. `--data-server-protocol unix` is gated
+  #    on strict-local only, so a co-located replica is now reached over TCP rather than a
+  #    unix socket. That is the real IO cost, and it is the reason to prefer strict-local
+  #    wherever it is actually usable.
+  #  - Every attach onto a node that does not already hold the replica triggers one full
+  #    rebuild of the volume (Longhorn creates an extra local replica, then reaps the remote
+  #    one) -- 40Gi for talos-vm, 200Gi for docker-vm. Bounded here: there are only two
+  #    candidate nodes, the VMs carry a preferred nodeAffinity toward one of them, and these
+  #    volumes are destroyed and rebuilt weekly by design anyway.
+  #  - Nothing else. The revisionCounterDisabled: true that Longhorn's mutating webhook
+  #    applies automatically to strict-local volumes is already set cluster-wide here by the
+  #    disable-revision-counter setting, so dropping strict-local does not change it.
+  # `disabled` was considered and rejected: it avoids the rebuild churn entirely, but then a
+  # mismatched replica stays remote for the VM's whole life instead of for one rebuild --
+  # permanently networked IO under an etcd workload is worse than a bounded one-off copy.
+  #
+  # volumeBindingMode: WaitForFirstConsumer looks like it should have prevented all of this
+  # and does not: it makes kube-scheduler choose a node first and record it as the PVC's
+  # volume.kubernetes.io/selected-node, but Longhorn does not honour that hint when placing
+  # replicas. Verified above rather than assumed -- talos-vm's selected-node and its actual
+  # placement were different nodes.
   #
   # Drift risk, and it is asymmetric -- this is the thing to get right when adding a node.
   # The tag itself is declared per node in ../node/*.yaml and applied by the same
@@ -61,15 +185,22 @@ parameters:
   # registration time, so on an already-registered node it is a hand-applied node-prep
   # step. Two halves, two mechanisms, and nothing enforces agreement between them -- which
   # is why the node-prep runbook in this repo's OPERATIONS.md walks both together.
-  #  - Labelled but untagged: the VM may run there, Longhorn will never put a disk there.
-  #    Harmless -- it only narrows placement.
-  #  - Tagged but unlabelled: Longhorn may place a disk on a node the VM cannot run on.
-  #    That is precisely the deadlock above, reintroduced. So the tagged set must always be
-  #    a SUBSET of the labelled set; never tag a node that isn't label-eligible.
+  # Keep the tagged set and the labelled set EQUAL. Note this is a change from what this
+  # file said while it was strict-local, and the change is real rather than editorial: back
+  # then a tagged-but-unlabelled node recreated the deadlock outright, so the rule was the
+  # one-directional "tagged must be a subset of labelled". With best-effort neither mismatch
+  # can strand a VM any more -- both merely cost IO locality, quietly:
+  #  - Labelled but untagged: the VM may run there, and Longhorn may never place a replica
+  #    there -- so best-effort's locality rebuild has nowhere to go and silently gives up
+  #    (it is best-effort; failing to achieve locality is not an error). The volume then
+  #    runs over the network for as long as the VM stays on that node. No alarm anywhere.
+  #  - Tagged but unlabelled: a replica may land on a node no VM will ever attach from,
+  #    costing one full rebuild to migrate it back once the VM does attach elsewhere.
+  #    Wasteful, not fatal.
   #  - Tagged nowhere at all: Longhorn rejects volume creation outright ("specified node
   #    tag ... does not exist") and the PVC stays Pending. Loud and obvious, which is the
   #    good failure mode -- but it does mean the tag must exist before the first PVC on
-  #    this class is created, not after.
+  #    this class is created, not after. This is the one case that is still hard-failing.
   #
   # Not applied to the sc-longhorn-local-non-replicated (Retain) twin on purpose: its
   # consumers (coder/authentik/litellm/home-automation databases) have no virtualization


### PR DESCRIPTION
## Problem

`talos-vm` in `sandbox-talos` has been `Pending` for 24h:

```
0/4 nodes are available: 2 node(s) didn't match PersistentVolume's node affinity,
                         2 node(s) didn't match Pod's node affinity/selector.
```

#854 did not cause this. It exposed a contradiction the class had carried since it was created, and converted a silent misplacement into a loud scheduling failure.

`sc-longhorn-local-non-replicated-ephemeral` was created as "identical to `sc-longhorn-local-non-replicated` except `reclaimPolicy`", inheriting `dataLocality: strict-local` along with everything else. The best practice the file has always cited says two things:

> "Use `best-effort` as the default data locality of Longhorn StorageClasses."

...and use `strict-local` **"for applications supporting replication"**, so a workload replicating at its own layer keeps exactly one Longhorn replica underneath rather than paying for replication twice.

That condition holds for the Retain twin, whose consumers are CNPG Postgres clusters running 2-3 self-replicating instances. It does not hold here: a sandbox VM's disk is a single copy of unreplicated state. **The parameter was inherited; its justification was not.**

## Mechanism — why `spec.nodeID` was a node the scheduler never picked

Traced end to end against the live objects **and** `longhorn-manager` at tag `v1.11.2` (the running version), not from the published docs.

1. On a brand-new `Volume`, `spec.nodeID` and `status.ownerID` are both empty. `isControllerResponsibleFor` treats an empty owner as unavailable, so `requiresNewOwner` is true on **every** longhorn-manager simultaneously — ownership is settled by an **unordered first-writer race**, not by hashing and not by any workload input.
2. Ten internal controllers open attachment tickets using `vol.Status.OwnerID` as the ticket's `nodeID`, and `volume_attachment_controller.go` writes `vol.Spec.NodeID = attachmentTicket.NodeID`. That is the **only** non-empty writer of `Spec.NodeID` in the codebase — `manager/volume.go` `Create()` does not set the field at all.

   Measured on the stuck volume, which closes which ticket it was:

   ```yaml
   # VolumeAttachment/pvc-a13c403c-… .spec.attachmentTickets
   volume-rebuilding-controller-pvc-a13c403c-…:
     type:   volume-rebuilding-controller
     nodeID: gmktec-g3plus-1
   ```

   Opened in the same second as the `Volume`. **Not** the CSI attacher — the VM pod never scheduled, so it never produced a ticket. (It exists at all because `offline-replica-rebuilding` is `true` cluster-wide.)
3. `strict-local` copies `Spec.NodeID` into the replica's `HardNodeAffinity`. The scheduler applies that pin in `getNodeCandidates` — reducing the candidate map to one node — **before** the tag filter runs in `getDiskCandidates`. The two are ANDed with no fallback, so an untagged pinned node yields `LocalReplicaSchedulingFailure`, retried every 30s forever.
4. `ReconcilePersistentVolume` then stamps that same node into the PV's `nodeAffinity`, inside an `if dataLocality == strict-local && spec.NodeID != ""` guard. PV `nodeAffinity` is immutable, so the volume is unrecoverable in place.

`volumeBindingMode: WaitForFirstConsumer` never helped because `CreateVolume` **does** receive the topology hint and explicitly discards it for `strict-local`:

> `"CreateVolume for %s ignores AccessibilityRequirements because dataLocality is strict-local"`

The PVC's `volume.kubernetes.io/selected-node` was `beelink-ser8-1` — a *tagged* node kube-scheduler had already chosen.

**`docker-vm` is not a different configuration.** Its volume was created 32 minutes after #854 merged, so it carries the same `nodeSelector`; it simply won the race. That is the luck being removed.

| volume | `nodeID` = `ownerID` | tagged? | outcome |
|---|---|---|---|
| `talos-vm` | `gmktec-g3plus-1` | no | `Scheduled=False`, `LocalReplicaSchedulingFailure` |
| `docker-vm` | `minisforum-nab9-1` | yes | healthy |

## Fix

One line: `dataLocality: "strict-local"` → `"best-effort"`. Everything else in the diff is documentation.

It is durable rather than lucky for **two independent reasons, the first sufficient on its own**:

1. **The PV stops constraining pod scheduling at all.** `ReconcilePersistentVolume` emits `nodeAffinity` only for `strict-local`. Measured on this cluster before trusting the source — same version, same CSI provisioner instance, only `dataLocality` differing:

   | PV | dataLocality | PV `nodeAffinity` |
   |---|---|---|
   | `vault-git-cache` (Aug 1) | best-effort | **none** |
   | `n8n-db-…-1` (Jul 25) | strict-local | pinned to one hostname |
   | `talos-vm-storage` (Aug 5) | strict-local | pinned to one hostname |

   The differing replica counts in those samples are not a confound — the guard is on data locality alone.
2. **The candidate set becomes exactly the set of nodes the VM may run on.** With no `HardNodeAffinity`, the tag filter finally has a set to filter instead of a single pre-chosen node. Set inclusion, not a lucky draw.

**There is no lever that keeps `strict-local` and steers `spec.nodeID`.** Ruled out from source, not from docs: `csi-allowed-topology-keys` and StorageClass `strictTopology` (both live on the `CreateVolume` topology path that `strict-local` skips outright — and `NodeGetInfo` publishes `kubernetes.io/hostname` unconditionally regardless of that setting, which is why the live `CSINode` already advertises it); the replica soft-anti-affinity family (they only choose *between* candidate buckets, all empty once the pinned node fails the tag filter); `allow-empty-node-selector-volume` (relaxes only the empty-selector case). A manager `nodeSelector` would bias the ownership race, not make it deterministic.

**Two levers that look right and make it worse**, both written into the file because they are what someone reaches for next:

- Tagging **fewer** nodes narrows the *winning* side of the flip. One tagged node would fail 3 times in 4.
- Tagging **all** nodes makes the filter vacuous: the pin always survives, the PV is pinned wherever the race landed — including nodes that cannot run a VM — restoring the original failure *silently*, with Longhorn reporting the volume healthy.

### What `best-effort` costs

- The unix-socket engine-to-replica data path is lost (`--data-server-protocol unix` is gated on `strict-local` only), so a co-located replica is reached over TCP.
- Every attach onto a node not already holding the replica costs one full rebuild. Bounded: two candidate nodes, a preferred `nodeAffinity` toward one of them, and these volumes are destroyed weekly by design.
- Nothing else. The `revisionCounterDisabled: true` that Longhorn's mutator applies to `strict-local` volumes is already set cluster-wide by `disable-revision-counter`.

`disabled` was considered and rejected: it avoids the churn, but a mismatched replica then stays remote for the VM's whole life instead of for one rebuild — permanently networked IO under an etcd workload is worse than a bounded one-off copy.

### `nodeSelector` is kept, and re-described

It is **not** what keeps the VM schedulable — `best-effort` is. It is placement quality: it keeps the single replica off the two nodes where it would serve no attach and be rebuilt away on first start. The old comment claimed it was the thing preventing the deadlock, and that overstatement is part of what made this possible.

### Not touched

`sc-longhorn-local-non-replicated` (Retain) is unchanged — verified by `kustomize build`, which renders `strict-local` on it and `best-effort` on this class only. `docker-vm` needs no action: its current volume keeps `strict-local` until its next weekly rebuild, then picks this up automatically. Only these two PVCs use this class cluster-wide.

## Doc corrections shipped in the same change

`OPERATIONS.md`'s label/tag rule was calibrated for `strict-local` and is now false. Under `best-effort` neither mismatch strands a VM; both only cost locality, quietly. The rule becomes "keep the two sets equal" rather than the one-directional "tagged must be a subset of labelled", and the Path-B line calling a dropped label "the one ordering that recreates the unschedulable-VM deadlock" is corrected to the locality cost it now is.

## Verified vs reasoned

**Verified** (live objects, read-only, plus `longhorn-manager` @ `v1.11.2`): the `Volume`/`PV`/`PVC`/`VolumeAttachment` state above; `spec.nodeID == ownerID` on both sandbox volumes; the sole attachment ticket and its type; `selected-node` ≠ `spec.nodeID`; PV pinned iff `strict-local`, measured *and* source-gated; `CSINode` advertising `kubernetes.io/hostname` with `csi-allowed-topology-keys` empty; only these two PVCs use this class; `config-storage` has no `force: true`; the cited best-practice text.

**Reasoned, not verified**: that PV `nodeAffinity` immutability is what blocks in-place repair (Kubernetes API semantics, not Longhorn source); the relative IO cost of one rebuild versus persistently networked IO for etcd — a judgement, not a measurement; expected rebuild frequency.

## Validation

`pre-commit` full suite passes on both changed files (yamllint, markdownlint, kubeconform manifest validation). `kustomize build` renders `dataLocality: best-effort` with `nodeSelector: virtualization` retained, and leaves the other four classes untouched.

---

## Operator remediation sequence

Nothing here has been run — the cluster was read-only throughout.

### 1. Update the StorageClass — suspend first, and this ordering matters

`StorageClass.parameters` is immutable and `config-storage` has no `force: true`, so Flux **cannot** patch it. If a reconcile runs with the new manifest against the existing object, the apply is rejected and **the whole `config-storage` Kustomization wedges** — StorageClasses, PVs, PVCs, RecurringJobs *and* the Longhorn node-tag manifests. Suspending removes the race rather than relying on winning it:

```bash
flux suspend kustomization config-storage
# --- merge this PR now ---
kubectl delete storageclass sc-longhorn-local-non-replicated-ephemeral
flux resume kustomization config-storage
flux reconcile kustomization config-storage --with-source
```

Deleting the class is safe with PVCs bound to it: a StorageClass is consulted only at provisioning time, and bound PVs keep working. The `kustomize.toolkit.fluxcd.io/prune: disabled` annotation on it affects pruning only, not re-creation.

Confirm before continuing — if this is wrong, stop:

```bash
flux get kustomization config-storage    # must be Ready
kubectl get sc sc-longhorn-local-non-replicated-ephemeral \
  -o jsonpath='{.parameters.dataLocality}{"  "}{.parameters.nodeSelector}{"\n"}'
# expect: best-effort  virtualization
```

### 2. Suspend the Kustomization that owns the VM and PVC

`apps-experiments` owns both and is currently `Ready: False` on this very failure. Suspending stops it recreating the VM mid-deletion, which would re-grab the PVC and block it on `pvc-protection`:

```bash
flux suspend kustomization apps-experiments
```

### 3. Destroy the VM and PVC

The broken PVC/PV/Volume **must** be deleted — `ReconcilePersistentVolume` never *removes* `nodeAffinity` and the field is immutable, so the existing PV stays pinned to `gmktec-g3plus-1` no matter what the class says. Delete the `VirtualMachine`, never the VMI (`runStrategy: Always` just recreates a deleted VMI); it cascades to VMI and virt-launcher via `ownerReferences`:

```bash
kubectl -n sandbox-talos delete virtualmachine talos-vm --wait=false
kubectl -n sandbox-talos delete pvc talos-vm-storage --wait=false
```

Poll until all are gone — the PVC's finalizer will not clear until the pod is:

```bash
kubectl -n sandbox-talos get vm,vmi,pod,pvc
```

### 4. Confirm the PV and Longhorn volume were actually reaped

`reclaimPolicy: Delete` should take both. Both must be `NotFound`:

```bash
kubectl get pv pvc-a13c403c-f81a-47c6-8764-0c79c966c0e4
kubectl -n longhorn-system get volume.longhorn.io pvc-a13c403c-f81a-47c6-8764-0c79c966c0e4
```

If the Longhorn `Volume` lingers on its `longhorn.io` finalizer, investigate before proceeding — do not strip the finalizer blind; that is how replica data gets orphaned.

### 5. Resume

```bash
flux resume kustomization apps-experiments
flux reconcile kustomization apps-experiments --with-source
```

### 6. Verify — including the assertion that proves the fix, not just that it booted

```bash
PVCUID=$(kubectl -n sandbox-talos get pvc talos-vm-storage -o jsonpath='{.metadata.uid}')

# the class actually took effect
kubectl -n longhorn-system get volume.longhorn.io pvc-$PVCUID \
  -o jsonpath='{.spec.dataLocality}{"\n"}'                                  # expect: best-effort

# scheduling succeeded
kubectl -n longhorn-system get volume.longhorn.io pvc-$PVCUID \
  -o jsonpath='{.status.conditions[?(@.type=="Scheduled")].status}{"\n"}'   # expect: True

# THE load-bearing one: no PV pin at all
kubectl get pv pvc-$PVCUID -o jsonpath='{.spec.nodeAffinity}{"\n"}'
# expect: EMPTY. Any output means the deadlock class is still reachable --
# check whether csi-allowed-topology-keys has been set since.

kubectl -n sandbox-talos get pod -l kubevirt.io=virt-launcher -o wide
```

A green `Running` pod alone does not prove the fix — it could still be a lucky placement. The empty `nodeAffinity` is what shows the failure mode is structurally gone.

## Related

- ppat/homelab-ops-kubernetes-clusters#854 — added the `nodeSelector` and the node tags; the contradiction this exposes, and whose in-file reasoning is corrected here.
- ppat/homelab-ops-kubernetes-experiments#227 — the weekly destroy-and-rebuild that turns this from a one-off into a recurring defect.
- ppat/homelab-ops-kubernetes-experiments#233 — the rebuild CronJobs; still suspended, and their Step 0 `*-ephemeral` class assertion is unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
