### PR TITLE
fix(policies): exclude alloy* from disallow-host-path for parallel promtail run

### DIFF
--- a/policies/pod-security-standard/baseline/disallow-host-path.yaml
+++ b/policies/pod-security-standard/baseline/disallow-host-path.yaml
@@ -50,6 +50,24 @@ spec:
           - 'promtail*'
           namespaces:
           - logging
+      # Grafana Alloy is replacing promtail as the node-level log collector; both run in
+      # parallel for a 24-72h equivalence comparison before promtail is removed, so this
+      # exclusion exists alongside (not instead of) the promtail one above -- it is not
+      # cutover yet. Necessary because node log files (/var/log/pods, /var/log/journal,
+      # /run/log/journal), /etc/machine-id, and Alloy's own read-offset state
+      # (/var/lib/alloy) are only reachable via the node filesystem, which is inherent to
+      # any node-level log collector, not a shortcut specific to Alloy. Bounded by
+      # namespace (logging) AND name prefix (alloy*) together -- the prefix match is a
+      # coarse control, so anything else deployed into `logging` named alloy* inherits it
+      # too. Wrong if Alloy ever stops needing node-level file access, or if `logging`
+      # becomes a namespace where arbitrary workloads can be created. The promtail entry
+      # above is removed in the cutover PR once the comparison window closes; this one
+      # stays after that.
+      - resources:
+          names:
+          - 'alloy*'
+          namespaces:
+          - logging
       - resources:
           names:
           - 'intel-gpu-plugin-gpu-device*'


### PR DESCRIPTION
## Summary

- `disallow-host-path`: adds an `alloy*` / `logging` exclusion alongside the existing `promtail*` one — Grafana Alloy is replacing promtail (EOL upstream, frozen chart) as the node-level log collector, and both will run in parallel for a 24–72h equivalence comparison before promtail is removed. Alloy needs the same hostPath mounts promtail has today (`/var/log/pods`, `/run/log/journal`, `/var/log/journal`, `/etc/machine-id`, `/var/lib/docker/containers`, plus `/var/lib/kubelet/pods` for tailing other pods' CSI-mounted volumes), plus a new one for its own read-offset state (`/var/lib/alloy`, promtail's equivalent is `/run/promtail`).
- The `promtail*` entry is **not** removed here — that happens in a separate cutover PR once the comparison window closes and promtail is actually deleted. Both collectors need to be exempt simultaneously in the meantime.
- The new entry carries an inline rationale comment (matching this file's existing promtail/virt-handler comment convention) covering what it permits, why it's necessary, what bounds it, and what would make it wrong later — so a future cleanup pass can tell from the file alone whether it's still needed.

**This is not a blocker, and I want to be upfront about that.** Every ClusterPolicy in this repo is force-patched to `validationFailureAction: Audit` (see the patch in `clusters/homelab/kustomizations/policy-pod-security-standards.yaml`, and the policy file itself already says `Audit`). An un-exempted `alloy*` DaemonSet would still schedule fine — it would just generate `PolicyReport` findings. This change is about keeping the audit report meaningful during the parallel-run window, not about unblocking a deployment.

## Investigation: do other policies need a matching entry?

Checked every baseline/restricted policy under `policies/pod-security-standard/` for an existing `promtail` reference (`grep -rln promtail policies/`) — it appears in `disallow-host-path.yaml` only. Cross-checked against promtail's actual `HelmRelease` (`../homelab-ops-kubernetes-apps/infrastructure/subsystems/observability-core/promtail/`): no `privileged`, `hostNetwork`, `hostPID`, extra capabilities, or `runAsUser: 0` anywhere — so `disallow-privileged-containers`, `disallow-host-namespaces`, `disallow-capabilities(-strict)`, and the `require-run-as-non-root*` checks all pass promtail on their own merits, no exclusion needed. Alloy's needs (per the migration plan) are the same shape — a plain, unprivileged log-collector DaemonSet — so I'd expect the same result, though that's worth re-confirming once Alloy's own manifest exists.

One gap worth flagging rather than fixing here: promtail is **not** excluded from `restrict-volume-types` (restricted profile), even though `hostPath` isn't on that policy's volume-type allow-list at all (the `virt-handler` exclusion already in that file explains why: "hostPath isn't in this policy's allow-list at all, so anything using it needs this exclusion"). Confirmed live against the homelab cluster's `PolicyReport` (read-only, via MCP): every `promtail-*` pod currently shows 4 failing checks. This predates this PR and Alloy will inherit the identical gap unless a follow-up adds `alloy*` to `restrict-volume-types` too. Leaving it out of scope here on purpose — one concern per PR, and it's a decision for a separate change.

## Test plan

- [x] `pre-commit run --all-files` (yamllint, markdownlint, shellcheck, kubeconform manifest validation) — green
- [x] `commitlint` via the commit-msg hook — green (scope `policies`, from `commitlint.config.js`'s enum)
- [x] Confirmed promtail's actual security posture against its live `HelmRelease` in the apps repo rather than assuming parity with Alloy
- [x] Confirmed the `restrict-volume-types` gap against the homelab cluster's live `PolicyReport` rather than reasoning from YAML alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)