### PR TITLE
feat(cluster-homelab): redeploy Garage in infra-storage-core

### DIFF
--- a/clusters/homelab/kustomizations/infra-storage-core.yaml
+++ b/clusters/homelab/kustomizations/infra-storage-core.yaml
@@ -28,100 +28,35 @@ spec:
       secret_store: bitwarden-secret-manager-store
       minio_admin_username_key: cluster_homelab_minio_admin_username
       minio_admin_password_key: cluster_homelab_minio_admin_password
-      # Garage stood up alongside MinIO (apps#3611) -- no consumer points at it yet.
-      # cert-manager ClusterIssuer for the Garage website endpoint's TLS certificate.
-      # Matches what apps-coder, apps-misc, infra-networking-core and
-      # infra-security-extra already pass on this cluster.
-      cert_issuer: letsencrypt-production-issuer
+      # Garage rebuilt on plain Kubernetes resources, no operator/CRDs (apps#3611,
+      # apps#3639) -- garage_replication_factor/garage_storage_replicas/
+      # garage_storage_class/garage_metadata_size/garage_data_size/
+      # garage_layout_capacity (variables the module carried at various points
+      # during that rebuild) no longer exist on the module; cert_issuer doesn't
+      # either, since the website Ingress relies on Traefik's default certificate
+      # the same way MinIO's own Ingresses do, not a dedicated cert-manager
+      # Certificate. garage-credentials keys unchanged from the pre-#3639 design.
       garage_admin_token_key: cluster_homelab_garage_admin_token
       garage_rpc_secret_key: cluster_homelab_garage_rpc_secret
-      # Single node, so both are 1: one Garage storage node, no cross-node replication.
-      garage_replication_factor: "1"
-      garage_storage_replicas: "1"
-      # Follows what MinIO's own PVC (minio-data) uses on this cluster.
-      garage_storage_class: sc-longhorn-replicated
-      # metadata.size is a PVC size, not a memory knob -- Garage's LMDB metadata store is
-      # a memory-mapped file on disk; the process's own RSS measured just 5.7 MiB in the
-      # same benchmark. Measured, not guessed: a benchmark at the production object count
-      # (3,439,460 objects) put metadata_dir at 6361.8 MiB. 16Gi is ~2.5x that for headroom.
-      garage_metadata_size: 16Gi
-      # Same benchmark measured data_dir at 11217 MiB (~10.95Gi) for the full object set
-      # (vs. 14293 MiB for the identical dataset on MinIO -- Garage uses ~78%). Garage's
-      # data_dir tracks live object bytes ~1:1 (unlike MinIO's measured 3.2x delete-marker
-      # amplification, apps#3611), so 24Gi (~2.2x) covers both that dataset and months of
-      # the estate's ongoing growth (~3,095 objects/day per #3611) before this PVC needs
-      # expansion.
-      garage_data_size: 24Gi
+      # Claim names for the externally-provisioned PVCs in
+      # ../../storage/infra/pvc/garage-{metadata,data}.yaml -- this module never
+      # provisions its own storage, matching every other module on this cluster.
+      garage_metadata_claim: garage-metadata
+      garage_data_claim: garage-data
+      # Estate-wide S3 signing region (owner decision; also set for Loki already
+      # in clusters#909's infra-observability-core.yaml, ahead of its own eventual
+      # cutover to Garage): boto3's hardcoded default, already what
+      # barman-cloud/CNPG backups sign with, and a value both MinIO and Garage
+      # accept -- one region for every S3 consumer on this cluster instead of
+      # three. Required: the module's conf.d/garage.toml has no default for this,
+      # so an unsupplied value fails the Kustomization build loudly rather than
+      # silently landing on something else. Garage rejects any S3 client whose
+      # signed region doesn't match this exactly (AuthorizationHeaderMalformed).
+      garage_s3_region: us-east-1
     substituteFrom:
     - kind: Secret
       name: cluster-secrets
   patches:
