### PR TITLE
chore(cluster-homelab): deploy infra-observability-core (v0.24.6 -> v0.26.0)

### DIFF
--- a/clusters/homelab/sources/infra-observability-core.yaml
+++ b/clusters/homelab/sources/infra-observability-core.yaml
@@ -14,5 +14,5 @@ spec:
     !/infrastructure/subsystems/observability-core
   interval: 1m0s
   ref:
-    tag: infra-observability-core-v0.24.6
+    tag: infra-observability-core-v0.26.0
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git

--- a/clusters/homelab/storage/infra/pvc/grafana-data.yaml
+++ b/clusters/homelab/storage/infra/pvc/grafana-data.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-data
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: grafana
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: sc-longhorn-replicated
+  volumeMode: Filesystem

--- a/clusters/homelab/storage/infra/pvc/kustomization.yaml
+++ b/clusters/homelab/storage/infra/pvc/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- grafana-data.yaml
 - minio-data.yaml
 - pihole-data.yaml
 - pihole-logs.yaml


### PR DESCRIPTION
Rolls homelab onto `infra-observability-core-v0.26.0`, which makes Grafana's state durable, and pre-provisions the claim it expects.

## Changes

- **`storage/infra/pvc/grafana-data.yaml`** (new) — RWO, `sc-longhorn-replicated`, 2Gi, namespace `monitoring`
- **`storage/infra/pvc/kustomization.yaml`** — registers it
- **`sources/infra-observability-core.yaml`** — `v0.24.6` → `v0.26.0`

No `postBuild.substitute` changes: the module takes `existingClaim: grafana-data` and no longer has storage variables.

## Why the claim lives here

Per `DESIGN.md`, `storage/` objects are pre-provisioned ahead of the module that claims them and are excluded from Flux pruning *"since deleting them would mean data loss."* A chart-created PVC is owned by the HelmRelease and is deleted with it — and this volume holds the only copy of Grafana's service accounts, tokens, users and dashboard version history.

The `-data` suffix is load-bearing: the existing `^.+-data$` patch in `storage/infra/pvc/kustomization.yaml` stamps the Longhorn `recurring-job` labels onto it, so it is enrolled in the snapshot and backup schedules. Verified in the rendered output.

## What this fixes

Grafana kept its state in sqlite on an ephemeral volume, so every restart destroyed service accounts and their tokens, users, dashboard version history and alert state.

Observed 2026-08-07: Grafana rolled at ~20:48 and `mcp-grafana` went down with `invalid API key` — Grafana's log showed `Failed to authenticate request client=auth.client.api-key error="invalid API key"`. external-secrets only re-mints hourly, so it stayed down until the 21:52 refresh: **64 minutes**.

Also unblocks ppat/homelab-ops-kubernetes-apps#3418.

## Worth watching on first reconcile

This Kustomization has `timeout: 2m0s`. The first apply binds a new PVC and replaces the Grafana pod under `Recreate` (the outgoing pod must fully release the RWO volume first), so it is slower than a steady-state reconcile. If it trips the health check, that is the #765 shape rather than a fault in the module, and a retry should settle it. Not changed here, since #765 was deliberately deferred.

## History

An earlier revision of this PR bumped to `v0.25.0` and supplied `grafana_storage_class`/`grafana_storage_size`, because that version had the chart create the PVC. That was wrong for the reason above and was corrected in ppat/homelab-ops-kubernetes-apps#3578. `v0.25.0` was never deployed, so there is nothing to migrate.
