### PR TITLE
fix(cluster-homelab): bound plex PVC-log glob to its two real depths

### DIFF
--- a/clusters/homelab/kustomizations/infra-observability-core.yaml
+++ b/clusters/homelab/kustomizations/infra-observability-core.yaml
@@ -330,7 +330,7 @@ spec:
           }
 
           // ----------------------------------------------------------------------------------
-          // plex -- *.log at any depth below the CSI volume root
+          // plex -- *.log at the CSI volume root, or one level down in a named subdirectory
           // ----------------------------------------------------------------------------------
 
           discovery.relabel "cluster_plex_pvc_logs" {
@@ -348,10 +348,28 @@ spec:
           		regex         = "plex"
           	}
 
+          	// The middle `*` matches the pod's CSI volume by PersistentVolume name, which this
+          	// job deliberately does not pin -- plex-logs is dynamically provisioned, so its PV
+          	// name is generated and would change (silently stopping collection) if the volume
+          	// were ever recreated.
+          	//
+          	// Do not widen `{*,*/*}` back to `**`: this pod also mounts its 32Gi config volume
+          	// and the entire read-only media library through the same kubernetes.io~csi/
+          	// prefix, and `**` recursively re-walks all three on every file_match sync_period,
+          	// not just plex-logs -- that walk measured ~740m CPU sustained on the node this pod
+          	// lands on (vs 17-52m for the DaemonSet's other pods), from a glob that did less
+          	// useful work than its peers while doing it. `{*,*/*}` is a doublestar alternation
+          	// bounded to the two depths plex actually writes logs at: the volume root, and one
+          	// named subdirectory (`PMS Plugin Logs/`). It deliberately excludes the crash
+          	// report file several levels deep in the *config* volume (Library/Application
+          	// Support/Plex Media Server/Crash Reports/...): that's a diagnostic dump from the
+          	// wrong volume, not a log this job is meant to collect, and reaching it would mean
+          	// either pinning the config volume's PV name or re-adding the expensive recursive
+          	// walk this change removes.
           	rule {
           		action        = "replace"
           		source_labels = ["__meta_kubernetes_pod_uid"]
-          		replacement   = "/var/lib/kubelet/pods/$1/volumes/kubernetes.io~csi/*/mount/**/*.log"
+          		replacement   = "/var/lib/kubelet/pods/$1/volumes/kubernetes.io~csi/*/mount/{*,*/*}.log"
           		target_label  = "__path__"
           	}
 
@@ -414,8 +432,13 @@ spec:
           	targets    = discovery.relabel.cluster_plex_pvc_logs.output
           	forward_to = [loki.process.cluster_plex_pvc_logs.receiver]
 
+          	// Defence-in-depth alongside the bounded glob above: these are tailed files, not a
+          	// once-per-period scrape, so a slower re-glob only delays *new* files/pods showing
+          	// up, by up to a minute -- not a problem for logs nothing alerts on. A future glob
+          	// mistake here (or a fourth volume added to the pod) re-walks less often.
           	file_match {
-          		enabled = true
+          		enabled     = true
+          		sync_period = "1m"
           	}
           }
 

--- a/clusters/homelab/services/logging/conf.d/cluster-pvc-logs.alloy
+++ b/clusters/homelab/services/logging/conf.d/cluster-pvc-logs.alloy
@@ -131,7 +131,7 @@ loki.process "cluster_pihole_pvc_logs" {
 }
 
 // ----------------------------------------------------------------------------------