-  # Garage is being rebuilt on plain Kubernetes resources (apps#3611): the
-  # garage-operator is dropped -- it granted itself a cluster-wide ClusterRole
-  # including secret reads across all namespaces, which is a large standing
-  # privilege for something whose only job is managing one Garage instance per
-  # cluster. Until the module ships that rebuild, delete both the operator and
-  # the GarageCluster CR here so infra-storage-core reconciles: the CR cannot be
-  # dry-run at all (its CRD only exists once the operator's chart installs, and
-  # the chart never installs because the CR fails the Kustomization's dry-run
-  # first), which took the whole Kustomization -- MinIO and Longhorn included --
-  # to Ready: False.
-  # yamllint disable-line rule:indentation
-  - patch: |-
-      $patch: delete
-      apiVersion: garage.rajsingh.info/v1beta2
-      kind: GarageCluster
-      metadata:
-        name: garage
-        namespace: garage
-  # yamllint disable-line rule:indentation
-  - patch: |-
-      $patch: delete
-      apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      metadata:
-        name: garage-operator-release
-        namespace: garage-operator-system
-  # yamllint disable-line rule:indentation
-  - patch: |-
-      $patch: delete
-      apiVersion: source.toolkit.fluxcd.io/v1
-      kind: OCIRepository
-      metadata:
-        name: garage-operator
-        namespace: flux-system
-  # yamllint disable-line rule:indentation
-  - patch: |-
-      $patch: delete
-      apiVersion: cert-manager.io/v1
-      kind: Certificate
-      metadata:
-        name: garage-web-tls-cert
-        namespace: garage
-  # yamllint disable-line rule:indentation
-  - patch: |-
-      $patch: delete
-      apiVersion: networking.k8s.io/v1
-      kind: Ingress
-      metadata:
-        name: garage-s3
-        namespace: garage
-  # yamllint disable-line rule:indentation
-  - patch: |-
-      $patch: delete
-      apiVersion: networking.k8s.io/v1
-      kind: Ingress
-      metadata:
-        name: garage-web
-        namespace: garage
-  # yamllint disable-line rule:indentation
-  - patch: |-
-      $patch: delete
-      apiVersion: external-secrets.io/v1
-      kind: ExternalSecret
-      metadata:
-        name: garage-credentials
-        namespace: garage
   # yamllint disable-line rule:indentation
   - patch: |-
       apiVersion: helm.toolkit.fluxcd.io/v2

--- a/clusters/homelab/sources/infra-storage-core.yaml
+++ b/clusters/homelab/sources/infra-storage-core.yaml
@@ -14,5 +14,5 @@ spec:
     !/infrastructure/subsystems/storage-core
   interval: 1m0s
   ref:
-    tag: infra-storage-core-v0.4.0
+    tag: infra-storage-core-v0.5.0
   url: https://github.com/ppat/homelab-ops-kubernetes-apps.git

--- a/clusters/homelab/storage/infra/pvc/garage-data.yaml
+++ b/clusters/homelab/storage/infra/pvc/garage-data.yaml
@@ -1,0 +1,26 @@
+---
+# Sized from the same H1 falsification run (apps#3611) as garage-metadata: data_dir
+# measured 11217.3 MiB at 3,439,460 objects. 28Gi applies the same ~2.5x headroom
+# multiplier used for garage-metadata's 16Gi (11217.3 MiB * 2.5 = 28043.25 MiB,
+# rounded up to the nearest whole Gi) rather than reusing any size a prior,
+# now-reverted Garage attempt on this cluster computed by a different method --
+# re-derive from a fresh measurement before resizing, don't just bump the multiplier.
+#
+# Name ends in "-data" on purpose: storage/infra/pvc/kustomization.yaml's Longhorn
+# recurring-job-label patch matches on that suffix, so this PVC gets the same
+# backup/snapshot labels as minio-data/grafana-data without repeating them here.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: garage-data
+  namespace: garage
+  labels:
+    app.kubernetes.io/name: garage
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 28Gi
+  storageClassName: sc-longhorn-replicated
+  volumeMode: Filesystem

