### PR TITLE
feat(cluster-homelab): extend prometheus retention to 30d and prep memory headroom

### DIFF
--- a/clusters/homelab/kustomizations/infra-observability-core.yaml
+++ b/clusters/homelab/kustomizations/infra-observability-core.yaml
@@ -37,10 +37,28 @@ spec:
       #   prometheus_retention_size = 70-80% x prometheus_storage_size
       # must match: should match '(^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$'
       prometheus_retention_size: 50GiB
-      prometheus_retention_period: 336h
+      # 720h (30d) so the Garage-vs-MinIO trial (apps#3611) has a comparable 30-day
+      # metrics window. Storage headroom checked, not assumed: prometheus_tsdb_storage_blocks_bytes
+      # measured ~15.8GiB at 336h (2026-08-12), which projects to ~34GiB at 720h -- comfortably
+      # inside both prometheus_retention_size (50GiB) and the 60Gi PV below, so storage is
+      # unchanged here. See apps#3613 for why memory (not storage) is this cluster's actual
+      # constraint at 30d retention.
+      prometheus_retention_period: 720h
       prometheus_storage_class: sc-longhorn-replicated
       prometheus_storage_size: 60Gi
       prometheus_volume_name: pv-prometheus
+      # Pre-existing defect (apps#3613), surfaced by this project: measured 2026-08-12 at
+      # 99.9% of the hardcoded 2Gi limit (max_over_time(container_memory_working_set_bytes{
+      # container="prometheus"}[14d]) = 1.9975GiB), and a 30-day range query over ~349k head
+      # series risks an OOMKill at that margin. These two variables are TAG-GATED: the module
+      # doesn't read them yet -- they land in apps-repo PR #3620 (parameterises
+      # prometheus.prometheusSpec.resources), currently draft/unmerged. Until sourceRef ref.tag
+      # in ../sources/infra-observability-core.yaml is bumped to a release containing #3620, the
+      # module keeps its hardcoded 1Gi/2Gi and these two keys are inert extra substitute values.
+      # TODO(apps#3620): once merged and released, bump ref.tag in
+      # clusters/homelab/sources/infra-observability-core.yaml to that version.
+      prometheus_memory_request: 2Gi
+      prometheus_memory_limit: 4Gi
       loki_storage_class: sc-longhorn-replicated
       loki_retention_size: 30d
       # each of the 3 monolithic replicas combines the write/read/backend roles that SimpleScalable


### PR DESCRIPTION
## What

- `clusters/homelab/kustomizations/infra-observability-core.yaml`:
  - `prometheus_retention_period`: `336h` → `720h` (**live now**)
  - adds `prometheus_memory_request: 2Gi` / `prometheus_memory_limit: 4Gi` (**tag-gated**, see below)

## Why, with the measurements (live cluster, 2026-08-12)

Two independent reasons:

1. **The Garage-vs-MinIO 30-day trial** (ppat/homelab-ops-kubernetes-apps#3611) needs a comparable metrics window. Retention was `336h` (14d), so a 30-day comparison was impossible.
2. **Prometheus is at 99.9% of its memory limit right now**, independently of the Garage project — filed separately as ppat/homelab-ops-kubernetes-apps#3613:
   - `max_over_time(container_memory_working_set_bytes{container="prometheus"}[14d])` = **1.9975 GiB** against a **2Gi** limit (reconfirmed live: `2144849920` bytes = 1.9976 GiB)
   - `prometheus_tsdb_head_series` = 349,061 (reconfirmed live: 347,536)
   - `restartCount` is 0 only because the pod was recreated 2026-07-31, not evidence of headroom
   - A 30-day range query over that series count risks an OOMKill

## Storage — deliberately unchanged

`prometheus_retention_size` (50GiB) and `prometheus_storage_size` (60Gi PV) are **not** touched. Verified live:

- `prometheus_tsdb_storage_blocks_bytes` = `17027153627` bytes ≈ **15.86 GiB** at 336h (issue #3611/#3613 quoted 15.73 GiB from an earlier measurement that same day; the small delta is normal ongoing block growth)
- Projected at 720h: 15.86 × (720/336) ≈ **34 GiB** — comfortably inside both the 50GiB `retentionSize` and the 60Gi PV

No contradiction found; storage math holds.

## Dependency / tag-gating

`prometheus_memory_request`/`prometheus_memory_limit` only take effect once apps-repo PR [#3620](https://github.com/ppat/homelab-ops-kubernetes-apps/pull/3620) (`refactor(infra-observability-core): parameterise prometheus memory resources`) is merged and released — **that PR is currently draft and unmerged**, stacked on another draft PR (#3616), so **no release tag containing it exists yet**.

I did not invent a tag. Instead:

- The two new `postBuild.substitute` keys are added now — Flux tolerates unused substitute keys, so this is harmless; the module doesn't reference `${prometheus_memory_request}`/`${prometheus_memory_limit}` at the currently-pinned tag (`infra-observability-core-v0.27.0`), so they're inert until the tag bump.
- A `TODO(apps#3620)` comment is left directly above them in the manifest, naming the blocking PR and the file (`clusters/homelab/sources/infra-observability-core.yaml`) that needs its `ref.tag` bumped once a release containing #3620 exists.

**Live now:** `prometheus_retention_period` → `720h`.
**Tag-gated:** the memory limit/request raise (currently a no-op; module still runs on its hardcoded `1Gi`/`2Gi` until the tag bump lands).

## Verification

`pre-commit run --all-files` — clean, no findings, nothing touched outside the one changed file (checked via `git status --short` before/after, and the diff below is the entire change).

```
$ git diff --stat main
 clusters/homelab/kustomizations/infra-observability-core.yaml | 20 +++++++++++++++++++-
 1 file changed, 19 insertions(+), 1 deletion(-)
```

## Refs

- ppat/homelab-ops-kubernetes-apps#3611 (Garage trial, tracking)
- ppat/homelab-ops-kubernetes-apps#3613 (Prometheus memory limit, pre-existing defect fixed here)
- Depends on (unreleased) ppat/homelab-ops-kubernetes-apps#3620 for the memory variables to take effect
