### PR TITLE
fix(cluster-homelab): add mountPropagation to promtail PVC log mount

### DIFF
--- a/clusters/homelab/services/logging/conf.d/extra-volumes.yaml
+++ b/clusters/homelab/services/logging/conf.d/extra-volumes.yaml
@@ -5,6 +5,11 @@ extraVolumes:
     path: /var/lib/kubelet/pods
 
 extraVolumeMounts:
+# mountPropagation is required: this path is where kubelet creates CSI mounts for other
+# pods' PVCs *after* this container's own mount already exists. Without HostToContainer,
+# those later mounts stay invisible to promtail with no error — the glob just matches
+# nothing, so pihole/plex/traefik PVC log tailing silently collects zero entries.
 - mountPath: /var/lib/kubelet/pods
   name: var-pod-volumes
   readOnly: true
+  mountPropagation: HostToContainer


### PR DESCRIPTION
## Symptom

Two of the three PVC log-tailing scrape jobs defined in
`clusters/homelab/services/logging/conf.d/extra-scrape-config.yaml` (`plex-pvc-logs`,
`traefik-access-rwx-logs`) have been silently collecting **zero** log entries. Live Loki confirms:

- `{filename="access.log"}` → 0 streams / 0 chunks / 0 entries / 0 bytes over 24h
- the `method` and `status` labels (produced only by the traefik job's JSON pipeline stage)
  don't exist anywhere in the label set
- `{app="plex"}` yields only `plex/0.log` (container stdout) — no `Plex Media Server.log`, and no
  `PMS Plugin Logs/...` paths at all

The third job (`pihole-pvc-logs`) works fine — see "why pihole was unaffected" below, which is the
detail that makes this diagnosis solid rather than a guess.

## Root cause

`clusters/homelab/services/logging/conf.d/extra-volumes.yaml` mounts `/var/lib/kubelet/pods` into
the promtail container with **no `mountPropagation`**, which defaults to `None` (private).

A per-pod CSI volume path (e.g.
`/var/lib/kubelet/pods/<pod-uid>/volumes/kubernetes.io~csi/<vol>/mount`) is *itself a new mount*,
created by kubelet/the CSI driver at pod-start time — it is not a file appearing inside an
already-mounted filesystem. Under propagation `None`, a container only ever sees mounts that
existed under that host path **at the instant its own bind-mount was created**; it never sees ones
created afterwards. `/var/log/pods` (the container-stdout path) is unaffected by this because those
are files inside a filesystem that's already mounted, not new mount points.

Confirmed directly against the live DaemonSet (read-only `kubectl get`) — the `var-pod-volumes`
volumeMount is exactly:

```json
{"mountPath": "/var/lib/kubelet/pods", "name": "var-pod-volumes", "readOnly": true}
```

No `mountPropagation` key at all.

### This is not an application bug, and not a glob/label bug

- Traefik really is writing the access log: its HelmRelease sets `--accesslog=true
  --accesslog.format=json --accesslog.filepath=/var/log/traefik/$(POD_NAME)/access.log`, `POD_NAME`
  is a genuine downward-API env var on the main container, the `traefik-logs` PVC
  (`sc-longhorn-rwx`, Longhorn = CSI) mounts at `/var/log/traefik` with no `subPath`, and the
  `log-rotate` sidecar's own logs show it repeatedly rotating that exact file under a `[ -s ... ]`
  (exists and non-empty) guard. Plex likewise symlinks `/var/log/plex → "Plex Media Server/Logs"`
  onto a Longhorn CSI PVC mounted with no `subPath`.
- Promtail's own pod logs show `msg="Adding target"
  key="/var/lib/kubelet/pods/<uid>/volumes/kubernetes.io~csi/*/mount/**/*.log:{app=\"plex\", ...}"`
  — so service discovery and the `keep` relabel rules are correct. But there is **never** a
  following `"watching new directory"` or `"tail routine: started"` line for those keys, while the
  sibling stdout targets for the same pod get both immediately. That's promtail's internal signature
  of a glob matching zero filesystem entries — no error or warning is logged, it just fails silently.

### Why pihole was unaffected (the timing that makes this convincing)

- promtail's pods are 24d old (their mount snapshot is from then)
- pihole's pod is 41d old with only container restarts since (same pod UID → same CSI mount), so its
  mount predates promtail's snapshot and was already visible when promtail's own mount was created
- plex's pod was created 2026-08-08 and traefik's DaemonSet rolled 2026-08-08 — both *after*
  promtail's snapshot, so their mounts are invisible under `None` propagation

Same pattern, same code path, only the pod-creation ordering differs — which is exactly what you'd
expect if propagation, not the app or the scrape config, is the cause.

## Fix

Add `mountPropagation: HostToContainer` to the `/var/lib/kubelet/pods` volumeMount in
`extra-volumes.yaml`, with a comment explaining why it's there (this is precisely the kind of
non-obvious setting a future maintainer could "clean up" and silently re-break, with zero errors to
flag it). `extra-scrape-config.yaml` is untouched — the globs are correct and simply have nothing to
match today.

**Promtail's pods must restart** for the new mount relationship to take effect — the running pods
won't pick this up in place, since it changes what's visible starting from the moment the container's
own mount is created. A Flux reconcile of the promtail HelmRelease will roll the DaemonSet
automatically, since this changes the pod template.

## Forward-looking: Grafana Alloy migration

This repair is deliberately landing **before** the promtail → Alloy migration, for two reasons:
(1) attribution — if the repair and the migration land together and something looks off afterwards,
we can't tell which change caused it; (2) baseline — the migration will be judged by "Alloy produces
the same streams as promtail," which is meaningless while two of promtail's three PVC jobs produce
nothing to compare against.

The Alloy DaemonSet will mount this same `/var/lib/kubelet/pods` path and is subject to the exact
same trap. That's being handled separately in the Alloy work, but flagging it here so the connection
is on record and nobody removes this setting later without knowing why it exists.

## Proof-of-fix checks (run after merge + Flux reconcile)

- [ ] `{filename="access.log"}` goes from 0 streams to >0
- [ ] `{app="traefik", method=~".+"}` returns entries
- [ ] `filename` label values start including `Plex Media Server.log`
- [ ] **Regression guard:** `{filename="FTL.log"}` (pihole) stays non-zero after promtail's pods
      restart — confirms the already-working job wasn't disturbed

## Open item (honest, not assumed)

Once the mount is visible and plex log data is flowing, worth re-confirming that the plex job's `**`
glob (`/var/lib/kubelet/pods/$1/volumes/kubernetes.io~csi/*/mount/**/*.log`) actually descends into
`PMS Plugin Logs/` and not just the top-level `Plex Media Server.log`. Cheap to check against real
data once entries exist — not safe to assume from the glob syntax alone, and it's exactly the kind of
partial fix this bug's silent-failure mode could hide again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)