--- a/clusters/homelab/storage/infra/pvc/garage-metadata.yaml
+++ b/clusters/homelab/storage/infra/pvc/garage-metadata.yaml
@@ -1,0 +1,30 @@
+---
+# Sized from the H1 falsification run (apps#3611): metadata_dir measured 6361.8 MiB
+# at 3,439,460 objects. 16Gi is ~2.5x that figure for headroom -- Garage's LMDB
+# metadata store grows with object *count*, not object size, so this is the volume
+# to watch as the bucket's item count grows, independent of garage-data's own growth.
+#
+# Not named "garage-metadata-data": storage/infra/pvc/kustomization.yaml's Longhorn
+# recurring-job-label patch only matches PVC names ending in "-data", so this PVC's
+# labels are set explicitly below rather than renamed to fit that pattern -- losing
+# Garage's node identity/cluster layout (this volume) is as disruptive as losing
+# object data, so it gets the same backup/snapshot treatment as garage-data.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: garage-metadata
+  namespace: garage
+  labels:
+    app.kubernetes.io/name: garage
+    recurring-job.longhorn.io/source: enabled
+    recurring-job-group.longhorn.io/default: enabled
+    recurring-job-group.longhorn.io/snapshot-ops: enabled
+    recurring-job-group.longhorn.io/backup-ops: enabled
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 16Gi
+  storageClassName: sc-longhorn-replicated
+  volumeMode: Filesystem

--- a/clusters/homelab/storage/infra/pvc/kustomization.yaml
+++ b/clusters/homelab/storage/infra/pvc/kustomization.yaml
@@ -3,6 +3,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- garage-data.yaml
+- garage-metadata.yaml
 - grafana-data.yaml
 - minio-data.yaml
 - pihole-data.yaml


### PR DESCRIPTION
## What this does