-// plex -- *.log at any depth below the CSI volume root
+// plex -- *.log at the CSI volume root, or one level down in a named subdirectory
 // ----------------------------------------------------------------------------------
 
 discovery.relabel "cluster_plex_pvc_logs" {
@@ -149,10 +149,28 @@ discovery.relabel "cluster_plex_pvc_logs" {
 		regex         = "plex"
 	}
 
+	// The middle `*` matches the pod's CSI volume by PersistentVolume name, which this
+	// job deliberately does not pin -- plex-logs is dynamically provisioned, so its PV
+	// name is generated and would change (silently stopping collection) if the volume
+	// were ever recreated.
+	//
+	// Do not widen `{*,*/*}` back to `**`: this pod also mounts its 32Gi config volume
+	// and the entire read-only media library through the same kubernetes.io~csi/
+	// prefix, and `**` recursively re-walks all three on every file_match sync_period,
+	// not just plex-logs -- that walk measured ~740m CPU sustained on the node this pod
+	// lands on (vs 17-52m for the DaemonSet's other pods), from a glob that did less
+	// useful work than its peers while doing it. `{*,*/*}` is a doublestar alternation
+	// bounded to the two depths plex actually writes logs at: the volume root, and one
+	// named subdirectory (`PMS Plugin Logs/`). It deliberately excludes the crash
+	// report file several levels deep in the *config* volume (Library/Application
+	// Support/Plex Media Server/Crash Reports/...): that's a diagnostic dump from the
+	// wrong volume, not a log this job is meant to collect, and reaching it would mean
+	// either pinning the config volume's PV name or re-adding the expensive recursive
+	// walk this change removes.
 	rule {
 		action        = "replace"
 		source_labels = ["__meta_kubernetes_pod_uid"]
-		replacement   = "/var/lib/kubelet/pods/$1/volumes/kubernetes.io~csi/*/mount/**/*.log"
+		replacement   = "/var/lib/kubelet/pods/$1/volumes/kubernetes.io~csi/*/mount/{*,*/*}.log"
 		target_label  = "__path__"
 	}
 
@@ -215,8 +233,13 @@ loki.source.file "cluster_plex_pvc_logs" {
 	targets    = discovery.relabel.cluster_plex_pvc_logs.output
 	forward_to = [loki.process.cluster_plex_pvc_logs.receiver]
 
+	// Defence-in-depth alongside the bounded glob above: these are tailed files, not a
+	// once-per-period scrape, so a slower re-glob only delays *new* files/pods showing
+	// up, by up to a minute -- not a problem for logs nothing alerts on. A future glob
+	// mistake here (or a fourth volume added to the pod) re-walks less often.
 	file_match {
-		enabled = true
+		enabled     = true
+		sync_period = "1m"
 	}
 }
 


### PR DESCRIPTION
## Summary

`alloy-glnwz` (the pod on `gmktec-g3plus-2`) burns ~740m CPU sustained vs 17-52m for its three DaemonSet peers, allocating memory at ~63.4 MB/s vs 0.87-2.0 MB/s on peers, while doing *less* line-processing work (18 lines/s across 99 files vs a peer's 36 lines/s across 139 files for 27m CPU). Root cause, confirmed via Loki: the cluster-owned plex job's `__path__` is `.../kubernetes.io~csi/*/mount/**/*.log`. The middle `*` matches the pod's CSI volume by PV name (correctly unconstrained, since plex-logs is dynamically provisioned); the trailing `**` recursively re-walks *every* CSI volume attached to the pod on every `file_match` `sync_period` (10s default) — not just the intended 3Gi `plex-logs` volume, but also the 32Gi `plex-data` config volume and the entire read-only NFS media library (`media-read-only`) mounted on the same pod. Evidence it's really walking the wrong volumes: Loki shows the job tailing a `Crash Reports` file several directories deep inside the config volume.

- `{app="plex", collector="alloy"}` `filename` values (queried live) show the job only ever needs two depths: the `plex-logs` volume root (`Plex Media Server*.log`, `Plex Media Scanner *.log`, `Plex Transcoder Statistics*.log`) and one named subdirectory (`PMS Plugin Logs/*.log`).
- Fix: replace `**` with the doublestar alternation `{*,*/*}`, bounding the walk to exactly those two depths on every CSI volume the pod has, on every node. Does **not** pin `plex-logs`'s PV name (dynamically provisioned; a literal name would silently break on recreation — the exact failure class this alloy migration has already hit three times).
- Deliberately drops the `Crash Reports` file: it's diagnostic dump data from the *wrong* (config) volume, not a log this job is meant to collect. Keeping it would require either pinning the config volume's PV name or re-adding the expensive recursive walk.
- Added `sync_period = "1m"` to the plex job's `file_match` as defence-in-depth (tailed files, not a scrape — a slower re-glob only delays new files/pods showing up by up to a minute, which nothing here needs to be faster than).
- Checked pihole and traefik, the other two cluster-owned PVC-log jobs in the same file: neither uses `**`. traefik's pod has only one CSI volume (traefik-logs) so its `*` never fans out; pihole's job globs one level (`*/mount/*.log`, no recursion) even though its pod does have two CSI volumes (pihole-data, pihole-logs). Neither is exposed to this failure mode — left unchanged.

## Validation

Ran the real `grafana/alloy:v1.18.1` binary (the version this repo's CI pins) on a Docker sandbox VM against a scratch directory tree mirroring the plex pod's actual shape: three sibling `kubernetes.io~csi/<name>/mount/` trees — one with the real `plex-logs` filenames/depths, one standing in for the config volume (including a decoy `Crash Reports` file at the real depth), one standing in for the media library (including a decoy `.log` file buried two directories deep, to catch any residual recursion).

| pattern | files tailed | decoy volumes touched |
|---|---|---|
| old `**` | 13 | both (config-volume Crash Reports + media-library decoy) |
| new `{*,*/*}` | 11 | none |

The 11 matched by the new pattern are exactly the files currently collected from `plex-logs` (9 root-level + 2 `PMS Plugin Logs/`); the old pattern matches those same 11 plus the 2 decoys. Also ran this repo's own CI gate (`ci/scripts/alloy-lint.sh`) against the changed fragment on that same binary: `fmt --test` and `validate --stability.level=generally-available` (with `ci/alloy/module-anchors.alloy.stub`) both pass. `check-embedded` passes locally too — the Flux `Kustomization` patch copy in `clusters/homelab/kustomizations/infra-observability-core.yaml` was regenerated verbatim from the source fragment.

## Post-merge check (once deployed)

After this rolls out to `gmktec-g3plus-2`, verify in Grafana:

1. **CPU falls**: `sum(rate(container_cpu_usage_seconds_total{pod="alloy-glnwz", container="alloy"}[5m]))` should drop from ~0.74 toward the 0.017-0.052 range its peers sit at (compare against the other `alloy-*` pods on the DaemonSet).
2. **filename set is unchanged apart from the deliberate drop**: `topk(50, count by (filename) (count_over_time({app="plex", collector="alloy"}[1h])))`, taken before and after rollout, should show the same set of `filename` values *except* `Library/Application Support/Plex Media Server/Crash Reports/.../*.log`, which should disappear (deliberately dropped — see above).
3. (Optional sanity) Memory allocation rate for the pod should fall out of the ~60 MB/s range back in line with peers (~1-2 MB/s).

## Test plan

- [x] `pre-commit run --all-files` (yamllint, kubeconform validate-kubernetes-manifests, commitlint) — green, diff scoped to the two intended files only
- [x] `ci/scripts/alloy-lint.sh`-equivalent checks (`fmt --test`, `validate`, embedded-copy diff) run manually against `grafana/alloy:v1.18.1` — green
- [x] Sandbox-VM proof: new pattern matches the 11 real files, old pattern also reaches 2 decoy files — done, see Validation above
- [ ] CI (`gh pr checks`)