### PR TITLE
chore(dev-tools): drop unused shellcheck suppressions after repo-wide audit

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,26 +1,3 @@
-# SC1091: Can't follow non-constant source
-# https://github.com/koalaman/shellcheck/wiki/SC1090
-disable=SC1090
-
-# SC1091: Not following: (error message here)
-# https://github.com/koalaman/shellcheck/wiki/SC1091
-disable=SC1091
-
-# SC2046: Quote this to prevent word splitting.
-# https://github.com/koalaman/shellcheck/wiki/SC2046
-disable=SC2046
-
-# SC2059: Don't use variables in the printf format string.
-# https://github.com/koalaman/shellcheck/wiki/SC2059
-disable=SC2059
-
-# SC2064: Use single quotes, otherwise this expands now rather than when signalled.
-# https://github.com/koalaman/shellcheck/wiki/SC2064
-disable=SC2064
-# SC2068: Double quote array expansions to avoid re-splitting elements.
-# https://github.com/koalaman/shellcheck/wiki/SC2068
-disable=SC2068
-
 # SC2086: Double quote to prevent globbing and word splitting.
 # https://github.com/koalaman/shellcheck/wiki/SC2086
 disable=SC2086
@@ -28,7 +5,3 @@ disable=SC2086
 # SC2155: Declare and assign separately to avoid masking return values
 # https://github.com/koalaman/shellcheck/wiki/SC2155
 disable=SC2155
-
-# SC2236: Use -n instead of ! -z.
-# https://github.com/koalaman/shellcheck/wiki/SC2236
-disable=SC2236


### PR DESCRIPTION
## Summary

Repo-wide audit of all 9 `.shellcheckrc` blanket suppressions (not just what a
recent PR touched). For each code, temporarily lifted just that one
`disable=` line, re-ran `pre-commit run shellcheck --all-files` (pinned
shellcheck v0.10.0.1, matching `.pre-commit-config.yaml`), recorded which
files triggered a finding, then restored the line before testing the next
code — one at a time, never lifting multiple codes together.

**Corpus scope note:** this repo's tracked shell corpus is currently only 5
files (`.github/scripts/prepare-sources.sh` + the 4 files added by the
still-**open**, unmerged PR #857 `refactor/extract-netpol-probe-scripts`,
which extracts previously-inline probe/heartbeat shell out of two Deployment
YAMLs into standalone `scripts/*.sh`). Since that PR isn't merged yet, all
analysis was run against a disposable local merge of `origin/main` +
`origin/refactor/extract-netpol-probe-scripts` (never pushed anywhere), so
the drop decisions below already account for that corpus once it lands. This
PR itself is based on plain `main` and only edits `.shellcheckrc` — nothing
from the other branch is included here.

| Code | Result | Reason |
|---|---|---|
| SC1090 | dropped | zero findings across the combined corpus |
| SC1091 | dropped | zero findings across the combined corpus |
| SC2046 | dropped | zero findings across the combined corpus |
| SC2059 | dropped | zero findings across the combined corpus |
| SC2064 | dropped | zero findings from the *blanket* rule — the one place it would fire (`.github/scripts/prepare-sources.sh:5`, a `trap "..." EXIT`) already has its own `# shellcheck disable=SC2064` per-file directive, confirmed still load-bearing (stripping it re-triggers the finding) |
| SC2068 | dropped | zero findings across the combined corpus |
| SC2086 | **kept** | 8 findings, all in `.github/scripts/prepare-sources.sh` (unquoted `${var}`/`$GITHUB_OUTPUT` expansions) |
| SC2155 | **kept** | 1 finding in `.github/scripts/prepare-sources.sh` (`local utilized=$(...)` masking the subshell's return value) |
| SC2236 | dropped | zero findings across the combined corpus |

For every dropped code, verified in the failing direction: a minimal
synthetic snippet unambiguously triggering that exact SC code was checked
with the code no longer suppressed, confirmed it fired, then deleted — a
clean run alone doesn't prove a suppression is unneeded (only that the
config is permissive), so this was done for all 7, not just some.