Rolls [apps#3639](https://github.com/ppat/homelab-ops-kubernetes-apps/pull/3639) out to `homelab`: bumps `infra-storage-core`'s `ref.tag` to `infra-storage-core-v0.5.0` (tagged and published), which reintroduces Garage as plain Kubernetes resources with no operator and no CRDs — replacing the garage-operator design reverted in #903 after a ~13h outage that took Longhorn and MinIO reconciliation down with it (all four `storage-core` components share one Flux `Kustomization`). Garage lives *inside* `storage-core`, not a separate module, so this is a change to the existing `infra-storage-core` `sources/`+`kustomizations/` pair.

- **PVCs** (`clusters/homelab/storage/infra/pvc/garage-{metadata,data}.yaml`): externally provisioned, referenced by the module only via claim name (`garage_metadata_claim`/`garage_data_claim`) — a module never owns a PVC's lifecycle on this cluster. Same storage class/access mode/prune-disabled handling as `minio-data.yaml`.
  - `garage-metadata`: **16Gi**. H1 falsification run ([apps#3611](https://github.com/ppat/homelab-ops-kubernetes-apps/issues/3611)): `metadata_dir` measured **6361.8 MiB** at 3,439,460 objects; 16Gi is ~2.5x that for headroom.
  - `garage-data`: **28Gi**. Same run: `data_dir` measured **11217.3 MiB** at the same object count; same ~2.5x headroom multiplier, rounded up to the nearest whole Gi.
  - `garage-metadata` doesn't end in `-data`, so it doesn't match the pvc-level kustomization's Longhorn-backup-label regex; labeled explicitly instead of renamed to fit the pattern.
- **`ref.tag: infra-storage-core-v0.5.0`** — no longer a placeholder.
- **Removed the seven `$patch: delete` blocks** (`GarageCluster` CR, `garage-operator-release` HelmRelease, `OCIRepository`, `Certificate`, both old `Ingress`es, the old `ExternalSecret`) that neutralized the pre-#3639 operator-shaped design, plus their comment ("until the module ships that rebuild" — it has). The tagged module ships none of those kinds/names, so they were dead weight. `minio-release`/`longhorn-release` patches untouched.
- **`postBuild.substitute`** updated to the module's actual, tagged contract: added `garage_metadata_claim`, `garage_data_claim`, `garage_s3_region` (`us-east-1`); removed everything from every earlier design iteration that isn't in the shipped module (`cert_issuer`, `garage_replication_factor`, `garage_storage_replicas`, `garage_storage_class`, `garage_metadata_size`, `garage_data_size`, `garage_layout_capacity` — see below on why that last one never lands here). Kept `garage_admin_token_key`/`garage_rpc_secret_key` (unchanged Bitwarden key names).

## Why `garage_layout_capacity` isn't here

An earlier revision of this PR (while `feat/garage-drop-operator` was still in flight, pre-tag) supplied `garage_layout_capacity: 28Gi` for a layout-bootstrap sidecar that read it. That sidecar didn't ship: **v0.5.0 replaces it with `garage server --single-node`**, a flag Garage v2.3.0 (the version this module pins) added. Confirmed by reading the tagged source (`garage/deployment.yaml`): the flag commits a single-node layout in-process before any listener binds, and capacity is auto-detected live from `data_dir`'s filesystem — no admin-API call, no sidecar, no variable. Removing the stale variable rather than leaving it as unused-but-harmless, since a postBuild variable nobody reads is exactly the kind of drift this PR is trying to clean up.

## Variable diff — re-derived against the tagged release, not trusted from any summary

Rendered the module **plus its two mixed-in components** (`oidc-credentials/minio`, `sso`) with `kustomize build` at `infra-storage-core-v0.5.0` — the actual assembled output this Kustomization produces, not just a grep of the module's own files — and collected every unresolved `${...}` token left in it:

| Variable | Supplied how |
| --- | --- |
| `domain_name` | `cluster-secrets` (already present) |
| `dns_zone` | `cluster-secrets` (already present — needed by `sso`'s `patch-minio.yaml`) |
| `secret_store` | inline (already present) |
| `garage_admin_token_key` | inline (unchanged from pre-#3639) |
| `garage_rpc_secret_key` | inline (unchanged from pre-#3639) |
| `garage_metadata_claim` | inline, **new** (`garage-metadata`) |
| `garage_data_claim` | inline, **new** (`garage-data`) |
| `garage_s3_region` | inline, **new** (`us-east-1`) — no default in the module; an unsupplied value fails the build loudly |
| `minio_admin_username_key` / `minio_admin_password_key` | inline (unchanged) |
| `oidc_minio_app_name` / `oidc_minio_clientid_key` / `oidc_minio_clientsecret_key` | inline (unchanged) |

That's every token the rendered output contains — nothing left over, nothing missing. This is a stronger check than tracing `${...}` per-file: it also validates that the two components mixed in via `spec.components` don't need anything this Kustomization doesn't already supply.

## Bitwarden: no new secrets needed

Checked against the **tagged** module, not `main` or an earlier commit: `infrastructure/subsystems/storage-core/garage/secrets.yaml` at `v0.5.0` defines one `ExternalSecret`, `garage-credentials`, with exactly two remote refs — `${garage_admin_token_key}` → `admin-token` and `${garage_rpc_secret_key}` → `rpc-secret`. This Kustomization already supplies `cluster_homelab_garage_admin_token` and `cluster_homelab_garage_rpc_secret` for those, unchanged from the pre-#3639 design. Same two Bitwarden items either design consumes — nothing new to create.

## Longhorn 1.11.2 pin: unaffected, unchanged

The `longhorn-release` patch's `chart.spec.version: 1.11.2` override is untouched, byte-for-byte. Checked the tagged module's own default (`longhorn/helm-release-longhorn.yaml` at `v0.5.0`): still `1.12.0` — apps#3639 didn't touch Longhorn. The pin is still load-bearing and still correctly overrides it. Not a blocking finding, just confirmed.

## Post-merge manual step: `garage-operator-system` namespace orphan

`infra-storage-core` is currently `Ready: True` on the still-live, pre-#3639 module version (operator-shaped, patched inert by #903). Its Flux inventory currently includes a `garage-operator-system` `Namespace` — that module version's `namespace.yaml` still declares it, even with the operator itself patched away. **`v0.5.0`'s `namespace.yaml` does not declare `garage-operator-system` at all.** Once this PR merges and reconciles, that namespace drops out of the rendered manifest set; since `prune: false` is cluster-wide (and the namespace itself carries its own `kustomize.toolkit.fluxcd.io/prune: disabled` annotation), Flux will not remove it — it becomes a silent, permanent orphan.

**Action required after this merges and reconciles successfully: `kubectl delete namespace garage-operator-system`.** Nothing in git will ever do this for you. I confirmed via a live cluster read (CRDs, `ClusterRole`s, the `garage` namespace's own PVCs) that no other operator-era objects exist beyond this one namespace — the CRD dry-run failure that caused #903's outage blocked the *entire* Kustomization apply, so the operator's chart, CRDs, and any `ClusterRole` it would have created never actually installed.

The `garage` namespace itself carries over unchanged (both the pre- and post-#3639 module declare it) — nothing reintroduced under a different name there.

## Operational note: `garage server --single-node` hard-errors past layout version 1

Read directly from the tagged `garage/deployment.yaml`, which documents this in detail at the flag itself:

`--single-node` hard-errors on startup once the cluster's committed layout version exceeds 1 ("Refusing to run in single-node mode: layout version is already superior to 1"). Version 0 (nothing yet) and version 1 (what the flag itself creates on first boot) are fine; anything past that crashloops the Deployment on its next restart. Capacity is auto-detected from `data_dir`'s filesystem total (not free space, so it doesn't shrink misleadingly as the volume fills) and zone is hardcoded to `"dc1"` by Garage itself — neither is configurable here, and neither has any write-path enforcement (`/health` never references capacity; real `ENOSPC` from the filesystem is what actually stops writes).

**Correcting my own earlier note here**: an earlier revision of this PR (written before #3639 landed, from a description of general project requirements rather than the shipped module) flagged a second node as a "foreseeable future" that would hit this wall. The module's own comment, now that it's shipped, resolves this differently: **this Deployment is single-node by design — growth means standing up a new Garage cluster and migrating data across, not adding a node to this one** — so its layout isn't expected to change and `--single-node` is stated as safe to leave in place indefinitely. The underlying mechanical fact still stands and is worth keeping in mind regardless: **before any deliberate layout change on this specific node** (a capacity or zone correction, however unlikely given both are already inert/auto-detected here), **confirm `--single-node` has been removed from the module first**, or that change turns into a crashloop, possibly discovered much later, whose cause this flag only indirectly explains.

## What this deliberately does not do

- **Does not ship bucket/key provisioning.** Out of this module's scope by design — Terraform's job (terraform#290, owned by a separate agent; not touched here).
- **Does not touch `loki_s3_region`.** Already handled, separately and independently, in #909 (merged) — `us-east-1`, matching this PR's `garage_s3_region`, so Loki's eventual cutover to Garage needs no region change when it happens.
- **Does not touch `clusters/homelab/cluster/secrets/bitwarden-secret-store.yaml`.** `garage` is already in the `ClusterSecretStore` allowlist (added by #901), still present, no change needed.

## Validation

`pre-commit run --all-files` (yamllint, kubeconform via `validate-k8s`, commitlint, markdownlint, shellcheck) is clean. Beyond the module-only `kustomize build` used for the variable diff above, also built `clusters/homelab/storage` locally to confirm both new PVCs render with the correct prune-disabled/backup-label annotations. I could **not** run this against a real kustomize-controller server-side dry-run — that's what actually caught the CRD problem in #903, not `kustomize build` — but the tagged module has no CRDs and no CR of any kind, which is the structural reason this design doesn't have that failure mode to catch.
