### PR TITLE
chore(cluster-homelab): deploy infra-observability-core (v0.26.1 -> v0.27.0)

### DIFF
--- a/clusters/homelab/sources/infra-observability-core.yaml
+++ b/clusters/homelab/sources/infra-observability-core.yaml
@@ -14,5 +14,5 @@ spec:
     !/infrastructure/subsystems/observability-core
   interval: 1m0s
   ref:
-    tag: infra-observability-core-v0.26.1
+    tag: infra-observability-core-v0.27.0
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git


### PR DESCRIPTION
Rolls homelab onto `infra-observability-core-v0.27.0`, the promtail -> Grafana
Alloy cutover. **What merging this actually does, in order:**

1. **Removes promtail from the module manifest — but promtail keeps running.**
   Flux `prune` is force-disabled cluster-wide, so deleting promtail's
   manifests from the module does not delete the running `HelmRelease`. That
   is deliberate: promtail is the safety net until Alloy is proven.
2. **Rolls the Alloy `DaemonSet`** (new memory limits — 512Mi `alloy`/64Mi
   `config-reloader` — plus the dropped `collector="alloy"` external label).
   This is a real pod spec change, so every Alloy pod restarts.

## Why the Alloy rollout matters here

Alloy has run in parallel with promtail and been validated, but **its read
offsets surviving a pod restart is the one property that has not yet been
tested** — nothing has restarted it since it went live. This rollout is that
test.

**Watch during/after rollout:**

```promql
sum(rate(loki_distributor_bytes_received_total[5m]))
```

- Staying near the current baseline (~31 KB/s) => positions persisted across
  the restart, cutover is sound.
- A jump back toward ~2 MB/s (promtail-parity full-file re-read volume) =>
  positions did **not** persist. Do not delete promtail if this happens —
  Alloy would be the only collector and would be re-ingesting from scratch.

## Only after that gate passes

```
kubectl -n logging delete helmrelease promtail-release
```

`helm-controller` performs a real uninstall on delete (unlike a manifest
removal, which prune can't reach): this takes the `DaemonSet`, `ServiceAccount`,
RBAC, `Service`, `ServiceMonitor`, `PrometheusRule` and release secrets with
it. Afterwards, sweep the leftover kustomize-owned promtail `ConfigMap`s by
hand (same prune-disabled reason they won't self-clean).

## Follow-ups (not in this PR)

- Remove the `promtail-extra-config` generator from
  `clusters/homelab/services/logging/kustomization.yaml`.
- Remove the `promtail*` exclusions in
  `policies/pod-security-standard/baseline/disallow-host-path.yaml` and
  `policies/pod-security-standard/restricted/restrict-volume-types.yaml`.

## Tag verification

- `infra-observability-core-v0.27.0` = apps-repo commit `2474833e`
  (`chore(release): release infra-observability-core v0.27.0 (#3603)`).
- `feat(infra-observability-core)!: remove promtail and cut over to grafana
  alloy (#3602)` (`45411bd3`) is confirmed an ancestor of that tag.
- Confirmed `infrastructure/subsystems/observability-core/promtail/` is
  absent from the tagged tree.