### PR TITLE
fix(cluster-homelab): bring prometheus data volume under gitops

### DIFF
--- a/clusters/homelab/storage/infra/pv/kustomization.yaml
+++ b/clusters/homelab/storage/infra/pv/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- pv-prometheus.yaml
 - static-nfs-share-unifi-backups.yaml

--- a/clusters/homelab/storage/infra/pv/pv-prometheus.yaml
+++ b/clusters/homelab/storage/infra/pv/pv-prometheus.yaml
@@ -1,0 +1,29 @@
+---
+# Statically created Longhorn volume, adopted into GitOps here (apps#3614) so it is
+# recoverable from Git rather than existing only as live cluster state -- created
+# 2025-07-03, outside Flux, with no manifest in either this repo or the apps repo until
+# now. Every field below is a verbatim copy of the live object (field-by-field diff done
+# in the PR description); do not "clean up" values that look redundant (e.g. the empty
+# diskSelector/nodeSelector) without re-diffing against the live PV first, since most of
+# spec.csi is immutable once bound and a mismatch fails the apply rather than converging.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-prometheus
+spec:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 60Gi
+  csi:
+    driver: driver.longhorn.io
+    fsType: ext4
+    volumeAttributes:
+      diskSelector: ""
+      nodeSelector: ""
+      numberOfReplicas: "2"
+      staleReplicaTimeout: "20"
+    volumeHandle: pv-prometheus
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: sc-longhorn-replicated
+  volumeMode: Filesystem


### PR DESCRIPTION
## What

Adds `clusters/homelab/storage/infra/pv/pv-prometheus.yaml` (a `PersistentVolume` manifest for the existing, already-bound Longhorn volume Prometheus runs on) and wires it into `clusters/homelab/storage/infra/pv/kustomization.yaml`.

## Why

The Prometheus data volume is a **static Longhorn PV created 2025-07-03** that exists in neither this repo nor the apps repo — `clusters/homelab/storage/infra/pv/` previously contained only the unrelated static NFS share for unifi backups. If this volume is lost (node failure, accidental deletion, Longhorn issue), it cannot be recreated declaratively and Prometheus will not schedule. This matters more than usual here because **Flux `prune` is disabled cluster-wide**, so nothing surfaces this kind of drift. Tracked as ppat/homelab-ops-kubernetes-apps#3614.

## Field-by-field diff against the live object

Read via read-only cluster access, 2026-08-12. Live `PersistentVolume/pv-prometheus`:

```json
{
  "metadata": {
    "name": "pv-prometheus",
    "annotations": {
      "longhorn.io/volume-scheduling-error": "",
      "pv.kubernetes.io/bound-by-controller": "yes"
    },
    "finalizers": ["kubernetes.io/pv-protection", "external-attacher/driver-longhorn-io"]
  },
  "spec": {
    "accessModes": ["ReadWriteOnce"],
    "capacity": {"storage": "60Gi"},
    "claimRef": {
      "kind": "PersistentVolumeClaim",
      "name": "prometheus-kube-prometheus-stack-db-prometheus-kube-prometheus-stack-0",
      "namespace": "monitoring", "uid": "...", "resourceVersion": "..."
    },
    "csi": {
      "driver": "driver.longhorn.io",
      "fsType": "ext4",
      "volumeAttributes": {
        "diskSelector": "", "nodeSelector": "",
        "numberOfReplicas": "2", "staleReplicaTimeout": "20"
      },
      "volumeHandle": "pv-prometheus"
    },
    "persistentVolumeReclaimPolicy": "Retain",
    "storageClassName": "sc-longhorn-replicated",
    "volumeMode": "Filesystem"
  },
  "status": {"phase": "Bound"}
}
```

