### PR TITLE
fix(policies): exempt promtail/alloy hostPath from restrict-volume-types

### DIFF
--- a/policies/pod-security-standard/restricted/restrict-volume-types.yaml
+++ b/policies/pod-security-standard/restricted/restrict-volume-types.yaml
@@ -159,3 +159,37 @@ spec:
           namespaces:
           - sandbox-docker
           - sandbox-talos
+      # promtail hostPath-mounts node log files, /etc/machine-id, and other pods' CSI-mounted
+      # volumes under /var/lib/kubelet/pods to do its job as a node-level log collector --
+      # hostPath isn't on this policy's allow-list at all, so it fails the `restricted-volumes`
+      # rule below (confirmed on the live PolicyReport for a promtail pod: `restrict-volume-types`
+      # / `restricted-volumes` is one of four rules it fails, alongside
+      # require-run-as-non-root-user, require-run-as-nonroot and restrict-seccomp-strict, none
+      # of which this exclusion touches). It has failed this rule, unflagged, since this policy
+      # was added; added here retroactively rather than left to keep masquerading as compliant.
+      # Grafana Alloy is replacing promtail as the node-level log collector; both run in
+      # parallel for a 24-72h comparison before promtail is removed (same pairing as
+      # ../baseline/disallow-host-path.yaml), so this exclusion is temporary and goes away with
+      # promtail in the cutover PR.
+      - resources:
+          names:
+          - 'promtail*'
+          namespaces:
+          - logging
+      # Alloy needs the same node-filesystem access for the same reason: node log files
+      # (/var/log/pods, /var/log/journal, /run/log/journal), /etc/machine-id, other pods'
+      # CSI-mounted PVC paths under /var/lib/kubelet/pods, and its own read-offset state are
+      # only reachable from the node filesystem -- inherent to any node-level collector, not a
+      # shortcut a refactor removes. Unlike promtail, Alloy runs non-root (runAsNonRoot, uid/gid
+      # 473, supplementalGroups: [0, <journal gid>]), so it already passes
+      # require-run-as-nonroot; this hostPath-driven volume-type exclusion is the only
+      # restricted-profile rule it needs relaxed. Bounded by namespace (logging) AND name prefix
+      # (alloy*) together -- the prefix match is coarse, so anything else deployed into
+      # `logging` named alloy* inherits it too. Wrong if Alloy ever stops needing node-level
+      # file access, or if `logging` becomes a namespace where arbitrary workloads can be
+      # created. Stays after promtail's exclusion above is removed at cutover.
+      - resources:
+          names:
+          - 'alloy*'
+          namespaces:
+          - logging


### PR DESCRIPTION
## Summary

- `restrict-volume-types.yaml`'s restricted-profile allow-list has no `hostPath` entry, so promtail (and Grafana Alloy, being added alongside it for a log-collector migration) fail its `restricted-volumes` rule on every pod -- silently, since every policy in this repo is force-patched to `validationFailureAction: Audit`.
- Adds a `promtail*`/`alloy*` exclusion scoped to namespace `logging`, mirroring the existing exclusion shape in `../baseline/disallow-host-path.yaml` exactly (two separate name-glob blocks, since promtail's is temporary and removed at cutover while Alloy's is permanent).
- Documents the exemption in the policy file itself: what it permits, why it's inherent to a node-level collector, what bounds it (namespace + name prefix together), what would make it wrong later, and the promtail/Alloy root-vs-non-root asymmetry.

## Verification

Read the live `PolicyReport` for a promtail pod (`logging/promtail-nbrdk`, via the `1f908c58-...` object -- its UID, not its scope name) rather than assuming. It fails exactly 4 of 27 checks:

| policy | rule |
|---|---|
| `restrict-volume-types` | `restricted-volumes` (fixed by this PR) |
| `require-run-as-non-root-user` | `run-as-non-root-user` |
| `require-run-as-nonroot` | `run-as-non-root` |
| `restrict-seccomp-strict` | `check-seccomp-strict` |

This confirms the exclusion targets the right (and only) rule in `restrict-volume-types`.

**Scope creep check (not fixed here, reporting only):** promtail also lacks exclusions in `require-run-as-non-root-user`, `require-run-as-nonroot`, and `restrict-seccomp-strict` -- all three restricted-profile policies it violates. The task's own brief already flagged the run-as-nonroot pair as known/root-caused; `restrict-seccomp-strict` was not previously called out and is a new finding. None of these are touched by this PR -- one concern per PR.

## Test plan

- [x] `yamllint --strict` on the changed file
- [x] `pre-commit run --files policies/pod-security-standard/restricted/restrict-volume-types.yaml` (all hooks pass, including kubeconform manifest validation)
- [x] Verified the exclusion targets the actual failing rule via the live `PolicyReport`, not assumption
- [ ] CI (`gh pr checks --watch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)