### PR TITLE
chore(cluster-homelab): deploy apps-ai (v0.6.22 -> v0.7.0)

### DIFF
--- a/clusters/homelab/sources/apps-ai.yaml
+++ b/clusters/homelab/sources/apps-ai.yaml
@@ -14,5 +14,5 @@ spec:
     !/apps/subsystems/ai
   interval: 1m0s
   ref:
-    tag: apps-ai-v0.6.22
+    tag: apps-ai-v0.7.0
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git


### PR DESCRIPTION
Rolls homelab onto `apps-ai-v0.7.0` (ppat/homelab-ops-kubernetes-apps#3557).

## What it carries

**`GRAFANA_ORG_ID: "1"` on mcp-grafana.** Unset, the server logged `No org ID found in request headers or environment variables` on *every* tool call. That noise is not cosmetic — it buried the auth-failure signal in the pod's logs, which is the surface the 2026-08-07 `invalid API key` outage was actually diagnosed from. `1` is correct because this is a single-org install and the ESO generator authenticates as admin with no org selector, so it is the only org its token can belong to.

**README fix.** The Required Variables table attributed the UniFi controller host to `\${domain_name}` when both `mcp-unifi-*` deployments substitute `\${dns_zone}`, which had no row at all. A cluster wiring from that table alone would have produced a silently empty hostname rather than an error.

## Variables

None new. `grafana_admin_username` appears in the module's table but is optional (`:=admin`) and unchanged from v0.6.22; `domain_name` and `dns_zone` already come from `cluster-secrets` via `substituteFrom`.

## Sequencing

Independent of #869 (observability-core) — different module, different source, no shared files.