| Field | Live | Manifest | Match |
| --- | --- | --- | --- |
| `apiVersion`/`kind` | `v1`/`PersistentVolume` | same | ✓ |
| `metadata.name` | `pv-prometheus` | same | ✓ |
| `spec.accessModes` | `[ReadWriteOnce]` | same | ✓ |
| `spec.capacity.storage` | `60Gi` | same | ✓ |
| `spec.csi.driver` | `driver.longhorn.io` | same | ✓ |
| `spec.csi.fsType` | `ext4` | same | ✓ |
| `spec.csi.volumeAttributes.diskSelector` | `""` | same | ✓ |
| `spec.csi.volumeAttributes.nodeSelector` | `""` | same | ✓ |
| `spec.csi.volumeAttributes.numberOfReplicas` | `"2"` | same | ✓ |
| `spec.csi.volumeAttributes.staleReplicaTimeout` | `"20"` | same | ✓ |
| `spec.csi.volumeHandle` | `pv-prometheus` | same | ✓ |
| `spec.persistentVolumeReclaimPolicy` | `Retain` | same | ✓ |
| `spec.storageClassName` | `sc-longhorn-replicated` | same | ✓ |
| `spec.volumeMode` | `Filesystem` | same | ✓ |
| `spec.nodeAffinity` | absent (Longhorn CSI doesn't set PV-level node affinity; scheduling is internal to the driver) | absent | ✓ (n/a) |
| `metadata.annotations` (2 controller-written: `longhorn.io/volume-scheduling-error`, `pv.kubernetes.io/bound-by-controller`) | present | **omitted** | intentional, see below |
| `spec.claimRef` | present, bound to the live PVC | **omitted** | intentional, see below |
| `metadata.finalizers`, `status.*` | present | n/a (not settable via apply) | n/a |

Every field the manifest sets is byte-identical to the live value. No mismatch anywhere.

## Why `claimRef` and the two annotations are deliberately omitted (this is the safety-critical part)

`clusters/homelab/storage/kustomization.yaml` already patches **every** `PersistentVolume`/`PersistentVolumeClaim` in this tree with:

```yaml
kustomize.toolkit.fluxcd.io/prune: disabled
kustomize.toolkit.fluxcd.io/ssa: merge
```

`ssa: merge` means Flux does a server-side apply that only sets the fields present in the manifest — it does not strip or reset fields it doesn't mention. So:

- Omitting `claimRef` means Flux never touches it; the controller-set binding to the live, already-bound PVC stays exactly as-is. Including a hand-typed `claimRef` here would risk a UID/resourceVersion mismatch that either gets ignored or (worse) confuses the binding — there's no upside to including it since the volume is already `Bound`.
- Omitting the two controller-written annotations means Flux never touches them either — they stay as whatever Longhorn/the PV controller manage.
- `persistentVolumeReclaimPolicy: Retain` is set explicitly and matches live exactly — this is the one field where a mismatch would be genuinely dangerous (a `Delete` policy reset could destroy the underlying Longhorn volume on unbind), so it's called out here specifically as verified-matching.

This `ssa: merge` + `prune: disabled` combination is not new or unproven — it's the same mechanism already governing every other adopted static/dynamic PV/PVC in this tree (`grafana-data`, `minio-data`, `pihole-*`, `traefik-logs`, `static-nfs-share-unifi-backups`).

## What Flux does on first apply

Because every field the manifest declares already matches the live object's value exactly, this is a **declarative no-op against the running cluster** — Flux/kustomize-controller registers as a co-owner (via SSA) of the fields it sets, but changes no actual value. It does not touch `claimRef`, the controller annotations, `finalizers`, or `status`. No data-loss risk identified; the manifest declares existing reality into Git rather than mutating anything.

## PVC — not included, and why

The bound PVC (`prometheus-kube-prometheus-stack-db-prometheus-kube-prometheus-stack-0`) is **not** a standalone object needing a manifest here: it's created by the `prometheus-operator`-managed `StatefulSet`'s `volumeClaimTemplate`, which is already fully GitOps-tracked in the apps repo (`infrastructure/subsystems/observability-core/kube-prometheus-stack/helm-release-kube-prometheus-stack.yaml`, pinning `volumeName: ${prometheus_volume_name}` = `pv-prometheus`). The Longhorn recurring-job labels visible on the live PVC also already come from an existing patch in `clusters/homelab/kustomizations/infra-observability-core.yaml` (the `volumeClaimTemplate/metadata/labels` patch). Only the underlying static PV was missing from GitOps.

## Verification

`pre-commit run --all-files` — clean, no findings. `kustomize build clusters/homelab/storage/` confirmed the new PV renders with the expected `prune: disabled` / `ssa: merge` annotations applied automatically by the existing blanket patch, with no manual annotation needed in the new manifest.

```
$ git diff --stat main
 clusters/homelab/storage/infra/pv/kustomization.yaml    |  1 +
 clusters/homelab/storage/infra/pv/pv-prometheus.yaml    | 29 +++++++++++++++++++++++++++++
 2 files changed, 30 insertions(+)
```

## Refs

- ppat/homelab-ops-kubernetes-apps#3611 (Garage trial, tracking — this PR is independent of it)
- ppat/homelab-ops-kubernetes-apps#3614 (Prometheus PV DR hole, fixed here)
