### PR TITLE
chore(cluster-homelab): deploy infra-observability-core v0.29.0 with required loki secret-store key variables

### DIFF
--- a/clusters/homelab/kustomizations/infra-observability-core.yaml
+++ b/clusters/homelab/kustomizations/infra-observability-core.yaml
@@ -37,10 +37,22 @@ spec:
       #   prometheus_retention_size = 70-80% x prometheus_storage_size
       # must match: should match '(^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$'
       prometheus_retention_size: 50GiB
-      prometheus_retention_period: 336h
+      # 720h (30d) so the Garage-vs-MinIO trial (apps#3611) has a comparable 30-day
+      # metrics window. Storage headroom checked, not assumed: prometheus_tsdb_storage_blocks_bytes
+      # measured ~15.8GiB at 336h (2026-08-12), which projects to ~34GiB at 720h -- comfortably
+      # inside both prometheus_retention_size (50GiB) and the 60Gi PV below, so storage is
+      # unchanged here. See apps#3613 for why memory (not storage) is this cluster's actual
+      # constraint at 30d retention.
+      prometheus_retention_period: 720h
       prometheus_storage_class: sc-longhorn-replicated
       prometheus_storage_size: 60Gi
       prometheus_volume_name: pv-prometheus
+      # Pre-existing defect (apps#3613): measured 2026-08-12 at 99.9% of the module's
+      # previously-hardcoded 2Gi limit (max_over_time(container_memory_working_set_bytes{
+      # container="prometheus"}[14d]) = 1.9975GiB), and a 30-day range query over ~349k head
+      # series risks an OOMKill at that margin.
+      prometheus_memory_request: 2Gi
+      prometheus_memory_limit: 4Gi
       loki_storage_class: sc-longhorn-replicated
       loki_retention_size: 30d
       # each of the 3 monolithic replicas combines the write/read/backend roles that SimpleScalable
@@ -49,6 +61,16 @@ spec:
       loki_singlebinary_storage_size: 16Gi
       loki_results_cache_memory: "1024"
       loki_chunks_cache_memory: "4096"
+      # Required as of apps-v0.29.0 (apps#3618) -- the module no longer hardcodes these
+      # Bitwarden key names, so every consumer must supply them explicitly. These three
+      # preserve today's behaviour exactly (Loki stays on MinIO); they only change when
+      # Loki cuts over to Garage (apps#3611). Deliberately NOT setting loki_s3_region here:
+      # it defaults to empty, which is correct for MinIO (which ignores the signed region);
+      # setting it prematurely would have no effect against MinIO but would need to be
+      # reverted for the eventual Garage cutover, so it should be set only at that point.
+      loki_s3_endpoint_key: cluster_homelab_minio_loki_endpoint
+      loki_s3_accesskeyid_key: cluster_homelab_minio_loki_accesskeyid
+      loki_s3_secretkey_key: cluster_homelab_minio_loki_secretkey
       # `getent group systemd-journal` on minisforum-nab9-1 (2026-08-11). The GID is
       # allocated per host, not a fixed constant - a rebuilt node or a newly-added node
       # could land on a different value, which fails *silently* (journal tailer reports

--- a/clusters/homelab/sources/infra-observability-core.yaml
+++ b/clusters/homelab/sources/infra-observability-core.yaml
@@ -14,5 +14,5 @@ spec:
     !/infrastructure/subsystems/observability-core
   interval: 1m0s
   ref:
-    tag: infra-observability-core-v0.28.0
+    tag: infra-observability-core-v0.29.0
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git


### PR DESCRIPTION
Deploys `infra-observability-core` **v0.29.0** to `homelab` and supplies the cluster-side
configuration it now requires.

Refs `ppat/homelab-ops-kubernetes-apps#3611`, `#3613`.

The Prometheus PV adoption that was originally bundled here has been split out to **#900** — it is
unrelated to this rollout and carries a different risk profile.

## BREAKING — three variables are now required

v0.29.0 includes apps#3618, which makes Loki's S3 secret-store key names **required post-build
variables with no defaults**. A consumer that does not supply them gets an ExternalSecret with empty
`remoteRef.key` values, and Loki fails. This PR supplies them with the literals the module used
previously, so **behaviour is unchanged**:

| variable | value |
| --- | --- |
| `loki_s3_endpoint_key` | `cluster_homelab_minio_loki_endpoint` |
| `loki_s3_accesskeyid_key` | `cluster_homelab_minio_loki_accesskeyid` |
| `loki_s3_secretkey_key` | `cluster_homelab_minio_loki_secretkey` |

The defaults were removed upstream deliberately: a default of `cluster_homelab_minio_loki_endpoint`
is a cluster-specific value baked into a module, which is exactly the coupling the change set out to
remove.

## `loki_s3_region` is deliberately NOT set

v0.29.0 also adds `region: ${loki_s3_region:=}` (apps#3628). Loki's S3 client signs every request
with the literal placeholder region `"dummy"` when unset (grafana/loki#11453). MinIO **ignores** the
signed region, so this has been invisible; Garage enforces an exact match and rejects with
`AuthorizationHeaderMalformed`, crashlooping the compactor.

Loki still points at MinIO, so the empty default is today's behaviour and correct. **This gets set
only when Loki cuts over to Garage** — please don't add it earlier.

## Prometheus

- `prometheus_retention_period` `336h` → **`720h`**, to support a 30-day MinIO-vs-Garage comparison.
- `prometheus_memory_request: 2Gi`, `prometheus_memory_limit: 4Gi`.

The memory raise is not cosmetic: measured peak was **1.9975 GiB against a 2 GiB limit — 99.9%** —
and a 30-day range query over ~349k series would OOMKill it. Tracked as apps#3613.

**Storage is deliberately unchanged.** `prometheus_tsdb_storage_blocks_bytes` measured 15.7–15.9 GiB
at 336h, projecting to ~34 GiB at 720h — inside both the configured 50 GiB `prometheus_retention_size`
and the 60Gi PV. Recorded because it is work deliberately *not* done.

## Note on the kube-prometheus-stack major

v0.28.0 carried a breaking chart major (87.21.0 → 88.3.0, apps#3609). That was rolled out separately
via #898 and verified live before this PR: `HelmRelease/kube-prometheus-stack-release` revision 43,
chart 88.3.0, `UpgradeSucceeded`, `Ready=True`, all `monitoring` pods Running with 0 restarts. **This
PR does not carry it** — it takes the module the rest of the way to v0.29.0.
