### PR TITLE
fix(cluster-homelab): bring the prometheus persistent volume under gitops

### DIFF
--- a/clusters/homelab/storage/infra/pv/kustomization.yaml
+++ b/clusters/homelab/storage/infra/pv/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- pv-prometheus.yaml
 - static-nfs-share-unifi-backups.yaml

--- a/clusters/homelab/storage/infra/pv/pv-prometheus.yaml
+++ b/clusters/homelab/storage/infra/pv/pv-prometheus.yaml
@@ -1,0 +1,29 @@
+---
+# Statically created Longhorn volume, adopted into GitOps here (apps#3614) so it is
+# recoverable from Git rather than existing only as live cluster state -- created
+# 2025-07-03, outside Flux, with no manifest in either this repo or the apps repo until
+# now. Every field below is a verbatim copy of the live object (field-by-field diff done
+# in the PR description); do not "clean up" values that look redundant (e.g. the empty
+# diskSelector/nodeSelector) without re-diffing against the live PV first, since most of
+# spec.csi is immutable once bound and a mismatch fails the apply rather than converging.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-prometheus
+spec:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 60Gi
+  csi:
+    driver: driver.longhorn.io
+    fsType: ext4
+    volumeAttributes:
+      diskSelector: ""
+      nodeSelector: ""
+      numberOfReplicas: "2"
+      staleReplicaTimeout: "20"
+    volumeHandle: pv-prometheus
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: sc-longhorn-replicated
+  volumeMode: Filesystem


### PR DESCRIPTION
Brings the Prometheus data volume under GitOps. Split out of #899, which now carries only the
`infra-observability-core` v0.29.0 rollout.

Tracked as `ppat/homelab-ops-kubernetes-apps#3614`.

## The problem

`pv-prometheus` is a **static Longhorn PersistentVolume created 2025-07-03 that exists in neither
repository**. `clusters/homelab/storage/infra/pv/` previously contained only an unrelated static NFS
share. If that volume is lost it cannot be recreated declaratively and Prometheus will not schedule.

This matters more than usual here because **Flux prune is disabled cluster-wide**, so nothing
surfaces the drift — the gap is silent.

## Why the first apply is a no-op, not a mutation

Adopting a live, bound, stateful object into GitOps is exactly where a well-meant change causes the
outage it was meant to prevent, so this was verified rather than assumed.

The manifest was diffed **field by field against the live object**. Identical on every field it sets:
`accessModes`, `capacity.storage`, `csi.driver` / `fsType` / `volumeAttributes` / `volumeHandle`,
`persistentVolumeReclaimPolicy` (`Retain`), `storageClassName`, `volumeMode`. Neither side sets
`nodeAffinity` — Longhorn's CSI doesn't set PV-level node affinity.

`claimRef` and two controller-written annotations are **deliberately omitted**, because
`clusters/homelab/storage/kustomization.yaml` already patches every PV/PVC with
`kustomize.toolkit.fluxcd.io/ssa: merge`. Server-side apply therefore only sets fields present in the
manifest and never touches controller-owned fields.

**The reclaim policy in the manifest matches the live object (`Retain`)** — the field most likely to
cause data loss if it drifted.

## No PVC manifest is needed

Worth recording, because it was initially assumed one was. The PVC is created by the
prometheus-operator StatefulSet's `volumeClaimTemplate` (already tracked, via
`volumeName: ${prometheus_volume_name}`), and the Longhorn recurring-job labels visible on the live
PVC come from an existing patch. Only the underlying static PV was missing.
