### PR TITLE
feat(cluster-homelab): deploy infra-storage-core v0.4.0, standing up Garage alongside MinIO

### DIFF
--- a/clusters/homelab/cluster/secrets/bitwarden-secret-store.yaml
+++ b/clusters/homelab/cluster/secrets/bitwarden-secret-store.yaml
@@ -70,6 +70,7 @@ spec:
     - external-dns
     - flux-system
     - freeradius
+    - garage
     - home-automation
     - image-builder
     - logging

--- a/clusters/homelab/kustomizations/config-storage-garage.yaml
+++ b/clusters/homelab/kustomizations/config-storage-garage.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: config-storage-garage
+  namespace: flux-system
+spec:
+  dependsOn:
+  - name: infra-storage-core
+    namespace: flux-system
+  interval: 15m0s
+  # Deliberately its own Kustomization, not folded into config-storage: GarageBucket/
+  # GarageKey carry a Ready status condition that kstatus assesses, same reasoning as the
+  # longhorn.io Node healthCheckExprs override in config-storage.yaml -- an unrelated
+  # resource's readiness must not gate storage's shared PVCs/StorageClasses/RecurringJobs.
+  path: ./clusters/homelab/storage/infra/garage
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: root
+    namespace: flux-system
+  timeout: 2m0s
+  wait: true

--- a/clusters/homelab/kustomizations/infra-storage-core.yaml
+++ b/clusters/homelab/kustomizations/infra-storage-core.yaml
@@ -48,11 +48,6 @@ spec:
       # the estate's ongoing growth (~3,095 objects/day per #3611) before this PVC needs
       # expansion.
       garage_data_size: 24Gi
-      # Literal, not composed from ${domain_name}: Flux's postBuild substitution is a
-      # single text-replacement pass, so a substitute value containing another ${var}
-      # token is never expanded -- it would land in the manifest verbatim. domain_name
-      # resolves to homelab.nikara.net (confirmed via the live minio Ingress hosts).
-      garage_web_root_domain: garage-web.homelab.nikara.net
     substituteFrom:
     - kind: Secret
       name: cluster-secrets

--- a/clusters/homelab/kustomizations/infra-storage-core.yaml
+++ b/clusters/homelab/kustomizations/infra-storage-core.yaml
@@ -36,14 +36,17 @@ spec:
       garage_storage_replicas: "1"
       # Follows what MinIO's own PVC (minio-data) uses on this cluster.
       garage_storage_class: sc-longhorn-replicated
-      # Measured, not guessed: a benchmark at the production object count (3,439,460
-      # objects) put metadata_dir at 6361.8 MiB. 12Gi is ~2x that for headroom.
-      garage_metadata_size: 12Gi
-      # Same benchmark measured data_dir at 11217 MiB (~10.95Gi) for the full object set.
-      # Garage's data_dir tracks live object bytes ~1:1 (unlike MinIO's measured 3.2x
-      # delete-marker amplification, apps#3611), so 24Gi (~2.2x) covers both that
-      # dataset and months of the estate's ongoing growth (~3,095 objects/day per #3611)
-      # before this PVC needs expansion.
+      # metadata.size is a PVC size, not a memory knob -- Garage's LMDB metadata store is
+      # a memory-mapped file on disk; the process's own RSS measured just 5.7 MiB in the
+      # same benchmark. Measured, not guessed: a benchmark at the production object count
+      # (3,439,460 objects) put metadata_dir at 6361.8 MiB. 16Gi is ~2.5x that for headroom.
+      garage_metadata_size: 16Gi
+      # Same benchmark measured data_dir at 11217 MiB (~10.95Gi) for the full object set
+      # (vs. 14293 MiB for the identical dataset on MinIO -- Garage uses ~78%). Garage's
+      # data_dir tracks live object bytes ~1:1 (unlike MinIO's measured 3.2x delete-marker
+      # amplification, apps#3611), so 24Gi (~2.2x) covers both that dataset and months of
+      # the estate's ongoing growth (~3,095 objects/day per #3611) before this PVC needs
+      # expansion.
       garage_data_size: 24Gi
       # Literal, not composed from ${domain_name}: Flux's postBuild substitution is a
       # single text-replacement pass, so a substitute value containing another ${var}

