### PR TITLE
chore(cluster-homelab): deploy apps-ai (v0.7.0 -> v0.7.1)

### DIFF
--- a/clusters/homelab/sources/apps-ai.yaml
+++ b/clusters/homelab/sources/apps-ai.yaml
@@ -14,5 +14,5 @@ spec:
     !/apps/subsystems/ai
   interval: 1m0s
   ref:
-    tag: apps-ai-v0.7.0
+    tag: apps-ai-v0.7.1
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git


### PR DESCRIPTION
## Summary
- Bumps `apps-ai`'s `GitRepository` ref to `apps-ai-v0.7.1`, which picks up the openclaw code-server sidecar from ppat/homelab-ops-kubernetes-apps#3585 (merged).
- No component wiring needed — code-server is built directly into openclaw's own manifests. home-assistant needed no changes at all.

## Test plan
- [x] `pre-commit run` clean.
- [x] Live-validated the exact code-server container/args/mounts on sandbox-talos — see ppat/homelab-ops-kubernetes-apps#3585's test plan.
- [x] apps-ai v0.7.1 released and tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)