### PR TITLE
fix(cluster-homelab): retire secondsToLive-stripping patch on mcp-grafana-token

### DIFF
--- a/clusters/homelab/kustomizations/apps-ai.yaml
+++ b/clusters/homelab/kustomizations/apps-ai.yaml
@@ -154,22 +154,3 @@ spec:
       kind: Deployment
       name: openclaw
       namespace: openclaw
-  # The Grafana generator's spec.serviceAccount.secondsToLive exists in the external-secrets
-  # CRD bundle the module targets, but not in the older CRD this cluster currently has
-  # installed, so server-side apply rejects the whole Kustomization with "field not declared
-  # in schema". Strip it here until the operator is upgraded.
-  #
-  # Cost of running without it: the generator mints a new token on every refresh and does not
-  # delete the previous one, so tokens accumulate on the Grafana service account instead of
-  # expiring on their own. Tolerable briefly, which is why this is a stopgap rather than a
-  # change to the module -- remove this patch once the CRD carries the field.
-  # yamllint disable-line rule:indentation
-  - patch: |
-      - op: remove
-        path: /spec/serviceAccount/secondsToLive
-    target:
-      group: generators.external-secrets.io
-      version: v1alpha1
-      kind: Grafana
-      name: mcp-grafana-token
-      namespace: ai


### PR DESCRIPTION
## Summary

- Removes the `spec.patches` entry in `clusters/homelab/kustomizations/apps-ai.yaml` (added in #773)
  that stripped `spec.serviceAccount.secondsToLive` from the `mcp-grafana-token` `Grafana` generator
  (`generators.external-secrets.io/v1alpha1`) before it reached the API server.
- Closes #775.

## Why this is safe now (Chesterton's fence, checked not assumed)

The patch existed because the `external-secrets` CRD installed on `homelab` predated the field and
server-side apply rejected the whole `apps-ai` Kustomization with "field not declared in schema" —
not because of any runtime behavior change in the operator. That's a CRD-schema question, so I
checked the schema directly rather than trusting the chart-version chain:

- Pulled the `external-secrets` Helm chart straight from `charts.external-secrets.io` and diffed
  `templates/crds/grafana.yaml` between `2.7.0` and `2.8.0`: `secondsToLive` is absent in `2.7.0`,
  present in `2.8.0` (`format: int64, minimum: 1`), matching upstream
  external-secrets/external-secrets#6479.
- Confirmed `clusters/homelab/sources/infra-security-core.yaml` (`ref.tag:
  infra-security-core-v0.2.9`) pins the apps-repo's `HelmRelease` for `external-secrets` at chart
  `2.8.0` (`git show infra-security-core-v0.2.9:infrastructure/subsystems/security-core/external-secrets/helm-release-external-secrets.yaml`).
- Read the live `homelab` cluster, read-only, via the Kubernetes MCP: the installed
  `grafanas.generators.external-secrets.io` CRD's schema now includes `secondsToLive`, and all four
  `external-secrets` Deployments (`external-secrets`, `-cert-controller`, `-webhook`,
  `bitwarden-sdk-server`) are running `v2.8.0` images.
- Confirmed the `apps-ai` module at the currently pinned tag (`apps-ai-v0.6.22`) still authors
  `secondsToLive: 14400` (4h) on this generator (`apps/subsystems/ai/mcp-grafana/secrets.yaml`), so
  with the patch gone that value reaches the API server unchanged instead of being silently dropped.

## Other clusters

`nas` has no `apps-ai` Kustomization/source at all (`grep` across `clusters/nas/` turns up nothing),
so it never carried this patch — nothing to retire there. This PR only needs to touch `homelab`.

## Not in scope: existing accumulated tokens

Flux `prune` is disabled cluster-wide on `homelab` (the top-level kustomization patches every
`Kustomization` to `prune: false`), and this change only affects future reconciles. The
never-expiring `mcp-grafana` service-account tokens minted while the patch was in effect will **not**
be cleaned up by this PR — that's a manual step already tracked in clusters#770 §6
("Remove the now-dead `grafana_service_account_token_mcp` ... dead-key cleanup"). Not attempting it
here.

## Test plan

- [x] `pre-commit run --all-files` (yamllint, kubeconform validation, commitlint) passes locally.
- [x] `grep -rn secondsToLive .` across the repo returns no remaining references after this change.
- [ ] CI (`lint.yaml`, `diff-changes.yaml`) — will confirm once it runs; baseline established against
      recent merged PRs (all `success`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)