No code was dropped by changing scripts to satisfy the linter — both kept
codes (SC2086, SC2155) stay disabled repo-wide exactly as before; only the
7 with zero triggering files were removed.

## Per-file directive audit

Both existing per-file `# shellcheck disable=` directives in
`.github/scripts/prepare-sources.sh` (`SC2064` line 5, `SC2002` line 15) were
tested by stripping each one (with the narrowed `.shellcheckrc` from this PR
in place) and re-running shellcheck — both still fire and are still needed,
so neither is touched here.

## Not done here (recommendations only)

- `SC2086` and `SC2155` are each triggered by exactly one file
  (`.github/scripts/prepare-sources.sh`) across the whole combined corpus —
  candidates for converting from a repo-wide blanket into narrow per-file
  `# shellcheck disable=` directives on that file instead, so future files
  aren't silently exempted. Not acted on here per scope — flagging only.
- PR #857 is still open/unmerged. Once it lands, its 4 new `scripts/*.sh`
  files should be re-checked against the narrowed `.shellcheckrc` (they were
  already included in this audit's combined-corpus analysis and triggered no
  additional findings for any of the 7 dropped codes, so no action is
  expected — but that's worth confirming again post-merge since new commits
  could land on that branch before it merges).

## Also confirmed (not changed, informational)

- The new `clusters/homelab/services/sandbox-{docker,talos}/scripts/*.sh`
  files from PR #857 (in the disposable combined-tree checkout) are actively
  scanned by the pre-commit `shellcheck` hook — proved by injecting an
  unused-variable line into one, confirming it failed with `SC2034`, then
  reverting.
- Inline shell embedded in Kubernetes YAML manifests (e.g. the `command: [
  /bin/sh, -c, ... ]` blocks that used to live directly in
  `deployment-netpol-falsifiability-probe.yaml` before PR #857 extracted
  them) is **not** scanned by either the pre-commit hook (`types: [shell]`
  is extension/shebang-based via `identify`; a `.yaml` file is tagged
  `yaml`/`text`, never `shell`) or CI's dedicated shellcheck job in
  `ppat/github-workflows` (`lint-shellcheck.yaml`), which only looks at
  `**.sh`-glob-changed files on PRs or `find -executable` on schedule/push.
  There is no extraction step anywhere in this pipeline for inline YAML
  shell. This is a pre-existing coverage gap, not something this PR
  introduces or fixes.
- CI's shellcheck enforcement (`lint-shellcheck.yaml` in
  `ppat/github-workflows`) does **not** go through pre-commit at all, and
  pins shellcheck **v0.11.0**, not the v0.10.0.1 pinned in this repo's
  `.pre-commit-config.yaml` — the `lint-pre-commit.yaml` reusable workflow
  explicitly enumerates which pre-commit hooks it runs in CI, and
  `shellcheck` isn't one of them. This audit followed the task's explicit
  instruction to use the pre-commit-pinned version for reproducibility, but
  it means local `pre-commit run shellcheck` and CI's actual shellcheck gate
  are on different shellcheck versions. Flagging as a separate, pre-existing
  drift issue — out of scope to fix here.

## Test plan

- [x] `pre-commit run shellcheck --all-files` clean on plain `main` before
      any change
- [x] `pre-commit run shellcheck --all-files` clean on the disposable
      combined tree (`main` + `refactor/extract-netpol-probe-scripts`)
      before any change
- [x] Each of the 9 codes lifted individually against the combined tree,
      findings recorded, restored before testing the next
- [x] Both existing per-file directives confirmed still load-bearing
      against the narrowed `.shellcheckrc`
- [x] Failing-direction proof (inject → confirm fires → revert) for all 7
      dropped codes
- [x] `pre-commit run shellcheck --all-files` clean on this branch (plain
      `main` + only the `.shellcheckrc` change)