--- a/clusters/homelab/kustomizations/infra-storage-core.yaml
+++ b/clusters/homelab/kustomizations/infra-storage-core.yaml
@@ -28,6 +28,28 @@ spec:
       secret_store: bitwarden-secret-manager-store
       minio_admin_username_key: cluster_homelab_minio_admin_username
       minio_admin_password_key: cluster_homelab_minio_admin_password
+      # Garage stood up alongside MinIO (apps#3611) -- no consumer points at it yet.
+      garage_admin_token_key: cluster_homelab_garage_admin_token
+      garage_rpc_secret_key: cluster_homelab_garage_rpc_secret
+      # Single node, so both are 1: one Garage storage node, no cross-node replication.
+      garage_replication_factor: "1"
+      garage_storage_replicas: "1"
+      # Follows what MinIO's own PVC (minio-data) uses on this cluster.
+      garage_storage_class: sc-longhorn-replicated
+      # Measured, not guessed: a benchmark at the production object count (3,439,460
+      # objects) put metadata_dir at 6361.8 MiB. 12Gi is ~2x that for headroom.
+      garage_metadata_size: 12Gi
+      # Same benchmark measured data_dir at 11217 MiB (~10.95Gi) for the full object set.
+      # Garage's data_dir tracks live object bytes ~1:1 (unlike MinIO's measured 3.2x
+      # delete-marker amplification, apps#3611), so 24Gi (~2.2x) covers both that
+      # dataset and months of the estate's ongoing growth (~3,095 objects/day per #3611)
+      # before this PVC needs expansion.
+      garage_data_size: 24Gi
+      # Literal, not composed from ${domain_name}: Flux's postBuild substitution is a
+      # single text-replacement pass, so a substitute value containing another ${var}
+      # token is never expanded -- it would land in the manifest verbatim. domain_name
+      # resolves to homelab.nikara.net (confirmed via the live minio Ingress hosts).
+      garage_web_root_domain: garage-web.homelab.nikara.net
     substituteFrom:
     - kind: Secret
       name: cluster-secrets
@@ -60,6 +82,18 @@ spec:
         name: longhorn-release
         namespace: longhorn-system
       spec:
+        chart:
+          spec:
+            # Deliberate hold, not an oversight: storage-core v0.3.0 bumps its default
+            # Longhorn chart to 1.12.0, but this cluster runs 1.11.2 and the standing
+            # practice here is to wait for a Longhorn `.1` release before adopting a new
+            # minor. Chart 1.11.2 ships Longhorn appVersion v1.11.2 (confirmed against
+            # charts.longhorn.io's index and this cluster's live longhorn-release
+            # HelmRelease/Setting current-longhorn-version, both v1.11.2 as of writing) --
+            # so this pin holds steady rather than upgrading. It must stay in the same
+            # commit as any storage-core ref.tag bump that changes this default, and
+            # should be removed once a Longhorn 1.12.1+ ships. Refs apps#3611.
+            version: 1.11.2
         values:
           persistence:
             defaultClass: false

--- a/clusters/homelab/kustomizations/kustomization.yaml
+++ b/clusters/homelab/kustomizations/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
 - apps-media.yaml
 - apps-misc.yaml
 - config-storage.yaml
+- config-storage-garage.yaml
 - config-services.yaml
 - config-services-image-builder.yaml
 - config-services-sandbox-docker.yaml

--- a/clusters/homelab/sources/infra-storage-core.yaml
+++ b/clusters/homelab/sources/infra-storage-core.yaml
@@ -14,5 +14,5 @@ spec:
     !/infrastructure/subsystems/storage-core
   interval: 1m0s
   ref:
-    tag: infra-storage-core-v0.2.3
+    tag: infra-storage-core-v0.3.0
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git

--- a/clusters/homelab/sources/infra-storage-core.yaml
+++ b/clusters/homelab/sources/infra-storage-core.yaml
@@ -14,5 +14,5 @@ spec:
     !/infrastructure/subsystems/storage-core
   interval: 1m0s
   ref:
-    tag: infra-storage-core-v0.3.0
+    tag: infra-storage-core-v0.4.0
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git

