### PR TITLE
fix(cluster-homelab): supply cert_issuer to infra-storage-core

### DIFF
--- a/clusters/homelab/kustomizations/infra-storage-core.yaml
+++ b/clusters/homelab/kustomizations/infra-storage-core.yaml
@@ -29,6 +29,10 @@ spec:
       minio_admin_username_key: cluster_homelab_minio_admin_username
       minio_admin_password_key: cluster_homelab_minio_admin_password
       # Garage stood up alongside MinIO (apps#3611) -- no consumer points at it yet.
+      # cert-manager ClusterIssuer for the Garage website endpoint's TLS certificate.
+      # Matches what apps-coder, apps-misc, infra-networking-core and
+      # infra-security-extra already pass on this cluster.
+      cert_issuer: letsencrypt-production-issuer
       garage_admin_token_key: cluster_homelab_garage_admin_token
       garage_rpc_secret_key: cluster_homelab_garage_rpc_secret
       # Single node, so both are 1: one Garage storage node, no cross-node replication.


### PR DESCRIPTION
**Hotfix** — `infra-storage-core` is currently `Ready: False` on homelab.

```
post build failed for 'Certificate.v1.cert-manager.io/garage-web-tls-cert':
envsubst error: variable substitution failed: variable not set (strict mode): "cert_issuer"
```

storage-core v0.4.0 adds a cert-manager `Certificate` for Garage's website endpoint, whose
`issuerRef` is `${cert_issuer}`. This cluster never supplied it, and Flux's envsubst runs in **strict
mode**, so the entire post-build fails.

Because all four storage-core components (csi-driver-nfs, MinIO, Garage, Longhorn) share **one** Flux
Kustomization, this took the whole thing to `Ready: False` — not just Garage — stalling every
Kustomization that `dependsOn` it. Running pods are unaffected; nothing new converges.

Value is `letsencrypt-production-issuer`, matching what `apps-coder`, `apps-misc`,
`infra-networking-core` and `infra-security-extra` already pass on this cluster.

## How this was missed, and the check that would have caught it

The module's own `CHANGELOG.md` for this release listed `cert_issuer` first among the newly required
post-build variables, and warned in terms that describe exactly what happened:

> Bumping an existing cluster's infra-storage-core ref.tag to this release without adding them fails
> the whole Kustomization to build, taking down Longhorn and MinIO reconciliation along with it,
> since all four components share one Flux Kustomization.

The rollout PR was written from a hand-supplied variable list rather than derived from the module.
The changelog said so and was not read.

To confirm there is no second gap waiting behind this one, every `${var}` the storage-core module
references at v0.4.0 was diffed against everything this cluster supplies via `postBuild.substitute`
plus `cluster-secrets`:

| module requires | supplied? |
| --- | --- |
| `cert_issuer` | **NO — this PR** |
| `domain_name`, `secret_store` | yes (cluster-secrets / substitute) |
| `minio_admin_username_key`, `minio_admin_password_key` | yes |
| `garage_admin_token_key`, `garage_rpc_secret_key` | yes |
| `garage_replication_factor`, `garage_storage_replicas` | yes |
| `garage_storage_class`, `garage_metadata_size`, `garage_data_size` | yes |

`cert_issuer` was the only one absent.

**Worth adopting as a rollout step**: derive the required-variable set from the module tree and diff
it against the cluster's, rather than transcribing a list. It is mechanical, and it is the check that
would have caught this before merge rather than in production.

Refs ppat/homelab-ops-kubernetes-apps#3611
