### PR TITLE
fix(cluster-homelab): set loki_s3_region to us-east-1 ahead of the Garage cutover

### DIFF
--- a/clusters/homelab/kustomizations/infra-observability-core.yaml
+++ b/clusters/homelab/kustomizations/infra-observability-core.yaml
@@ -64,13 +64,25 @@ spec:
       # Required as of apps-v0.29.0 (apps#3618) -- the module no longer hardcodes these
       # Bitwarden key names, so every consumer must supply them explicitly. These three
       # preserve today's behaviour exactly (Loki stays on MinIO); they only change when
-      # Loki cuts over to Garage (apps#3611). Deliberately NOT setting loki_s3_region here:
-      # it defaults to empty, which is correct for MinIO (which ignores the signed region);
-      # setting it prematurely would have no effect against MinIO but would need to be
-      # reverted for the eventual Garage cutover, so it should be set only at that point.
+      # Loki cuts over to Garage (apps#3611).
       loki_s3_endpoint_key: cluster_homelab_minio_loki_endpoint
       loki_s3_accesskeyid_key: cluster_homelab_minio_loki_accesskeyid
       loki_s3_secretkey_key: cluster_homelab_minio_loki_secretkey
+      # us-east-1 is the estate-wide S3 signing region (owner decision): boto3's hardcoded
+      # default, already what barman-cloud/CNPG backups sign with, and a value both MinIO and
+      # Garage accept -- one region for every S3 consumer on this cluster instead of three.
+      # This is set now, not deferred to the Garage cutover the way the three keys above are:
+      # MinIO ignores the signed region entirely (grafana/loki#11453), so us-east-1 behaves
+      # exactly like the previous empty default against it today, and it's the same value
+      # Garage will be configured with -- so, unlike those three, this needs no revert and no
+      # re-visit at cutover. That supersedes this line's own earlier reasoning (see git
+      # history), which deferred it on the assumption the eventual region was still unknown.
+      # Proving it now instead of at cutover matters because a region mismatch crashloops
+      # Loki's compactor immediately with no client-side recovery (apps#3611 comment
+      # 5282296514; reproduced live on sandbox-talos's logging/loki-0). Discovering that
+      # during the actual cutover window would be the worst time to find it; proving it now
+      # against a lenient MinIO is free.
+      loki_s3_region: us-east-1
       # `getent group systemd-journal` on minisforum-nab9-1 (2026-08-11). The GID is
       # allocated per host, not a fixed constant - a rebuilt node or a newly-added node
       # could land on a different value, which fails *silently* (journal tailer reports


### PR DESCRIPTION
## What this does

Sets `loki_s3_region: us-east-1` in `clusters/homelab/kustomizations/infra-observability-core.yaml`'s `postBuild.substitute`, and rewrites the comment above the `loki_s3_*` block that previously argued for deferring this to the Garage cutover.

`us-east-1` is now the estate-wide S3 signing region — an owner decision, not something this PR is proposing: it's boto3's hardcoded default, it's already what barman-cloud (CNPG backups) signs with, and both MinIO and Garage accept it. This puts every S3 consumer on this cluster on one value instead of three.

## Why this is safe to merge now, standalone

- **Verified the variable is genuinely wired**, not just assumed from the request: `infrastructure/subsystems/observability-core/loki/helm-release-loki.yaml` (apps#3628, merged into `infra-observability-core-v0.29.0`) sets `region: ${loki_s3_region:=}` → `loki.storage.s3.region`, defaulting to empty when unset. This cluster's `sources/infra-observability-core.yaml` is **already pinned to `infra-observability-core-v0.29.0`** — the variable is live at the currently-deployed tag, so this PR needs no `ref.tag` bump, just the new `postBuild.substitute` entry. Confirmed by building the module at that exact tag locally (`kustomize build infrastructure/subsystems/observability-core`) and finding the same `region: ${loki_s3_region:=}` token.
- **No behavior change against MinIO.** Loki is still MinIO-backed (`loki_s3_endpoint_key`/`loki_s3_accesskeyid_key`/`loki_s3_secretkey_key` are untouched). MinIO ignores the signed region entirely (grafana/loki#11453) — that's true whether Loki signs with the previous empty-string default (which the AWS SDK renders as `"dummy"`) or with `us-east-1`. Region-only change, one HelmRelease (`loki-release`), no other module touched.
- **This value never needs to change again.** The comment it replaces argued for leaving the variable unset until the actual Garage cutover, specifically to avoid a value that would need reverting. That reasoning assumed the eventual region was still undecided. It's now decided, and it's the same value Garage will be configured with (see clusters#908, currently blocked on the apps-side module change) — so setting it now doesn't create a revert-at-cutover step, it removes one.
- **The failure mode this avoids is severe and already reproduced.** A region mismatch doesn't degrade gracefully — it crashloops Loki's compactor immediately, with no client-side recovery (apps#3611, comment [5282296514](https://github.com/ppat/homelab-ops-kubernetes-apps/issues/3611#issuecomment-5282296514)). Live evidence, not just theory: `sandbox-talos`'s `logging/loki-0` has been in `CrashLoopBackOff` for 23h at 280 restarts from exactly this. Proving `us-east-1` against a lenient MinIO now is free; discovering a region problem during the actual cutover window — when Loki is mid-migration and every minute of `logging` downtime is felt elsewhere — would not be.
- **Independent of #908.** Different module (`observability-core`, not `storage-core`), different release cadence, already-deployed tag vs. a pending one. Useful whether or not the Garage rollout in #908 ever ships, and it can merge immediately — #908 cannot (its `ref.tag` is a deliberate placeholder; see that PR).

## Validation

`pre-commit run` (yamllint, kubeconform via `validate-k8s`, commitlint) is clean on the changed file. Confirmed the target field and default behavior by building the module at the exact tag this cluster runs (`infra-observability-core-v0.29.0`), not just reading source.