--- a/clusters/homelab/storage/infra/garage/externalsecret-garage-migration-credentials.yaml
+++ b/clusters/homelab/storage/infra/garage/externalsecret-garage-migration-credentials.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: garage-migration-import-credentials
+  namespace: garage
+spec:
+  data:
+  - secretKey: access-key-id
+    remoteRef:
+      key: cluster_homelab_garage_migration_accesskeyid
+  - secretKey: secret-access-key
+    remoteRef:
+      key: cluster_homelab_garage_migration_secretkey
+  refreshInterval: 24h
+  secretStoreRef:
+    name: bitwarden-secret-manager-store
+    kind: ClusterSecretStore

--- a/clusters/homelab/storage/infra/garage/garagebucket-homelab-authentik-media.yaml
+++ b/clusters/homelab/storage/infra/garage/garagebucket-homelab-authentik-media.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: homelab-authentik-media
+  namespace: garage
+spec:
+  clusterRef:
+    name: garage

--- a/clusters/homelab/storage/infra/garage/garagebucket-homelab-loki-chunks.yaml
+++ b/clusters/homelab/storage/infra/garage/garagebucket-homelab-loki-chunks.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: homelab-loki-chunks
+  namespace: garage
+spec:
+  clusterRef:
+    name: garage

--- a/clusters/homelab/storage/infra/garage/garagebucket-homelab-loki-ruler.yaml
+++ b/clusters/homelab/storage/infra/garage/garagebucket-homelab-loki-ruler.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: homelab-loki-ruler
+  namespace: garage
+spec:
+  clusterRef:
+    name: garage

--- a/clusters/homelab/storage/infra/garage/garagebucket-homelab-terraform-state.yaml
+++ b/clusters/homelab/storage/infra/garage/garagebucket-homelab-terraform-state.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: homelab-terraform-state
+  namespace: garage
+spec:
+  clusterRef:
+    name: garage

--- a/clusters/homelab/storage/infra/garage/garagekey-homelab-migration.yaml
+++ b/clusters/homelab/storage/infra/garage/garagekey-homelab-migration.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: homelab-migration
+  namespace: garage
+spec:
+  clusterRef:
+    name: garage
+  # One shared key across all four buckets, scoped to this key's actual purpose: letting a
+  # future migration script copy bucket contents from MinIO into Garage. It is not meant to
+  # be handed to Loki/Authentik/Terraform -- each gets its own least-privilege GarageKey
+  # from its own module at actual cutover time, matching how MinIO credentials are scoped
+  # per-consumer today (e.g. loki_s3_accesskeyid_key).
+  bucketPermissions:
+  - bucketRef:
+      name: homelab-loki-chunks
+    read: true
+    write: true
+  - bucketRef:
+      name: homelab-loki-ruler
+    read: true
+    write: true
+  - bucketRef:
+      name: homelab-authentik-media
+    read: true
+    write: true
+  - bucketRef:
+      name: homelab-terraform-state
+    read: true
+    write: true
+  # Imported, not generated: the credential originates in Bitwarden and is handed to the
+  # operator via a Secret produced by the ExternalSecret in this same directory.
+  importKey:
+    secretRef:
+      name: garage-migration-import-credentials
+      namespace: garage
+  secretTemplate:
+    name: homelab-migration-credentials

--- a/clusters/homelab/storage/infra/garage/kustomization.yaml
+++ b/clusters/homelab/storage/infra/garage/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Bucket/key provisioning for Garage (apps#3611), ahead of any consumer cutover -- these
+# exist so a later data-migration step has somewhere to land, not because Loki/Authentik/
+# Terraform point at Garage yet (they don't; MinIO keeps serving all three). Lifecycle and
+# quota policy are deliberately left unset on every bucket: this estate's plain-Expiration-
+# on-a-versioned-bucket defect (measured 3.2x disk amplification, apps#3611) came from a
+# lifecycle decision made without a real workload behind it, so those decisions are left to
+# each app's own cutover rather than guessed at here.
+resources:
+- garagebucket-homelab-loki-chunks.yaml
+- garagebucket-homelab-loki-ruler.yaml
+- garagebucket-homelab-authentik-media.yaml
+- garagebucket-homelab-terraform-state.yaml
+- garagekey-homelab-migration.yaml
+- externalsecret-garage-migration-credentials.yaml


### PR DESCRIPTION
> **Superseded — verified against live state 2026-08-13.** The `GarageCluster`/`GarageBucket`/
> `GarageKey` design this PR deploys (via `rajsinghtech/garage-operator`) was reverted **within
> hours** by PR #903 — the operator was dropped entirely (owner's call: its ClusterRole granted
> cluster-wide Secret-read access across every namespace to run at most one Garage instance). Nothing
> from the "Bucket/key CRs" section below is live on `homelab` today. Garage's eventual redeploy will
> use plain Kubernetes resources (Deployment/Service/ConfigMap/Ingress/ExternalSecret) with PVCs
> referenced by claim name, and Terraform provisions buckets/keys instead of the `GarageBucket`/
> `GarageKey` CRs described here. The Longhorn version-pin reasoning and blast-radius methodology
> below remain generally correct and reusable, independent of the Garage design that was reverted.

---

## What

Bumps `infra-storage-core` to **v0.4.0** on the `homelab` cluster, which folds Garage
object storage into `storage-core` (apps#3611, apps PR #3636). Garage is stood up
**alongside** MinIO with **no consumer pointed at it yet** — Loki, Authentik, and
Terraform state all keep using MinIO. A separate follow-up migrates bucket contents and
cuts consumers over.

Refs apps#3611.

## The Longhorn pin (read this first)

`storage-core` v0.3.0's own default bumps its Longhorn chart to **1.12.0**. This cluster
runs Longhorn **v1.11.2**, and the standing practice here is to wait for a `.1` release
before adopting a new minor — so bumping the `ref.tag` alone would upgrade Longhorn as an
unwanted side effect of deploying Garage.

`clusters/homelab/kustomizations/infra-storage-core.yaml` adds a `spec.patches` entry
holding `spec.chart.spec.version` at `1.11.2`, in the **same commit** as the tag bump —
never a window where the bump lands without the pin.

**Chart↔app mapping**, confirmed two ways:

- `charts.longhorn.io/index.yaml`: chart `1.11.2` → `appVersion: v1.11.2`.
- Live cluster (read-only): `HelmRelease/longhorn-release` in `longhorn-system` currently
  runs `chart 1.11.2` (`status.history[0].appVersion: v1.11.2`), and
  `Setting/current-longhorn-version` reads `v1.11.2`. So this pin **holds steady** at
  what's already running — it does not change anything about Longhorn.

**Rendered-output proof the pin actually takes effect** (Flux applies `spec.patches`
before `postBuild.substitute`, so a plain `kustomize build` is sufficient to prove this —
no envsubst needed since this field carries no `${}` token):

```
$ kustomize build infrastructure/subsystems/storage-core   # v0.3.0, unpatched
  → spec.chart.spec.version: 1.12.0          # confirms the module's own default

$ kustomize build <overlay-with-this-PRs-patches>
  → spec.chart.spec.version: 1.11.2          # confirms the patch holds it
```

Both other `spec.values` keys on `longhorn-release` (persistence, defaultSettings) are
unchanged and still present in the rendered output.

## Bitwarden prerequisites — merge blocker

I do not have Bitwarden access to check whether these already exist. **These four keys
must exist in the `bitwarden-secret-manager-store` secret store before this merges**, or
the `ExternalSecret`s referencing them fail and the Kustomization stays unhealthy (see
blast-radius section below):

| Key | Used by | Format |
| --- | --- | --- |
| `cluster_homelab_garage_admin_token` | `GarageCluster` admin API | bearer token (any opaque string) |
| `cluster_homelab_garage_rpc_secret` | `GarageCluster` inter-node RPC | **32-byte / 64-hex-char string** |
| `cluster_homelab_garage_migration_accesskeyid` | migration `GarageKey` import | Garage access key ID (must start with `GK`) |
| `cluster_homelab_garage_migration_secretkey` | migration `GarageKey` import | Garage secret access key |

The two migration-key values need to already be valid Garage credentials, not arbitrary
strings — since `GarageKey.spec.importKey` hands them to the operator as-is rather than
generating them. If you'd rather have the operator generate them, say so and I'll drop
`importKey` from `garagekey-homelab-migration.yaml` and read the operator-generated
secret instead.

## Bucket/key CRs

`clusters/homelab/storage/infra/garage/`, deployed via a new `config-storage-garage`
Kustomization (`dependsOn: infra-storage-core`) — **not** folded into `config-storage`,
which already carries a comment explaining why an unrelated resource's readiness
shouldn't gate storage's shared PVCs/StorageClasses/RecurringJobs (same reasoning applies
to `GarageBucket`/`GarageKey`, which also carry a `Ready` condition kstatus assesses).

Four `GarageBucket`s mirror today's MinIO bucket set exactly: `homelab-loki-chunks`,
`homelab-loki-ruler`, `homelab-authentik-media`, `homelab-terraform-state`. **No
lifecycle or quota policy is set on any of them** — that's deliberate, not an oversight:
this estate's disk-amplification defect (apps#3611: 3.25M delete markers, ~44 GB
consumed against 13.58 GB live) came from a lifecycle/versioning decision made without a
real workload behind it, so those decisions are left to each app's own cutover rather
than guessed at here. Garage has no bucket-versioning feature at all (confirmed in
apps#3611's research), so there's nothing to explicitly disable — the "don't enable
versioning" decision from apps#3611 is satisfied by construction, not by a setting.

One `GarageKey` (`homelab-migration`), scoped read/write across all four buckets via
`importKey.secretRef` — a single shared key because its only purpose is letting a future
migration script copy MinIO's bucket contents into Garage, not serving a wired consumer.
Each app gets its own least-privilege `GarageKey` from its own module at actual cutover
time, matching how MinIO credentials are scoped per-consumer today (e.g.
`loki_s3_accesskeyid_key`).

## Explicitly NOT in this PR

- **No consumer is repointed.** Loki, Authentik, and Terraform state all stay on MinIO.
- **`loki_s3_region` stays unset.** Loki's S3 client signs with the literal region
  `"dummy"` when unset (grafana/loki#11453); MinIO ignores it, Garage rejects it with
  `AuthorizationHeaderMalformed`. It gets set only at cutover — do not add it early.
- **No data migration.** Separate follow-up, once the migration key above exists and is
  populated in Bitwarden.

## Blast-radius assessment (Munger's inversion)

Two ways this PR could cause an outage, both assessed:

1. **The Longhorn pin failing to take effect** would silently upgrade the storage layer
   under running workloads. Addressed above with rendered-output proof — the pin holds.

2. **Garage's `ExternalSecret`s referencing missing Bitwarden keys.** `GarageCluster` and
   its `garage-credentials` `ExternalSecret` live *inside* the `storage-core` module
   itself (`infra-storage-core` Kustomization, `wait: true`), alongside MinIO and
   Longhorn — this coupling is inherent to folding Garage into `storage-core` (apps PR
   #3636's own tradeoff, not something this clusters-repo PR can route around). If the
   two `garage-credentials` Bitwarden keys are missing, `GarageCluster` and its
   `ExternalSecret` fail to reach `Ready`, and kstatus assessment makes the **whole**
   `infra-storage-core` Kustomization report `Ready: False`.
   - **What that does NOT do:** it doesn't touch already-running MinIO or Longhorn pods —
     Kubernetes doesn't tear anything down because a Flux `Kustomization` object is
     unhealthy.
   - **What it DOES do:** `infra-storage-core` gates a long dependency chain —
     `infra-observability-core`, `infra-security-extra`, `infra-networking-extra`,
     `config-storage`, `apps-coder`, `apps-ai`, `apps-downloaders`, `apps-media`,
     `apps-home-automation` all `dependsOn` it directly or transitively. An unhealthy
     `infra-storage-core` stalls Flux's reconciliation of **all of them** — no new
     changes land anywhere in that chain until it clears, even though nothing currently
     running is affected. This is exactly why the two `garage-credentials` keys
     (`cluster_homelab_garage_admin_token`, `cluster_homelab_garage_rpc_secret`) are a
     hard merge blocker, not a nice-to-have.
   - The `config-storage-garage` Kustomization (bucket/key CRs) is deliberately isolated
     from this — its own health failure (e.g. the migration key's Bitwarden values
     missing) only blocks itself, nothing downstream depends on it.

## Verification

- `pre-commit run --all-files`: all hooks pass, including `Validate Kubernetes manifests`
  (kubeconform via `ci/validation/.env`).
- Longhorn-pin rendered-output check: see above.
- CI (`lint`, `diff-changes`) — reporting the real terminal result once it completes;
  `diff-changes`'s flux-local jobs are known-flaky (hardcoded 60s per-command timeout +
  transient GitHub-Releases fetch stalls) — will re-run once on a `TimeoutError` signature
  before treating a failure as real.

